### PR TITLE
fix: add .env.example and verify secrets not in repo (#20)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -21,6 +21,9 @@ SLEEPER_LEAGUE_ID=your_league_id
 SLEEPER_DRAFT_ID=your_draft_id
 
 # ── Flask / Application ────────────────────────────────────────────────────────
+# Set to 'development' or 'production' — controls Flask behaviour (e.g. error pages)
+FLASK_ENV=development
+
 # Set to 'false' in production — never commit a .env with DEBUG=true
 FLASK_DEBUG=false
 
@@ -33,3 +36,6 @@ FLASK_SECRET_KEY=change-me-to-a-long-random-string
 
 # Override the number of teams (default: 10, set in config/config.json)
 # NUM_TEAMS=10
+
+# Override the data path for player projections (default: data/data/sheets)
+# DATA_PATH=data/data/sheets

--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,35 @@
+# Pigskin Fantasy Football Auction Draft — Environment Variables
+#
+# Copy this file to .env and fill in your values.
+# .env is listed in .gitignore and must NEVER be committed.
+#
+# Usage:
+#   cp .env.example .env
+#   # Edit .env with your actual credentials
+
+# ── Sleeper API ────────────────────────────────────────────────────────────────
+# Your Sleeper username (visible in your Sleeper profile URL)
+SLEEPER_USERNAME=your_sleeper_username
+
+# Your Sleeper user ID (numeric ID from the Sleeper API)
+SLEEPER_USER_ID=your_sleeper_user_id
+
+# The Sleeper league ID for your fantasy league
+SLEEPER_LEAGUE_ID=your_league_id
+
+# The Sleeper draft ID for the specific draft you are running
+SLEEPER_DRAFT_ID=your_draft_id
+
+# ── Flask / Application ────────────────────────────────────────────────────────
+# Set to 'false' in production — never commit a .env with DEBUG=true
+FLASK_DEBUG=false
+
+# Secret key for Flask session signing — use a long random string in production
+FLASK_SECRET_KEY=change-me-to-a-long-random-string
+
+# ── Optional Overrides ─────────────────────────────────────────────────────────
+# Override the default auction budget (default: 200, set in config/config.json)
+# AUCTION_BUDGET=200
+
+# Override the number of teams (default: 10, set in config/config.json)
+# NUM_TEAMS=10


### PR DESCRIPTION
## Summary

Closes #20

Addresses the P0 security baseline requirement to ensure no personal credentials are committed to the repository.

## Changes

- Added `.env.example` documenting all required environment variables (Sleeper API credentials, Flask config)
- Verified `.env` is already in `.gitignore` (line 123) — no change needed
- Verified `config/config.json` already uses `null` placeholders for all Sleeper IDs — no personal data present

## Acceptance Criteria Checklist

- [x] `.env` is in `.gitignore`
- [x] `config.json` has no personal IDs
- [x] `.env.example` exists with all required env vars documented

## Notes for QA

This is a documentation/config change only. No Python code was modified. Pre-existing test failures in `test_auction_budget.py` and `test_auction_enforcement.py` are unrelated (DraftConfig signature mismatch, tracked separately).