### PR TITLE
fix: resolve pytest collection errors — add tests/ to pythonpath (#3)

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -1,5 +1,5 @@
 [pytest]
-pythonpath = .
+pythonpath = . tests
 testpaths = tests
 python_files = test_*.py
 python_classes = Test*


### PR DESCRIPTION
## Summary
Closes #3

## Problem
The 7 specific orphaned files listed in the issue do not exist in the repository. The actual 5 collection errors were caused by test files using bare `from test_base import ...` which required `tests/` to be on `sys.path`.

## Fix
Added `tests` to `pythonpath` in `pytest.ini`:
```
pythonpath = . tests
```

## Result
- **0 collection errors** (down from 5)
- **92 tests collected** successfully

## Acceptance Criteria
- [x] Zero collection errors when running `python -m pytest tests/`