### PR TITLE
chore: add pythonpath = . to pytest.ini (#21)

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,13 @@
+[pytest]
+pythonpath = .
+testpaths = tests
+python_files = test_*.py
+python_classes = Test*
+python_functions = test_*
+markers =
+    integration: marks tests as integration tests (deselect with '-m "not integration"')
+    performance: marks tests as performance tests (slow)
+    ml: marks tests that require ML/torch dependencies
+    unit: marks tests as unit tests
+    simulation: marks tests as simulation tests
+    slow: marks tests as slow-running


### PR DESCRIPTION
## Summary
Closes #21

Adds `pytest.ini` with `pythonpath = .` so pytest automatically adds the project root to `sys.path`.

## Changes
- Created `pytest.ini` with `pythonpath = .`
- Registered all custom marks to suppress `PytestUnknownMarkWarning`

## Acceptance Criteria
- [x] `pythonpath = .` in `pytest.ini`
- [x] Test files no longer need `sys.path.append` to import project modules