### PR TITLE
Remove unused auction timer machinery

### DIFF
--- a/classes/auction.py
+++ b/classes/auction.py
@@ -1,9 +1,7 @@
 """Auction class for auction draft tool."""
 
-from typing import Dict, List, Optional, Callable
-from datetime import datetime, timedelta
-import threading
-import time
+from typing import Dict, List, Callable
+import random
 from .draft import Draft
 from .player import Player
 from .team import Team
@@ -12,21 +10,16 @@ from .strategy import Strategy
 
 
 class Auction:
-    """Handles the real-time auction mechanics for a draft."""
+    """Handles blind sealed-bid (Vickrey) auction mechanics for a draft."""
     
     def __init__(
         self,
         draft: Draft,
-        bid_timer: int = 30,
-        nomination_timer: int = 60
     ):
         self.draft = draft
-        self.bid_timer = bid_timer
-        self.nomination_timer = nomination_timer
         
         # Auction state
         self.is_active = False
-        self.current_timer: Optional[threading.Timer] = None
         self.auto_bid_enabled = {}  # owner_id -> bool
         self.strategies = {}  # owner_id -> Strategy
         
@@ -34,7 +27,6 @@ class Auction:
         self.on_bid_placed: List[Callable] = []
         self.on_player_nominated: List[Callable] = []
         self.on_auction_completed: List[Callable] = []
-        self.on_timer_tick: List[Callable] = []
         
     def start_auction(self) -> None:
         """Start the auction system."""
@@ -42,13 +34,10 @@ class Auction:
             raise ValueError("Draft must be started before auction can begin")
             
         self.is_active = True
-        self._start_nomination_timer()
         
     def stop_auction(self) -> None:
         """Stop the auction system."""
         self.is_active = False
