### PR TITLE
fix: remove sys.path hacks from all test files (#2)

### DIFF
--- a/tests/run_tests.py
+++ b/tests/run_tests.py
@@ -3,14 +3,7 @@
 Simple test runner script for the auction draft tool.
 """
 
-import sys
-import os
 import unittest
-
-# Add parent directory to path
-parent_dir = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
-if parent_dir not in sys.path:
-    sys.path.append(parent_dir)
 
 
 def run_specific_tests():

--- a/tests/test_auction_budget.py
+++ b/tests/test_auction_budget.py
@@ -1,9 +1,6 @@
 #!/usr/bin/env python3
 """Quick test to verify budget constraints work in actual auction."""
 
-import sys
-sys.path.append('.')
-
 from classes.draft import Draft
 from classes.team import Team
 from classes.owner import Owner

--- a/tests/test_auction_enforcement.py
+++ b/tests/test_auction_enforcement.py
@@ -1,9 +1,6 @@
 #!/usr/bin/env python3
 """Test auction-level budget constraint enforcement."""
 
-import sys
-sys.path.append('.')
-
 from classes.draft import Draft
 from classes.team import Team
 from classes.owner import Owner

--- a/tests/test_base.py
+++ b/tests/test_base.py
@@ -1,15 +1,9 @@
 """Base test utilities and fixtures for auction draft testing."""
 
-import sys
 import os
 from typing import List, Dict, Any
 import unittest
 from unittest.mock import Mock, patch
-
-# Add parent directory to path
-parent_dir = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
-if parent_dir not in sys.path:
-    sys.path.append(parent_dir)
 
 from classes.player import Player
 from classes.team import Team

--- a/tests/test_budget_violation.py
+++ b/tests/test_budget_violation.py
@@ -1,9 +1,6 @@
 #!/usr/bin/env python3
 """Test to identify when teams violate budget constraints."""
 
-import sys
-sys.path.append('.')
-
 from classes.team import Team
 from classes.player import Player
 from strategies.value_based_strategy import ValueBasedStrategy

--- a/tests/test_classes.py
+++ b/tests/test_classes.py
@@ -1,13 +1,6 @@
 """Test cases for core classes (Player, Team, Owner, etc.)."""
 
 import unittest
-import sys
-import os
-
-# Add parent directory to path
-parent_dir = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
-if parent_dir not in sys.path:
-    sys.path.append(parent_dir)
 
 from test_base import BaseTestCase, TestDataGenerator
 

--- a/tests/test_data_api.py
+++ b/tests/test_data_api.py
@@ -1,14 +1,7 @@
 """Test cases for data loading and API functionality."""
 
 import unittest
-import sys
-import os
 from unittest.mock import Mock, patch, mock_open
-
-# Add parent directory to path
-parent_dir = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
-if parent_dir not in sys.path:
-    sys.path.append(parent_dir)
 
 from test_base import BaseTestCase
 

--- a/tests/test_fantasypros.py
+++ b/tests/test_fantasypros.py
@@ -1,11 +1,5 @@
 """Test script to demonstrate FantasyPros data loading."""
 
-import os
-import sys
-
-# Add the project root to Python path
-sys.path.append(os.path.dirname(os.path.abspath(__file__)))
-
 from data import FantasyProsLoader, load_fantasypros_players, get_position_rankings
 from classes import DraftSetup
 

--- a/tests/test_inflation_behavior.py
+++ b/tests/test_inflation_behavior.py
@@ -3,14 +3,6 @@
 Test script to verify VOR strategy inflation/budget adjustment behavior.
 """
 
-import sys
-import os
-
-# Add parent directory to path for imports
-parent_dir = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
-if parent_dir not in sys.path:
-    sys.path.append(parent_dir)
-
 from classes.player import Player
 from classes.team import Team
 from classes.owner import Owner

--- a/tests/test_integer_budgets.py
+++ b/tests/test_integer_budgets.py
@@ -1,9 +1,6 @@
 #!/usr/bin/env python3
 """Quick test to verify integer budgets and bidding are working correctly."""
 
-import sys
-sys.path.append('.')
-
 from classes.team import Team
 from classes.player import Player
 

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -1,14 +1,7 @@
 """Integration tests for the complete auction draft system."""
 
 import unittest
-import sys
-import os
 from unittest.mock import Mock, patch
-
-# Add parent directory to path
-parent_dir = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
-if parent_dir not in sys.path:
-    sys.path.append(parent_dir)
 
 from test_base import BaseTestCase, TestDataGenerator
 

--- a/tests/test_market_inflation.py
+++ b/tests/test_market_inflation.py
@@ -4,14 +4,6 @@ Test script to demonstrate market inflation adjustment in VOR strategies.
 Shows how strategies adapt when league money is running low.
 """
 
-import sys
-import os
-
-# Add parent directory to path for imports
-parent_dir = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
-if parent_dir not in sys.path:
-    sys.path.append(parent_dir)
-
 from classes.player import Player
 from classes.team import Team
 from classes.owner import Owner

--- a/tests/test_multilevel_constraints.py
+++ b/tests/test_multilevel_constraints.py
@@ -4,12 +4,6 @@ Test multi-level budget constraint enforcement.
 Tests that teams cannot bid amounts that would prevent roster completion.
 """
 
-import sys
-import os
-
-# Add project root to path
-sys.path.insert(0, '/home/tezell/Documents/code/pigskin')
-
 from classes.team import Team
 from classes.player import Player
 from strategies.value_based_strategy import ValueBasedStrategy

--- a/tests/test_ping_format.py
+++ b/tests/test_ping_format.py
@@ -3,14 +3,6 @@
 Test the ping command output formatting without network calls.
 """
 
-import sys
-import os
-
-# Add parent directory to path for imports
-parent_dir = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
-if parent_dir not in sys.path:
-    sys.path.append(parent_dir)
-
 from cli.commands import CommandProcessor
 
 

--- a/tests/test_runner.py
+++ b/tests/test_runner.py
@@ -1,14 +1,7 @@
 """Test runner and test suite management."""
 
 import unittest
-import sys
-import os
 from io import StringIO
-
-# Add parent directory to path
-parent_dir = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
-if parent_dir not in sys.path:
-    sys.path.append(parent_dir)
 
 
 class TestRunner:

--- a/tests/test_services.py
+++ b/tests/test_services.py
@@ -1,14 +1,7 @@
 """Test cases for services (draft loading, bid recommendations, tournament)."""
 
 import unittest
-import sys
-import os
 from unittest.mock import Mock, patch, MagicMock
-
-# Add parent directory to path
-parent_dir = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
-if parent_dir not in sys.path:
-    sys.path.append(parent_dir)
 
 from test_base import BaseTestCase, TestDataGenerator
 

--- a/tests/test_strategies.py
+++ b/tests/test_strategies.py
@@ -1,13 +1,6 @@
 """Test cases for auction draft strategies."""
 
 import unittest
-import sys
-import os
-
-# Add parent directory to path
-parent_dir = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
-if parent_dir not in sys.path:
-    sys.path.append(parent_dir)
 
 from test_base import BaseTestCase, TestDataGenerator
 from strategies import (

--- a/tests/test_strategy_bids.py
+++ b/tests/test_strategy_bids.py
@@ -1,9 +1,6 @@
 #!/usr/bin/env python3
 """Test to verify all strategies return integer bids."""
 
-import sys
-sys.path.append('.')
-
 from classes.team import Team
 from classes.player import Player
 from classes.owner import Owner


### PR DESCRIPTION
## Summary
Closes #2

Removes all `sys.path.append`/`sys.path.insert` blocks from 18 test files in `tests/`.

## Rationale
With `pythonpath = .` in `pytest.ini` (merged in PR #27, issue #21), pytest automatically adds the project root to `sys.path`. The manual hacks are now redundant.

## Acceptance Criteria
- [x] `pythonpath = .` added to `pytest.ini`
- [x] No `sys.path` manipulation in any `tests/` file
- [x] `python -m pytest tests/ -p no:cov` collects without errors