### PR TITLE
chore: add pytest marks verification tests (#24)

### DIFF
--- a/tests/unit/test_pytest_marks.py
+++ b/tests/unit/test_pytest_marks.py
@@ -1,0 +1,52 @@
+"""Verify all custom pytest marks are registered in pytest.ini."""
+
+import pathlib
+
+import pytest
+
+
+REQUIRED_MARKS = ["integration", "performance", "ml", "unit", "simulation", "slow"]
+
+
+class TestPytestMarksRegistered:
+    """Ensure all project-specific marks are declared to suppress PytestUnknownMarkWarning."""
+
+    def test_all_required_marks_in_ini(self):
+        """pytest.ini must declare all required custom marks."""
+        ini_path = pathlib.Path(__file__).resolve().parents[2] / "pytest.ini"
+        content = ini_path.read_text()
+        missing = [mark for mark in REQUIRED_MARKS if mark not in content]
+        assert not missing, (
+            f"Missing marks in pytest.ini: {missing}\n"
+            "Add them to the [pytest] markers section."
+        )
+
+    @pytest.mark.integration
+    def test_integration_mark_recognized(self):
+        """integration mark is recognized by pytest without raising PytestUnknownMarkWarning."""
+        pass
+
+    @pytest.mark.performance
+    def test_performance_mark_recognized(self):
+        """performance mark is recognized by pytest without raising PytestUnknownMarkWarning."""
+        pass
+
+    @pytest.mark.ml
+    def test_ml_mark_recognized(self):
+        """ml mark is recognized by pytest without raising PytestUnknownMarkWarning."""
+        pass
+
+    @pytest.mark.unit
+    def test_unit_mark_recognized(self):
+        """unit mark is recognized by pytest without raising PytestUnknownMarkWarning."""
+        pass
+
+    @pytest.mark.simulation
+    def test_simulation_mark_recognized(self):
+        """simulation mark is recognized by pytest without raising PytestUnknownMarkWarning."""
+        pass
+
+    @pytest.mark.slow
+    def test_slow_mark_recognized(self):
+        """slow mark is recognized by pytest without raising PytestUnknownMarkWarning."""
+        pass


### PR DESCRIPTION
## Summary
Closes #24

All 6 required marks (`integration`, `performance`, `ml`, `unit`, `simulation`, `slow`) were already registered in `pytest.ini` as part of issue #21. This PR adds `tests/unit/test_pytest_marks.py` with 7 tests that verify the marks are registered and produce zero `PytestUnknownMarkWarning`.

## Changes
- **`tests/unit/test_pytest_marks.py`**: 7 tests — 1 checks pytest.ini content, 6 use each mark directly

## Test Results
```
7 passed in 0.07s
```

## Acceptance Criteria
- [x] Zero `PytestUnknownMarkWarning` warnings (marks were already registered)
- [x] All 6 marks verified: `integration`, `performance`, `ml`, `unit`, `simulation`, `slow`