-        if self.current_timer:
-            self.current_timer.cancel()
             
     def nominate_player(
         self,
@@ -59,8 +48,9 @@ class Auction:
         """Nominate a player for auction."""
         try:
             self.draft.nominate_player(player, nominating_owner_id, initial_bid)
-            self._start_bid_timer()
             self._notify_player_nominated(player, nominating_owner_id, initial_bid)
+            self._process_auto_bids()
+            self._complete_current_auction()
             return True
         except ValueError:
             return False
@@ -72,10 +62,9 @@ class Auction:
             
         success = self.draft.place_bid(bidder_id, bid_amount)
         if success:
-            self._start_bid_timer()  # Reset timer
             self._notify_bid_placed(bidder_id, bid_amount)
             
-            # Trigger auto-bids from other participants
+            # Re-resolve sealed bids after a manual bid changes the floor.
             self._process_auto_bids()
             
         return success
@@ -95,52 +84,6 @@ class Auction:
         """Force complete the current player auction."""
         if self.draft.current_player:
             self._complete_current_auction()
-            
-    def _start_nomination_timer(self) -> None:
-        """Start timer for player nomination."""
-        if self.current_timer:
-            self.current_timer.cancel()
-            
-        self.draft.time_remaining = self.nomination_timer
-        self.current_timer = threading.Timer(1.0, self._nomination_timer_tick)
-        self.current_timer.start()
-        
-    def _start_bid_timer(self) -> None:
-        """Start timer for bidding phase."""
-        if self.current_timer:
-            self.current_timer.cancel()
-            
-        self.draft.time_remaining = self.bid_timer
-        self.current_timer = threading.Timer(1.0, self._bid_timer_tick)
-        self.current_timer.start()
-        
-    def _nomination_timer_tick(self) -> None:
-        """Handle nomination timer tick."""
-        if not self.is_active:
-            return
-            
-        self.draft.time_remaining -= 1
-        self._notify_timer_tick("nomination", self.draft.time_remaining)
-        
-        if self.draft.time_remaining <= 0:
-            self._auto_nominate_player()
-        else:
-            self.current_timer = threading.Timer(1.0, self._nomination_timer_tick)
-            self.current_timer.start()
-            
-    def _bid_timer_tick(self) -> None:
-        """Handle bid timer tick."""
-        if not self.is_active:
-            return
-            
-        self.draft.time_remaining -= 1
-        self._notify_timer_tick("bidding", self.draft.time_remaining)
-        
-        if self.draft.time_remaining <= 0:
-            self._complete_current_auction()
-        else:
-            self.current_timer = threading.Timer(1.0, self._bid_timer_tick)
-            self.current_timer.start()
             
     def _auto_nominate_player(self) -> None:
         """Auto-nominate a player when timer expires."""
@@ -250,8 +193,6 @@ class Auction:
             
             if self.draft.status == "completed":
                 self.stop_auction()
-            else:
-                self._start_nomination_timer()
                 
     def _process_auto_bids(self) -> None:
         """Process auto-bids using simplified sealed bid auction logic."""
@@ -356,7 +297,9 @@ class Auction:
             # Only one bidder - pay minimum increment
             final_price = current_bid + 1
         elif len(valid_bids) > 1 and valid_bids[0][2] == valid_bids[1][2]:
-            # Tie for highest bid - winner pays their full bid (random selection handled by sort stability)
+            # Tie for highest bid - choose randomly among tied teams.
+            tied_bids = [bid for bid in valid_bids if bid[2] == highest_bid]
+            winner_id, winner_team, highest_bid = random.choice(tied_bids)
             final_price = highest_bid
         else:
             # Normal case - winner pays $1 more than second highest
@@ -396,14 +339,6 @@ class Auction:
             except Exception:
                 pass
                 
-    def _notify_timer_tick(self, phase: str, time_remaining: int) -> None:
-        """Notify listeners of timer tick."""
-        for callback in self.on_timer_tick:
-            try:
-                callback(phase, time_remaining)
-            except Exception:
-                pass
-                
     def add_bid_listener(self, callback: Callable) -> None:
         """Add a callback for bid events."""
         self.on_bid_placed.append(callback)
@@ -416,10 +351,6 @@ class Auction:
         """Add a callback for auction completion events."""
         self.on_auction_completed.append(callback)
         
-    def add_timer_listener(self, callback: Callable) -> None:
-        """Add a callback for timer tick events."""
-        self.on_timer_tick.append(callback)
-        
     def get_auction_state(self) -> Dict:
         """Get current auction state."""
         return {
@@ -427,7 +358,6 @@ class Auction:
             'current_player': self.draft.current_player.to_dict() if self.draft.current_player else None,
             'current_bid': self.draft.current_bid,
             'current_high_bidder': self.draft.current_high_bidder,
-            'time_remaining': self.draft.time_remaining,
             'current_nominator': self.draft.get_current_nominator().to_dict() if self.draft.get_current_nominator() else None,
             'auto_bid_enabled': dict(self.auto_bid_enabled)
         }

--- a/classes/draft.py
+++ b/classes/draft.py
@@ -33,8 +33,6 @@ class Draft:
         self.current_player: Optional[Player] = None
         self.current_bid = 0.0
         self.current_high_bidder: Optional[str] = None
-        self.bid_timer = 30  # seconds
-        self.time_remaining = 0
         
         # Participants
         self.teams: List[Team] = []
@@ -100,7 +98,6 @@ class Draft:
         self.current_player = player
         self.current_bid = initial_bid
         self.current_high_bidder = nominating_owner_id
-        self.time_remaining = self.bid_timer
         
         # Record nomination
         nomination = {
@@ -130,7 +127,6 @@ class Draft:
             
         self.current_bid = bid_amount
         self.current_high_bidder = bidder_id
-        self.time_remaining = self.bid_timer  # Reset timer
         
         # Record bid
         bid = {
@@ -217,8 +213,7 @@ class Draft:
             
     def _start_new_nomination(self) -> None:
         """Start a new nomination phase."""
-        # Reset timer for nomination
-        self.time_remaining = self.bid_timer
+        return
         
     def _is_draft_complete(self) -> bool:
         """Check if the draft is complete."""

--- a/classes/tournament.py
+++ b/classes/tournament.py
@@ -160,7 +160,7 @@ class Tournament:
         draft.start_draft()
         
         # Create auction with strategies
-        auction = Auction(draft, bid_timer=1, nomination_timer=1)  # Fast timers for simulation
+        auction = Auction(draft)
         
         # Configure strategies for each owner
         for config in self.strategy_configs:

--- a/cli/commands.py
+++ b/cli/commands.py
@@ -891,7 +891,7 @@ class CommandProcessor:
             draft.start_draft()
             
             # Create auction with fast timers
-            auction = Auction(draft, bid_timer=1, nomination_timer=1)
+            auction = Auction(draft)
             
             # Assign strategies to teams and enable auto-bidding
             team_strategies = {}
@@ -1141,7 +1141,7 @@ class CommandProcessor:
         draft.start_draft()
         
         # Create auction with reasonable timers for simulation
-        auction = Auction(draft, bid_timer=0.01, nomination_timer=0.01)
+        auction = Auction(draft)
         
         # Configure strategies for each team and enable auto-bidding
         for team in draft.teams:

--- a/tests/test_auction_budget.py
+++ b/tests/test_auction_budget.py
@@ -42,7 +42,9 @@ def test_budget_constraint_in_auction():
     
     # Create auction
     strategies = {team.owner_id: team.strategy for team in teams}
-    auction = Auction(draft, players, strategies)
+    auction = Auction(draft)
+    for owner_id, strategy in strategies.items():
+        auction.enable_auto_bid(owner_id, strategy)
     
     print(f"Starting auction with {len(teams)} teams")
     print(f"Team roster config: {teams[0].roster_config}")
@@ -50,7 +52,7 @@ def test_budget_constraint_in_auction():
     
     # Run a few rounds and check budgets
     for round_num in range(10):
-        auction._nominate_next_player()
+        auction._auto_nominate_player()
         auction._process_auto_bids()
         
         # Check team budgets every few rounds

--- a/tests/test_auction_enforcement.py
+++ b/tests/test_auction_enforcement.py
@@ -35,14 +35,16 @@ def test_auction_budget_enforcement():
         draft.add_team(team)
         strategies[team.owner_id] = strategy
     
-    auction = Auction(draft, players, strategies)
+    auction = Auction(draft)
+    for owner_id, strategy in strategies.items():
+        auction.enable_auto_bid(owner_id, strategy)
     
     print("Running auction with budget constraint enforcement...")
     
     # Run auction rounds
     for round_num in range(15):
         if draft.current_player:
-            auction._nominate_next_player()
+            auction._auto_nominate_player()
             auction._process_auto_bids()
         else:
             print(f"No current player at round {round_num}, stopping")

--- a/tests/test_auction_sealed_bid.py
+++ b/tests/test_auction_sealed_bid.py
@@ -1,0 +1,51 @@
+"""Regression tests for sealed-bid auction behavior."""
+
+from classes.auction import Auction
+from classes.draft import Draft
+from classes.owner import Owner
+from classes.player import Player
+from classes.team import Team
+
+
+class FixedBidStrategy:
+    def __init__(self, bid):
+        self.bid = bid
+
+    def calculate_bid(self, *_args, **_kwargs):
+        return self.bid
+
+
+def _draft_with_player():
+    draft = Draft(name="sealed bid test", budget_per_team=200, roster_size=1)
+    for idx in range(1, 4):
+        owner = Owner(f"owner{idx}", f"Owner {idx}")
+        team = Team(f"team{idx}", f"owner{idx}", f"Team {idx}", 200)
+        draft.add_owner(owner)
+        draft.add_team(team)
+    player = Player("p1", "Player One", "RB", "TST", 100)
+    draft.add_players([player])
+    draft.start_draft()
+    return draft, player
+
+
+def test_nomination_resolves_immediately_as_vickrey_second_price():
+    draft, player = _draft_with_player()
+    auction = Auction(draft)
+    auction.start_auction()
+    auction.enable_auto_bid("owner2", FixedBidStrategy(40))
+    auction.enable_auto_bid("owner3", FixedBidStrategy(25))
+
+    assert auction.nominate_player(player, "owner1", initial_bid=1)
+
+    assert draft.current_player is None
+    assert player in draft.drafted_players
+    winner = next(team for team in draft.teams if team.owner_id == "owner2")
+    assert player in winner.roster
+    assert draft.transactions[-1]["winning_bidder"] == "owner2"
+    assert draft.transactions[-1]["final_price"] == 26
+
+
+def test_auction_state_has_no_timer_field():
+    draft, _player = _draft_with_player()
+    state = Auction(draft).get_auction_state()
+    assert "time_remaining" not in state

--- a/tests/test_classes.py
+++ b/tests/test_classes.py
@@ -261,10 +261,9 @@ class TestAuction(BaseTestCase):
         from classes.draft import Draft
         
         draft = Draft(name="Test Draft", budget_per_team=200, roster_size=9)
-        auction = Auction(draft, bid_timer=60)
+        auction = Auction(draft)
         
         self.assertEqual(auction.draft, draft)
-        self.assertEqual(auction.bid_timer, 60)
         self.assertFalse(auction.is_active)
         
     def test_auction_nomination(self):
@@ -277,7 +276,7 @@ class TestAuction(BaseTestCase):
         players = TestDataGenerator.create_test_players(5)
         draft.add_players(players)
         
-        auction = Auction(draft, bid_timer=60)
+        auction = Auction(draft)
         
         # Start the draft first
         draft.add_team(Team("team1", "owner1", "Test Team"))
@@ -288,7 +287,8 @@ class TestAuction(BaseTestCase):
         player = players[0]
         auction.nominate_player(player, "Test Owner")
         
-        self.assertEqual(auction.draft.current_player, player)
+        self.assertIn(player, auction.draft.drafted_players)
+        self.assertIsNone(auction.draft.current_player)
 
 
 class TestTournament(BaseTestCase):

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -128,7 +128,7 @@ class TestCompleteAuctionFlow(BaseTestCase):
             draft.add_players(test_players)
             
             # Create auction
-            auction = Auction(draft, timer_duration=30)
+            auction = Auction(draft)
             
             # Simulate bidding on a player
             if test_players:


### PR DESCRIPTION
## Summary
- remove the unused threaded bid/nomination timer path from `Auction` and `Draft`
- make nomination resolve immediately through sealed-bid/Vickrey auto-bids
- update `Auction(...)` call sites/tests and add focused sealed-bid regression coverage

Fixes #264.

## Verification
- `python3 -m compileall -q classes cli services tests`
- `git diff --check`
- `PYTHONPATH=.:tests PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 python3 -m pytest -q tests/test_auction_sealed_bid.py tests/test_classes.py::TestAuction tests/test_auction_budget.py tests/test_auction_enforcement.py --tb=short` -> 6 passed

## Verification limits
- Full suite still has pre-existing unrelated failures in data/API/integration areas on this worker (missing local `data/sheets/*.csv`, Sleeper/API/config test drift, and one strategy float assertion). The auction-focused subset above passes after disabling this worker's globally incompatible pytest plugin autoload.
