### PR TITLE
fix: remove sys.path manipulation from source files (#1)

### DIFF
--- a/classes/draft_setup.py
+++ b/classes/draft_setup.py
@@ -1,13 +1,6 @@
 """Utilities for setting up draft relationships and importing from Sleeper API."""
 
-import sys
-import os
 from typing import List, Dict, Optional
-
-# Add the parent directory to the path for imports
-parent_dir = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
-if parent_dir not in sys.path:
-    sys.path.append(parent_dir)
 
 from .player import Player
 from .team import Team

--- a/classes/strategy.py
+++ b/classes/strategy.py
@@ -1,13 +1,5 @@
 """Strategy imports for backwards compatibility."""
 
-import os
-import sys
-
-# Add the parent directory to the path for imports
-parent_dir = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
-if parent_dir not in sys.path:
-    sys.path.append(parent_dir)
-
 # Import everything from the strategies module
 from strategies import (
     Strategy,

--- a/services/bid_recommendation_service.py
+++ b/services/bid_recommendation_service.py
@@ -1,13 +1,6 @@
 """Bid recommendation service for the auction draft tool."""
 
-import os
-import sys
 from typing import Optional, Dict, Any, List
-
-# Add the parent directory to the path for imports
-parent_dir = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
-if parent_dir not in sys.path:
-    sys.path.append(parent_dir)
 
 from classes import Player, Team, Owner, Strategy, create_strategy, Draft
 from config.config_manager import ConfigManager

--- a/services/draft_loading_service.py
+++ b/services/draft_loading_service.py
@@ -1,13 +1,7 @@
 """Draft loading service for the auction draft tool."""
 
 import os
-import sys
 from typing import Optional, Dict, Any, List
-
-# Add the parent directory to the path for imports
-parent_dir = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
-if parent_dir not in sys.path:
-    sys.path.append(parent_dir)
 
 from classes import Draft, DraftSetup, Player
 from api.sleeper_api import SleeperAPI

--- a/services/sleeper_draft_service.py
+++ b/services/sleeper_draft_service.py
@@ -5,14 +5,7 @@ This service handles fetching and displaying current Sleeper draft data
 including draft order, picks, and league information.
 """
 
-import sys
-import os
 from typing import Dict, List, Optional, Any
-
-# Add parent directory to path for imports
-parent_dir = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
-if parent_dir not in sys.path:
-    sys.path.append(parent_dir)
 
 from api.sleeper_api import SleeperAPI
 from utils.print_module import print_sleeper_draft, print_sleeper_league

--- a/services/tournament_service.py
+++ b/services/tournament_service.py
@@ -1,15 +1,9 @@
 """Tournament service for testing auction draft strategies."""
 
 import os
-import sys
 from typing import Optional, Dict, Any, List, Tuple
 import json
 from datetime import datetime
-
-# Add the parent directory to the path for imports
-parent_dir = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
-if parent_dir not in sys.path:
-    sys.path.append(parent_dir)
 
 from classes import Tournament, DraftSetup, create_strategy, AVAILABLE_STRATEGIES
 from config.config_manager import ConfigManager


### PR DESCRIPTION
## Summary
Closes #1

Removes all `sys.path.append`/`sys.path.insert` blocks from `classes/` and `services/`.

## Files Changed
- `classes/strategy.py` — removed sys.path block
- `classes/draft_setup.py` — removed sys.path block
- `services/bid_recommendation_service.py` — removed sys.path block
- `services/draft_loading_service.py` — removed sys.path block
- `services/sleeper_draft_service.py` — removed sys.path block
- `services/tournament_service.py` — removed sys.path block

## Acceptance Criteria
- [x] No `sys.path.append` or `sys.path.insert` in `classes/`, `services/`, or `strategies/`
- [x] All imports resolve correctly under `python -m pytest`