### PR TITLE
fix(sprint8): P1 bug clearance — Tracks A-D (15 issues)

### DIFF
--- a/.agents/development/git-workflow.agent.md
+++ b/.agents/development/git-workflow.agent.md
@@ -160,6 +160,51 @@ refactor(strategies): extract VOR helpers into utils/strategy_helpers.py
 test(integration): add 12-team full-auction E2E test
 ```
 
+### When CI Fails on Your PR
+
+When CI fails on a PR you submitted, the `notify-ci-failure` workflow will automatically:
+- Post a structured comment on the PR identifying which jobs failed and linking to the run logs
+- Apply the `ci:failed` label
+
+**As the agent that submitted the PR, you must:**
+
+1. Check which jobs failed:
+   ```bash
+   gh pr checks <PR_NUMBER>
+   ```
+
+2. Read the failure logs (the run ID is in the automated comment, or look it up):
+   ```bash
+   gh run list --branch <your-branch> --limit 5          # find the run ID
+   gh run view <RUN_ID> --log-failed                     # read only failing step output
+   ```
+
+3. Fix the failures on your existing branch — **do NOT open a new PR**:
+   ```bash
+   # Common fixes by job:
+   # lint (flake8)  → remove unused imports, fix syntax
+   # typecheck (mypy) → add missing type hints, fix type errors
+   # security (bandit) → remove hardcoded values, fix MEDIUM+ findings
+   # tests/coverage → fix failing tests, add tests to meet 85% gate
+   ```
+
+4. Verify locally before pushing — all gates must pass:
+   ```bash
+   make ci   # lint + typecheck + security + coverage (mirrors CI exactly)
+   ```
+
+5. Push your fix — CI reruns automatically. The `ci:failed` label is removed on success:
+   ```bash
+   git add -p
+   git commit -m "fix(<scope>): resolve CI failures — <brief description>"
+   git push origin <your-branch>
+   ```
+
+**Do NOT:**
+- Close the PR and open a new one
+- Ask for review while `ci:failed` is present
+- Push without running `make ci` locally first
+
 ### After PR Is Merged
 ```bash
 git checkout develop

--- a/.github/workflows/add-to-project.yml
+++ b/.github/workflows/add-to-project.yml
@@ -1,5 +1,3 @@
-name: Add Issues to Project Board
-
 # Automatically adds newly opened issues to the GitHub Project board
 # and sets their status to "Backlog".
 #
@@ -8,6 +6,8 @@ name: Add Issues to Project Board
 #   (and `repo` scope if this is a private repository), then add it as a
 #   repository secret named ADD_TO_PROJECT_PAT under:
 #   Settings → Secrets and variables → Actions → New repository secret
+
+name: Add Issues to Project Board
 
 on:
   issues:

--- a/.github/workflows/notify-ci-failure.yml
+++ b/.github/workflows/notify-ci-failure.yml
@@ -1,0 +1,148 @@
+# notify-ci-failure.yml — Post a structured comment when CI fails on a PR
+#
+# Triggers whenever CI, App CI, or Lint Gate completes on a branch that has
+# an open PR. On failure: posts an actionable comment, applies ci:failed label.
+# On success: removes ci:failed label (so the agent knows the PR is clean again).
+#
+# Prerequisites: create the label `ci:failed` (color: #e11d48) at
+#   github.com/TylerJWhit/pigskin/labels  before this workflow is used.
+
+name: Notify CI Failure
+
+on:
+  workflow_run:
+    workflows: ["CI", "App CI", "Lint Gate"]
+    types: [completed]
+
+permissions:
+  pull-requests: write
+  issues: write
+  actions: read
+
+jobs:
+  # ── Failure path ────────────────────────────────────────────────────────────
+  notify-failure:
+    name: Comment on PR (failure)
+    runs-on: ubuntu-latest
+    if: github.event.workflow_run.conclusion == 'failure'
+
+    steps:
+      - name: Find open PR for this branch
+        id: pr
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          BRANCH="${{ github.event.workflow_run.head_branch }}"
+          PR_NUMBER=$(gh pr list \
+            --repo "${{ github.repository }}" \
+            --head "$BRANCH" \
+            --state open \
+            --json number \
+            --jq '.[0].number // empty')
+          if [ -z "$PR_NUMBER" ]; then
+            echo "::notice::No open PR found for branch ${BRANCH} — skipping comment."
+          fi
+          echo "pr_number=${PR_NUMBER}" >> "$GITHUB_OUTPUT"
+
+      - name: Get list of failed jobs
+        if: steps.pr.outputs.pr_number != ''
+        id: jobs
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          FAILED=$(gh run view "${{ github.event.workflow_run.id }}" \
+            --repo "${{ github.repository }}" \
+            --json jobs \
+            --jq '[.jobs[] | select(.conclusion == "failure") | "- `" + .name + "`"] | join("\n")')
+          echo "failed_jobs<<EOF" >> "$GITHUB_OUTPUT"
+          echo "$FAILED" >> "$GITHUB_OUTPUT"
+          echo "EOF" >> "$GITHUB_OUTPUT"
+
+      - name: Post failure comment on PR
+        if: steps.pr.outputs.pr_number != ''
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          PR="${{ steps.pr.outputs.pr_number }}"
+          ACTOR="${{ github.event.workflow_run.actor.login }}"
+          WF_NAME="${{ github.event.workflow_run.name }}"
+          RUN_URL="${{ github.event.workflow_run.html_url }}"
+          RUN_ID="${{ github.event.workflow_run.id }}"
+          BRANCH="${{ github.event.workflow_run.head_branch }}"
+          FAILED_JOBS="${{ steps.jobs.outputs.failed_jobs }}"
+
+          {
+            echo "## CI Failed: ${WF_NAME}"
+            echo ""
+            echo "@${ACTOR} — CI checks on this PR failed. Resolve all failures before this PR can progress to In Review."
+            echo ""
+            echo "| Field | Value |"
+            echo "|-------|-------|"
+            echo "| Workflow | \`${WF_NAME}\` |"
+            echo "| Branch | \`${BRANCH}\` |"
+            echo "| Run | [View logs](${RUN_URL}) |"
+            echo ""
+            echo "### Failed Jobs"
+            echo ""
+            echo "${FAILED_JOBS}"
+            echo ""
+            echo "### Agent: Required Actions"
+            echo ""
+            echo "1. Inspect the failure output:"
+            echo '   ```bash'
+            echo "   gh run view ${RUN_ID} --log-failed"
+            echo '   ```'
+            echo "2. Fix the failures on branch \`${BRANCH}\` — do **not** open a new PR"
+            echo "3. Verify locally before pushing:"
+            echo '   ```bash'
+            echo "   make ci   # lint + typecheck + security + coverage — must all pass"
+            echo '   ```'
+            echo "4. Push your fix — CI re-runs automatically; the \`ci:failed\` label is removed on success"
+            echo ""
+            echo "> Auto-posted by the \`notify-ci-failure\` workflow."
+          } > comment.md
+
+          gh pr comment "$PR" \
+            --repo "${{ github.repository }}" \
+            --body-file comment.md
+
+      - name: Apply ci:failed label
+        if: steps.pr.outputs.pr_number != ''
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh pr edit "${{ steps.pr.outputs.pr_number }}" \
+            --repo "${{ github.repository }}" \
+            --add-label "ci:failed" \
+          || echo "::warning::Label 'ci:failed' not found — create it at github.com/${{ github.repository }}/labels"
+
+  # ── Success path — clear stale ci:failed label ───────────────────────────
+  clear-failure:
+    name: Remove ci:failed label (CI passed)
+    runs-on: ubuntu-latest
+    if: github.event.workflow_run.conclusion == 'success'
+
+    steps:
+      - name: Find open PR for this branch
+        id: pr
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          BRANCH="${{ github.event.workflow_run.head_branch }}"
+          PR_NUMBER=$(gh pr list \
+            --repo "${{ github.repository }}" \
+            --head "$BRANCH" \
+            --state open \
+            --json number \
+            --jq '.[0].number // empty')
+          echo "pr_number=${PR_NUMBER}" >> "$GITHUB_OUTPUT"
+
+      - name: Remove ci:failed label
+        if: steps.pr.outputs.pr_number != ''
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh pr edit "${{ steps.pr.outputs.pr_number }}" \
+            --repo "${{ github.repository }}" \
+            --remove-label "ci:failed" \
+          || echo "::notice::Label 'ci:failed' was not present — nothing to remove."

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 # Makefile for Pigskin Auction Draft Tool
 
-.PHONY: setup install dev-install test clean help run-tests format lint typecheck coverage security audit ci standup lab-bench lab-gate
+.PHONY: setup install dev-install test clean help run-tests format lint typecheck coverage security audit ci standup lab-bench lab-gate install-hooks
 
 # Default target
 help:
@@ -28,6 +28,7 @@ help:
 	@echo "Operations:"
 	@echo "  standup     - Print daily standup summary (git log + project board)"
 	@echo "  clean       - Clean up cache and temporary files"
+	@echo "  install-hooks - Install shared git hooks from .githooks/"
 	@echo ""
 	@echo "Lab (pigskin-lab — ADR-001/Sprint 5 migration required):"
 	@echo "  lab-bench   - Run simulation benchmark batch (STRATEGY=all or STRATEGY=<name>)"
@@ -128,6 +129,14 @@ audit:
 
 ci: lint typecheck security coverage
 	@echo "All CI checks passed."
+
+# Install shared git hooks so every developer runs CI checks locally
+install-hooks:
+	@echo "Installing git hooks from .githooks/..."
+	git config core.hooksPath .githooks
+	chmod +x .githooks/pre-commit .githooks/pre-push
+	@echo "Git hooks installed. pre-commit (lint) and pre-push (full CI) are active."
+	@echo "To bypass in an emergency: git push --no-verify"
 
 # Lab targets (pigskin-lab — requires ADR-001 Sprint 5 migration: lab/ directory must exist)
 # Usage:

--- a/api/sleeper_api.py
+++ b/api/sleeper_api.py
@@ -62,7 +62,12 @@ class SleeperAPI:
                 self.last_request_time = time.time()
 
                 if response.status_code == 200:
-                    return response.json()
+                    try:
+                        return response.json()
+                    except Exception as e:
+                        raise SleeperAPIError(
+                            f"Failed to decode JSON response from {url}: {e}"
+                        ) from e
 
                 if response.status_code == 429:
                     if attempt < self.max_retries:
@@ -279,8 +284,7 @@ class SleeperAPI:
                 query_lower in first_name or 
                 query_lower in last_name):
                 
-                player_data['player_id'] = player_id
-                results.append(player_data)
+                results.append({**player_data, 'player_id': player_id})
                 
         return results[:50]  # Limit results
         
@@ -299,8 +303,7 @@ class SleeperAPI:
                 
             full_name = player_data.get('full_name', '').lower()
             if full_name == name_lower:
-                player_data['player_id'] = player_id
-                return player_data
+                return {**player_data, 'player_id': player_id}
                 
         return None
         
@@ -367,8 +370,8 @@ class SleeperAPI:
         
         converted_players = []
         for player_id, player_data in sleeper_players.items():
-            player_data['player_id'] = player_id
-            converted = self.convert_to_auction_player(player_data, projections)
+            player_data_copy = {**player_data, 'player_id': player_id}
+            converted = self.convert_to_auction_player(player_data_copy, projections)
             converted_players.append(converted)
             
         return converted_players

--- a/classes/team.py
+++ b/classes/team.py
@@ -419,36 +419,7 @@ class Team:
                 return True  # Can fill BN/BENCH slot
                 
         return False  # No available slots
-        direct_needed = config.get(pos, 0)
-        direct_filled = current_counts.get(pos, 0)
-        
-        if direct_filled < direct_needed:
-            return True  # Can fill direct position slot
-        
-        # Check FLEX slots (RB/WR/TE can fill FLEX)
-        if pos in ['RB', 'WR', 'TE'] and 'FLEX' in config:
-            flex_needed = config['FLEX']
-            flex_filled = self._count_flex_usage(current_counts)
-            if flex_filled < flex_needed:
-                return True  # Can fill FLEX slot
-        
-        # Check BN/BENCH slots with QB constraint
-        bench_key = 'BENCH' if 'BENCH' in config else 'BN'
-        if bench_key in config:
-            bn_needed = config[bench_key]
-            bn_filled = self._count_bench_usage(current_counts)
-            
-            # Special constraint: Only 1 QB allowed on bench
-            if pos == 'QB':
-                qb_on_bench = max(0, current_counts.get('QB', 0) - direct_needed)
-                if qb_on_bench >= 1:
-                    return False  # Already have max QBs on bench
-            
-            if bn_filled < bn_needed:
-                return True  # Can fill BN/BENCH slot
-                
-        return False  # No available slots
-    
+
     def _has_minimum_required_positions(self, current_counts: dict) -> bool:
         """Check if team has minimum required positions filled."""
         required_positions = self._get_required_positions()

--- a/cli/commands.py
+++ b/cli/commands.py
@@ -172,14 +172,9 @@ class CommandProcessor:
         print("Starting elimination tournament with all available strategies...")
         print(f"Tournament format: {teams_per_draft} teams per draft, {rounds_per_group} rounds per group")
         
-        # Get all available strategies
-        all_strategies = [
-            'value', 'aggressive', 'conservative', 'sigmoid', 'improved_value',
-            'adaptive', 'vor', 'random', 'balanced', 'basic', 'elite_hybrid',
-            'value_random', 'value_smart', 'inflation_vor', 'league',
-            'refined_value_random'
-        ]
-        
+        # Use AVAILABLE_STRATEGIES so dynamically-registered strategies are included (#161)
+        all_strategies = list(AVAILABLE_STRATEGIES.keys())
+
         print(f"Available strategies: {', '.join(all_strategies)}")
         
         return self._run_elimination_rounds(all_strategies, rounds_per_group, teams_per_draft, verbose)
@@ -271,40 +266,7 @@ class CommandProcessor:
             'tournament_winner': tournament_winner,
             'total_rounds': round_number - 1
         }
-        """Run a comprehensive tournament with statistical significance testing."""
-        print("Starting comprehensive tournament with statistical testing...")
-        print(f"Tournament format: {teams_per_draft} teams per draft, 10 runs per group for variance")
-        print(f"Available strategies: {', '.join(AVAILABLE_STRATEGIES)}")
-        
-        start_time = time.time()
-        
-        try:
-            # Get all available strategies
-            all_strategies = list(AVAILABLE_STRATEGIES)
-            
-            # Run the comprehensive tournament with multiple rounds
-            tournament_results = self._run_comprehensive_statistical_tournament(all_strategies, teams_per_draft, verbose=verbose)
-            
-            if not tournament_results.get('success', False):
-                return {
-                    'success': False,
-                    'error': tournament_results.get('error', 'Tournament failed')
-                }
-            
-            # Add timing information
-            elapsed_time = time.time() - start_time
-            tournament_results['execution_time'] = elapsed_time
-            tournament_results['tournament_name'] = 'Comprehensive Statistical Tournament'
-            tournament_results['created_at'] = time.strftime('%Y-%m-%d %H:%M:%S')
-            
-            return tournament_results
-            
-        except Exception as e:
-            return {
-                'success': False,
-                'error': f"Tournament failed: {str(e)}"
-            }
-    
+
     def _run_comprehensive_statistical_tournament(self, strategies: List[str], teams_per_draft: int = 10, verbose: bool = False) -> Dict:
         """Run comprehensive tournament with statistical significance (10 runs per group + championship)."""
         print(f"\nStarting comprehensive statistical tournament with {len(strategies)} strategies")

--- a/cli/main.py
+++ b/cli/main.py
@@ -544,7 +544,7 @@ class AuctionDraftCLI:
                 print(f"       {test['details']}")
         else:
             error_msg = result.get('error', 'No details available')
-            print(f"[FAIL] connectivity_check      ERROR")
+            print("[FAIL] connectivity_check      ERROR")
             print(f"       {error_msg}")
         
         print("="*50)

--- a/cli/main.py
+++ b/cli/main.py
@@ -205,8 +205,20 @@ class AuctionDraftCLI:
             else:
                 filtered_args.append(arg)
         
-        rounds = int(filtered_args[0]) if filtered_args else 10  # Number of drafts per group
-        teams_per_draft = int(filtered_args[1]) if len(filtered_args) > 1 else 10  # Teams per draft
+        rounds = 10
+        teams_per_draft = 10
+        if filtered_args:
+            try:
+                rounds = int(filtered_args[0])
+            except ValueError:
+                print(f"ERROR: Invalid rounds value '{filtered_args[0]}' — must be an integer")
+                return 1
+        if len(filtered_args) > 1:
+            try:
+                teams_per_draft = int(filtered_args[1])
+            except ValueError:
+                print(f"ERROR: Invalid teams_per_draft value '{filtered_args[1]}' — must be an integer")
+                return 1
         
         print("Starting elimination tournament...")
         print(f"Rounds (drafts per group): {rounds}")
@@ -523,19 +535,27 @@ class AuctionDraftCLI:
         """Display Sleeper API connectivity test results."""
         print("\nCONNECTIVITY TEST RESULTS")
         print("="*50)
-        
-        for test in result['tests']:
-            status_prefix = "PASS" if test['status'] == 'PASS' else "WARN" if test['status'] == 'WARN' else "FAIL"
-            print(f"[{status_prefix}] {test['test']:<20} {test['status']}")
-            print(f"       {test['details']}")
+
+        tests = result.get('tests')
+        if tests:
+            for test in tests:
+                status_prefix = "PASS" if test['status'] == 'PASS' else "WARN" if test['status'] == 'WARN' else "FAIL"
+                print(f"[{status_prefix}] {test['test']:<20} {test['status']}")
+                print(f"       {test['details']}")
+        else:
+            error_msg = result.get('error', 'No details available')
+            print(f"[FAIL] connectivity_check      ERROR")
+            print(f"       {error_msg}")
         
         print("="*50)
-        print(f"Summary: {result['summary']}")
-        print(f"Overall Status: {result['overall_status']}")
-        
-        if result['overall_status'] == 'HEALTHY':
+        summary = result.get('summary', 'N/A')
+        overall_status = result.get('overall_status', 'UNKNOWN')
+        print(f"Summary: {summary}")
+        print(f"Overall Status: {overall_status}")
+
+        if overall_status == 'HEALTHY':
             print("All systems operational!")
-        elif result['overall_status'] == 'DEGRADED':
+        elif overall_status == 'DEGRADED':
             print("Some features may be limited")
         else:
             print("Connection issues detected")

--- a/services/bid_recommendation_service.py
+++ b/services/bid_recommendation_service.py
@@ -430,16 +430,14 @@ class BidRecommendationService:
             target_player = None
             for player_id, player_data in players_data.items():
                 if player_data.get('full_name', '').lower() == player_name.lower():
-                    target_player = player_data
-                    target_player['player_id'] = player_id
+                    target_player = {**player_data, 'player_id': player_id}
                     break
             
             if not target_player:
                 # Try partial match
                 for player_id, player_data in players_data.items():
                     if player_name.lower() in player_data.get('full_name', '').lower():
-                        target_player = player_data
-                        target_player['player_id'] = player_id
+                        target_player = {**player_data, 'player_id': player_id}
                         break
             
             if not target_player:

--- a/services/draft_loading_service.py
+++ b/services/draft_loading_service.py
@@ -219,25 +219,44 @@ class DraftLoadingService:
         
         # Calculate based on starting positions plus bench
         bench_spots = roster_positions.get('BN', roster_positions.get('BENCH', 5))
-        
+        # FLEX spots: any one skill-position player may fill a FLEX slot,
+        # but each FLEX slot can only be used *once* — add it only once to the
+        # shared pool, not independently to each eligible position.
+        flex_spots = roster_positions.get('FLEX', 0)
+
         # Distribute bench spots proportionally
         starting_spots = {
             'QB': roster_positions.get('QB', 1),
-            'RB': roster_positions.get('RB', 2) + roster_positions.get('FLEX', 0),  # RBs can fill FLEX
-            'WR': roster_positions.get('WR', 2) + roster_positions.get('FLEX', 0),  # WRs can fill FLEX
-            'TE': roster_positions.get('TE', 1) + roster_positions.get('FLEX', 0),  # TEs can fill FLEX
+            'RB': roster_positions.get('RB', 2),
+            'WR': roster_positions.get('WR', 2),
+            'TE': roster_positions.get('TE', 1),
             'K': roster_positions.get('K', 1),
             'DST': roster_positions.get('DST', 1)
         }
         
-        # Add bench allocation
+        # Add bench + flex allocation
+        # FLEX is a shared pool — it must NOT be added to each eligible
+        # position separately (triple-counting).  Instead, distribute the
+        # flex capacity once across all flex-eligible positions: the
+        # TOTAL of RB+WR+TE limits == starters + flex + bench_share. (#129)
+        flex_eligible = ['RB', 'WR', 'TE']
         for position in limits:
             starting = starting_spots.get(position, 1)
             if position in ['QB', 'K', 'DST']:
                 limits[position] = starting + 1  # Minimal bench for these positions
+            elif position in flex_eligible:
+                # Each flex-eligible position gets only its own starting spots +
+                # bench share.  FLEX capacity is counted in the pool exactly once,
+                # distributed to ONE representative position (RB) so the total
+                # RB+WR+TE == sum(starters) + flex_spots. (#129)
+                limits[position] = starting + (bench_spots // 3)
             else:
-                limits[position] = starting + (bench_spots // 3)  # Distribute bench among skill positions
-                
+                limits[position] = starting + (bench_spots // 3)
+
+        # Add flex_spots once to the pool by bumping only RB (representative)
+        if flex_spots > 0:
+            limits['RB'] = limits.get('RB', starting_spots.get('RB', 2)) + flex_spots
+
         return limits
     
     def reload_draft(self) -> Optional[Draft]:
@@ -266,7 +285,7 @@ class DraftLoadingService:
             'num_teams': config.num_teams,
             'budget': config.budget,
             'sleeper_configured': bool(config.sleeper_draft_id),
-            'fantasypros_configured': os.path.exists(config.data_path)
+            'fantasypros_configured': os.path.exists(config.data_path) if config.data_path is not None else False
         }
         
         # Try to load draft to check if it's working

--- a/strategies/adaptive_strategy.py
+++ b/strategies/adaptive_strategy.py
@@ -68,10 +68,11 @@ class AdaptiveStrategy(Strategy):
         # Calculate maximum possible bid to ensure roster completion (needed for mandatory positions)
         max_possible_bid = self.calculate_max_bid(team, remaining_budget)
         
-        # Special handling for mandatory positions (K, DST) with very high priority
-        if position_priority >= 2.0 and player.position in ['K', 'DST']:
-            # We MUST have these positions - bid aggressively even if player value is low
-            min_mandatory_bid = min(10.0, remaining_budget * 0.1)  # At least $10 or 10% of budget
+        # Special handling for mandatory positions (K, DST) with high priority.
+        # _calculate_position_priority caps at 1.0, so use > 0.5 as the gate
+        # (position is still needed but not yet filled). (#143)
+        if player.position in ['K', 'DST'] and position_priority > 0.5:
+            min_mandatory_bid = min(10.0, remaining_budget * 0.1)
             return min(current_bid + min_mandatory_bid, max_possible_bid)
         
         # If position priority is very low, still bid minimally to fill roster if needed

--- a/strategies/aggressive_strategy.py
+++ b/strategies/aggressive_strategy.py
@@ -35,15 +35,19 @@ class AggressiveStrategy(Strategy):
         """Calculate aggressive bid."""
         # Check position priority for mandatory positions
         position_priority = self._calculate_position_priority(player, team)
-        
-        # Special handling for mandatory positions (K, DST) with very high priority
-        if position_priority >= 2.0 and player.position in ['K', 'DST']:
-            # We MUST have these positions - bid aggressively even if player value is low
-            min_mandatory_bid = min(15.0, remaining_budget * 0.15)  # At least $15 or 15% of budget
-            max_possible_bid = self.calculate_max_bid(team, remaining_budget)
+
+        max_possible_bid = self.calculate_max_bid(team, remaining_budget)
+
+        # Special handling for mandatory positions (K, DST) with high priority.
+        # _calculate_position_priority caps at 1.0, so the gate is > 0.5 when
+        # the position is still needed (not yet filled). (#143)
+        if player.position in ['K', 'DST'] and position_priority > 0.5:
+            min_mandatory_bid = min(15.0, remaining_budget * 0.15)
             return min(current_bid + min_mandatory_bid, max_possible_bid)
-        
-        budget_ratio = remaining_budget / team.initial_budget
+
+        # Guard against ZeroDivisionError when initial_budget is 0. (#145)
+        initial_budget = getattr(team, 'initial_budget', None) or remaining_budget or 1
+        budget_ratio = remaining_budget / initial_budget
         
         # If budget is low, be conservative
         if budget_ratio < self.parameters['budget_threshold']:

--- a/strategies/sigmoid_strategy.py
+++ b/strategies/sigmoid_strategy.py
@@ -51,8 +51,12 @@ class SigmoidStrategy(Strategy):
         
     def _calculate_budget_pressure(self, remaining_budget: float, team: 'Team') -> float:
         """Calculate budget pressure (0.0 = no pressure, 1.0 = high pressure)."""
-        budget_ratio = remaining_budget / team.initial_budget
-        roster_filled_ratio = len(team.roster) / sum(team.roster_requirements.values())
+        # Guard against ZeroDivisionError when initial_budget or roster_requirements is 0. (#146)
+        initial_budget = getattr(team, 'initial_budget', None) or remaining_budget or 1
+        budget_ratio = remaining_budget / initial_budget
+        total_requirements = sum(getattr(team, 'roster_requirements', {}).values())
+        roster_filled_ratio = (len(getattr(team, 'roster', [])) / total_requirements
+                               if total_requirements > 0 else 0.0)
         
         # More pressure if we have little budget relative to roster spots left
         return max(0.0, min(1.0, (1.0 - budget_ratio) + roster_filled_ratio - 0.5))

--- a/strategies/vor_strategy.py
+++ b/strategies/vor_strategy.py
@@ -138,8 +138,8 @@ class VorStrategy(Strategy):
         scarcity_adjustment = 1.0 + (scarcity_factor * self.scarcity_weight)
         
         # Calculate base bid from VOR with more aggressive scaling
-        vor_scaling_factor = 0.25  # Increased from 0.15 to 0.25 per VOR point
-        base_bid = vor * vor_scaling_factor * scarcity_adjustment
+        # Use instance attribute so subclass overrides are respected (#147)
+        base_bid = vor * self._vor_scaling_factor * scarcity_adjustment
         
         # Apply aggression factor with boost
         base_bid *= (self.aggression * 1.3)  # 30% more aggressive

--- a/tests/test_sprint8_regressions.py
+++ b/tests/test_sprint8_regressions.py
@@ -625,7 +625,7 @@ class TestHandleTournamentCommandNonNumericArgs(unittest.TestCase):
         """Non-numeric teams_per_draft arg must not raise ValueError."""
         cli = self._make_cli()
         try:
-            return_code = cli.handle_tournament_command(["10", "not_a_number"])
+            cli.handle_tournament_command(["10", "not_a_number"])
         except ValueError as exc:
             self.fail(
                 f"handle_tournament_command raised ValueError on non-numeric "

--- a/tests/test_sprint8_regressions.py
+++ b/tests/test_sprint8_regressions.py
@@ -53,6 +53,7 @@ import json
 import os
 import sys
 import unittest
+from typing import Optional
 from unittest.mock import AsyncMock, MagicMock, patch
 
 sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
@@ -65,7 +66,7 @@ from classes.team import Team
 # Shared helpers
 # ---------------------------------------------------------------------------
 
-def _make_player(player_id: str, position: str = "QB", name: str = None,
+def _make_player(player_id: str, position: str = "QB", name: Optional[str] = None,
                  auction_value: float = 20.0, projected_points: float = 15.0) -> Player:
     return Player(
         player_id=player_id,
@@ -77,7 +78,7 @@ def _make_player(player_id: str, position: str = "QB", name: str = None,
     )
 
 
-def _make_team(budget: int = 200, roster_config: dict = None) -> Team:
+def _make_team(budget: int = 200, roster_config: Optional[dict] = None) -> Team:
     cfg = roster_config or {"QB": 1, "RB": 2, "WR": 2, "TE": 1, "K": 1, "DST": 1}
     return Team("t1", "o1", "TestTeam", budget=budget, roster_config=cfg)
 

--- a/tests/test_sprint8_regressions.py
+++ b/tests/test_sprint8_regressions.py
@@ -1,0 +1,765 @@
+"""Sprint 8 — QA Agent Phase 1 regression tests.
+
+These tests are intentionally written to FAIL against the current codebase,
+documenting the precise expected behaviour for each P1 bug.  Backend Agent must
+make all tests pass without breaking any previously-passing tests.
+
+Track A — API:
+    #94  SleeperAPI._make_request: json.JSONDecodeError not caught — raw exception
+         bubbles up instead of being wrapped in SleeperAPIError.
+    #95  SleeperAPI.search_players / get_player_by_name: both inject `player_id`
+         directly into the caller's dict, mutating shared state.
+
+Track B — Services & Classes:
+    #111 Team._can_fit_in_roster_structure: the QB-bench constraint (≤1 QB on
+         bench) is dead code — it lives after an unconditional `return False`
+         and never executes.
+    #127 BidRecommendationService._get_sleeper_draft_context: `target_player =
+         player_data` is a reference copy; the subsequent `target_player[
+         'player_id'] = player_id` mutates the caller's shared players_data dict.
+    #129 DraftLoadingService._calculate_position_limits: FLEX spots are added to
+         RB, WR, *and* TE starting counts independently — 1 FLEX spot inflates
+         total capacity by 3 instead of 1.
+    #130 DraftLoadingService.get_draft_status: calls `os.path.exists(config.
+         data_path)` without guarding against `data_path is None` → TypeError.
+
+Track C — Strategies:
+    #143 AdaptiveStrategy / AggressiveStrategy: the `if position_priority >= 2.0`
+         mandatory-bid branch is unreachable because _calculate_position_priority
+         caps its return value at 1.0 via `min(1.0, …)`.
+    #145 AggressiveStrategy.calculate_bid: `remaining_budget / team.initial_budget`
+         is unguarded — ZeroDivisionError when initial_budget == 0.
+    #146 SigmoidStrategy._calculate_budget_pressure: `remaining_budget /
+         team.initial_budget` and `len(team.roster) / sum(team.roster_requirements
+         .values())` are both unguarded — ZeroDivisionError on edge-case teams.
+    #147 VorStrategy.calculate_bid: local variable `vor_scaling_factor = 0.25`
+         shadows `self._vor_scaling_factor`, so subclass overrides are ignored.
+
+Track D — CLI & Utils:
+    #156 cli/commands.py: a large block of code lives after an unconditional
+         `return` inside _run_elimination_rounds — dead, unreachable, misleading.
+    #157 utils/path_utils.py: get_data_file("data/sheets/x.csv") silently returns
+         data/data/sheets/x.csv; the doubled prefix is not caught.
+    #158 cli/main.py: handle_tournament_command calls int() on raw args without a
+         try/except — ValueError on non-numeric input crashes the CLI.
+    #159 cli/main.py: _display_ping_results accesses result['tests'] without
+         guard — KeyError if 'tests' key is absent (e.g. on error responses).
+    #161 cli/commands.py: run_elimination_tournament hard-codes the strategy list
+         instead of reading list(AVAILABLE_STRATEGIES.keys()).
+"""
+
+import asyncio
+import json
+import os
+import sys
+import unittest
+from unittest.mock import AsyncMock, MagicMock, patch
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+from classes.player import Player
+from classes.team import Team
+
+
+# ---------------------------------------------------------------------------
+# Shared helpers
+# ---------------------------------------------------------------------------
+
+def _make_player(player_id: str, position: str = "QB", name: str = None,
+                 auction_value: float = 20.0, projected_points: float = 15.0) -> Player:
+    return Player(
+        player_id=player_id,
+        name=name or f"Player {player_id}",
+        position=position,
+        team="KC",
+        projected_points=projected_points,
+        auction_value=auction_value,
+    )
+
+
+def _make_team(budget: int = 200, roster_config: dict = None) -> Team:
+    cfg = roster_config or {"QB": 1, "RB": 2, "WR": 2, "TE": 1, "K": 1, "DST": 1}
+    return Team("t1", "o1", "TestTeam", budget=budget, roster_config=cfg)
+
+
+# ===========================================================================
+# Track A — #94  SleeperAPI JSONDecodeError not caught
+# ===========================================================================
+
+class TestSleeperAPIJSONDecodeError(unittest.TestCase):
+    """#94 — _make_request must wrap json.JSONDecodeError in SleeperAPIError."""
+
+    def test_json_decode_error_raises_sleeper_api_error(self):
+        """When response.json() raises JSONDecodeError a SleeperAPIError must be raised."""
+        from api.sleeper_api import SleeperAPI, SleeperAPIError
+
+        api = SleeperAPI()
+
+        mock_response = MagicMock()
+        mock_response.status_code = 200
+        mock_response.json.side_effect = json.JSONDecodeError("Expecting value", "", 0)
+
+        mock_client = AsyncMock()
+        mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+        mock_client.__aexit__ = AsyncMock(return_value=False)
+        mock_client.get = AsyncMock(return_value=mock_response)
+
+        with patch("httpx.AsyncClient", return_value=mock_client):
+            with self.assertRaises(SleeperAPIError,
+                                   msg="JSONDecodeError from response.json() must be wrapped "
+                                       "in SleeperAPIError, not propagated raw"):
+                asyncio.run(api._make_request("/test"))
+
+
+# ===========================================================================
+# Track A — #95  Shared-dict mutation in search_players / get_player_by_name
+# ===========================================================================
+
+class TestSleeperAPISharedDictMutation(unittest.TestCase):
+    """#95 — search_players and get_player_by_name must not mutate input dicts."""
+
+    def _players_data(self) -> dict:
+        return {
+            "p1": {
+                "full_name": "Patrick Mahomes",
+                "first_name": "Patrick",
+                "last_name": "Mahomes",
+                "position": "QB",
+            },
+            "p2": {
+                "full_name": "Tyreek Hill",
+                "first_name": "Tyreek",
+                "last_name": "Hill",
+                "position": "WR",
+            },
+        }
+
+    def test_search_players_does_not_inject_player_id_into_source(self):
+        """search_players must return copies, not mutate the source dict entries."""
+        from api.sleeper_api import SleeperAPI
+
+        api = SleeperAPI()
+        data = self._players_data()
+        original_keys = {k: frozenset(v.keys()) for k, v in data.items()}
+
+        api.search_players("Patrick", data)
+
+        for pid, keys_before in original_keys.items():
+            self.assertEqual(
+                frozenset(data[pid].keys()), keys_before,
+                f"search_players mutated source entry '{pid}': "
+                f"injected keys {frozenset(data[pid].keys()) - keys_before}",
+            )
+
+    def test_get_player_by_name_does_not_inject_player_id_into_source(self):
+        """get_player_by_name must return a copy, not mutate the source dict entry."""
+        from api.sleeper_api import SleeperAPI
+
+        api = SleeperAPI()
+        data = self._players_data()
+        original_keys = {k: frozenset(v.keys()) for k, v in data.items()}
+
+        api.get_player_by_name("Patrick Mahomes", data)
+
+        for pid, keys_before in original_keys.items():
+            self.assertEqual(
+                frozenset(data[pid].keys()), keys_before,
+                f"get_player_by_name mutated source entry '{pid}': "
+                f"injected keys {frozenset(data[pid].keys()) - keys_before}",
+            )
+
+    def test_search_results_contain_player_id(self):
+        """search_players results must still include player_id (via copy, not mutation)."""
+        from api.sleeper_api import SleeperAPI
+
+        api = SleeperAPI()
+        data = self._players_data()
+        results = api.search_players("Patrick", data)
+
+        self.assertTrue(len(results) > 0, "Expected at least one result for 'Patrick'")
+        for result in results:
+            self.assertIn("player_id", result, "Result dict must contain player_id")
+
+
+# ===========================================================================
+# Track B — #111  QB bench constraint is dead code
+# ===========================================================================
+
+class TestTeamQBBenchConstraint(unittest.TestCase):
+    """#111 — Only 1 QB should be allowed on bench; constraint is currently dead code."""
+
+    def test_third_qb_rejected_from_bench(self):
+        """After starter + 1 bench QB, a 3rd QB must be rejected.
+
+        roster_config = {QB:1, RB:2, WR:3, TE:1, K:1, DST:1, BN:3}
+        Sequence:
+          qb1 → fills QB starter slot   (ok)
+          qb2 → fills 1 BN slot         (ok — 0 QBs were on bench before)
+          qb3 → must be rejected        (1 QB already on bench; limit is 1)
+        """
+        roster_config = {
+            "QB": 1, "RB": 2, "WR": 3, "TE": 1, "K": 1, "DST": 1, "BN": 3,
+        }
+        team = Team("t1", "o1", "TestTeam", budget=200, roster_config=roster_config)
+
+        qb1 = _make_player("qb1", "QB", "QB Starter", auction_value=30.0)
+        qb2 = _make_player("qb2", "QB", "QB Backup", auction_value=10.0)
+        qb3 = _make_player("qb3", "QB", "QB Third",  auction_value=5.0)
+
+        self.assertTrue(team.add_player(qb1, 30), "First QB (starter) should be added")
+        self.assertTrue(team.add_player(qb2, 10), "Second QB (bench) should be added")
+
+        result = team.add_player(qb3, 5)
+        self.assertFalse(
+            result,
+            "Third QB must be REJECTED — only 1 QB allowed on bench, "
+            "but dead code prevents this constraint from firing",
+        )
+
+
+# ===========================================================================
+# Track B — #127  BidRecommendationService cache mutation
+# ===========================================================================
+
+class TestBidRecommendationServiceCacheMutation(unittest.TestCase):
+    """#127 — _get_sleeper_draft_context must not mutate the shared players_data cache."""
+
+    def _players_data(self) -> dict:
+        return {
+            "p_mahomes": {
+                "full_name": "Patrick Mahomes",
+                "position": "QB",
+                "team": "KC",
+                # player_id intentionally absent — represents a clean cache entry
+            },
+            "p_hill": {
+                "full_name": "Tyreek Hill",
+                "position": "WR",
+                "team": "MIA",
+            },
+        }
+
+    def test_player_cache_not_mutated_after_context_fetch(self):
+        """After _get_sleeper_draft_context, source cache entries must be unchanged."""
+        from services.bid_recommendation_service import BidRecommendationService
+
+        players_data = self._players_data()
+        original_keys = {k: frozenset(v.keys()) for k, v in players_data.items()}
+
+        service = BidRecommendationService.__new__(BidRecommendationService)
+        service.config_manager = MagicMock()
+        service.config_manager.load_config.return_value = MagicMock(
+            sleeper_user_id=None, budget=200
+        )
+
+        mock_api = AsyncMock()
+        mock_api.get_draft = AsyncMock(return_value={"draft_id": "d1", "league_id": "l1"})
+        mock_api.get_draft_picks = AsyncMock(return_value=[])
+        service.sleeper_api = mock_api
+        service.get_sleeper_players = MagicMock(return_value=players_data)
+
+        asyncio.run(service._get_sleeper_draft_context("d1", "Patrick Mahomes"))
+
+        for pid, keys_before in original_keys.items():
+            self.assertEqual(
+                frozenset(players_data[pid].keys()), keys_before,
+                f"Cache entry '{pid}' was mutated: "
+                f"injected keys {frozenset(players_data[pid].keys()) - keys_before}",
+            )
+
+
+# ===========================================================================
+# Track B — #129  FLEX triple-counted in _calculate_position_limits
+# ===========================================================================
+
+class TestDraftLoadingFLEXTripleCounting(unittest.TestCase):
+    """#129 — DraftLoadingService._calculate_position_limits: FLEX counted 3 times."""
+
+    def test_flex_spot_not_triple_counted(self):
+        """With 1 FLEX spot, the total RB+WR+TE capacity must equal
+        RB_starters + WR_starters + TE_starters + 1, not +3."""
+        from services.draft_loading_service import DraftLoadingService
+
+        service = DraftLoadingService.__new__(DraftLoadingService)
+
+        # No bench (BN=0) to isolate FLEX-only inflation.
+        roster_positions = {
+            "QB": 1, "RB": 2, "WR": 2, "TE": 1,
+            "K": 1, "DST": 1, "FLEX": 1, "BN": 0,
+        }
+        limits = service._calculate_position_limits(roster_positions)
+
+        rb = limits.get("RB", 0)
+        wr = limits.get("WR", 0)
+        te = limits.get("TE", 0)
+        total_flex_eligible = rb + wr + te
+
+        # Correct: 2 + 2 + 1 + 1 (FLEX) = 6
+        # Buggy:   3 + 3 + 2        = 8   (FLEX counted once per position)
+        self.assertLessEqual(
+            total_flex_eligible, 6,
+            f"FLEX triple-counted: RB({rb})+WR({wr})+TE({te})={total_flex_eligible}; "
+            f"expected ≤ 6 with 1 FLEX spot",
+        )
+
+
+# ===========================================================================
+# Track B — #130  get_draft_status crashes when data_path is None
+# ===========================================================================
+
+class TestGetDraftStatusNoneDataPath(unittest.TestCase):
+    """#130 — get_draft_status must not raise TypeError when data_path is None."""
+
+    def test_no_type_error_when_data_path_is_none(self):
+        from services.draft_loading_service import DraftLoadingService
+
+        mock_config = MagicMock()
+        mock_config.data_path = None          # Trigger condition
+        mock_config.data_source = "fantasypros"
+        mock_config.num_teams = 10
+        mock_config.budget = 200
+        mock_config.sleeper_draft_id = None
+
+        service = DraftLoadingService.__new__(DraftLoadingService)
+        service.config_manager = MagicMock()
+        service.config_manager.load_config.return_value = mock_config
+
+        # load_current_draft is not under test here — stub it out
+        with patch.object(service, "load_current_draft", return_value=None):
+            try:
+                result = service.get_draft_status()
+            except TypeError as exc:
+                self.fail(
+                    f"get_draft_status raised TypeError when data_path=None: {exc}"
+                )
+
+        self.assertIn("config_loaded", result)
+
+
+# ===========================================================================
+# Track C — #143  Mandatory K/DST bid boost (dead branch position_priority >= 2.0)
+# ===========================================================================
+
+class TestMandatoryPositionBidBoost(unittest.TestCase):
+    """#143 — position_priority >= 2.0 branch is dead; urgently-needed K/DST bids
+    are not boosted.  After fix the tests below must pass."""
+
+    def _team_needing_k(self) -> Team:
+        """Full roster except K — K slot is the last critical need."""
+        team = _make_team(budget=50,
+                          roster_config={"QB": 1, "RB": 2, "WR": 2, "TE": 1,
+                                         "K": 1, "DST": 1})
+        for i, pos in enumerate(["QB", "RB", "RB", "WR", "WR", "TE", "DST"]):
+            team.add_player(_make_player(f"p{i}", pos, auction_value=10.0), 1)
+        return team
+
+    def test_adaptive_strategy_boosts_bid_for_urgently_needed_k(self):
+        """AdaptiveStrategy must apply mandatory-bid boost when K is the last need.
+
+        With current code the branch `if position_priority >= 2.0` is never
+        reached (max priority = 1.0), so the boost never fires.
+        Expected: bid > min(10.0, budget * 0.1) when K is urgently needed.
+        """
+        from strategies.adaptive_strategy import AdaptiveStrategy
+
+        strategy = AdaptiveStrategy()
+        team = self._team_needing_k()
+        owner = MagicMock()
+        owner.get_risk_tolerance.return_value = 0.7
+
+        k_player = _make_player("k1", "K", "Justin Tucker", auction_value=8.0,
+                                projected_points=10.0)
+        bid = strategy.calculate_bid(k_player, team, owner, 1.0, team.budget, [k_player])
+
+        mandatory_minimum = min(10.0, team.budget * 0.1)
+        self.assertGreater(
+            bid, mandatory_minimum,
+            f"AdaptiveStrategy K bid ({bid}) must exceed mandatory minimum "
+            f"({mandatory_minimum}) when K is last urgent need",
+        )
+
+    def test_aggressive_strategy_boosts_bid_for_urgently_needed_k(self):
+        """AggressiveStrategy: same mandatory-bid branch check."""
+        from strategies.aggressive_strategy import AggressiveStrategy
+
+        strategy = AggressiveStrategy()
+        team = self._team_needing_k()
+        owner = MagicMock()
+        owner.get_risk_tolerance.return_value = 0.7
+
+        k_player = _make_player("k1", "K", "Justin Tucker", auction_value=8.0,
+                                projected_points=10.0)
+        bid = strategy.calculate_bid(k_player, team, owner, 1.0, team.budget, [k_player])
+
+        mandatory_minimum = min(15.0, team.budget * 0.15)
+        self.assertGreater(
+            bid, mandatory_minimum,
+            f"AggressiveStrategy K bid ({bid}) must exceed mandatory minimum "
+            f"({mandatory_minimum}) when K is last urgent need",
+        )
+
+
+# ===========================================================================
+# Track C — #145  AggressiveStrategy unguarded initial_budget
+# ===========================================================================
+
+class TestAggressiveStrategyInitialBudgetGuard(unittest.TestCase):
+    """#145 — calculate_bid must not crash when team.initial_budget is 0 or missing."""
+
+    def test_no_zero_division_when_initial_budget_is_zero(self):
+        from strategies.aggressive_strategy import AggressiveStrategy
+
+        strategy = AggressiveStrategy()
+        team = MagicMock()
+        team.initial_budget = 0
+        team.budget = 0
+        team.roster = []
+        team.roster_config = {"QB": 1, "RB": 2, "WR": 2, "TE": 1, "K": 1, "DST": 1}
+        team.roster_requirements = team.roster_config.copy()
+        team.get_needs.return_value = ["K"]
+        team.get_remaining_roster_slots.return_value = 1
+        team.enforce_budget_constraint.return_value = 0
+        team.calculate_position_priority.return_value = 0.5
+
+        owner = MagicMock()
+        player = _make_player("k1", "K")
+
+        try:
+            strategy.calculate_bid(player, team, owner, 1.0, 0.0, [player])
+        except ZeroDivisionError:
+            self.fail(
+                "AggressiveStrategy.calculate_bid raised ZeroDivisionError "
+                "when team.initial_budget == 0"
+            )
+
+    def test_no_attribute_error_when_initial_budget_missing(self):
+        from strategies.aggressive_strategy import AggressiveStrategy
+
+        strategy = AggressiveStrategy()
+        # MagicMock with spec=[] means NO attributes exist
+        team = MagicMock(spec=[])
+        owner = MagicMock()
+        player = _make_player("p1", "QB", auction_value=25.0)
+
+        try:
+            strategy.calculate_bid(player, team, owner, 1.0, 50.0, [player])
+        except AttributeError as exc:
+            self.fail(
+                f"AggressiveStrategy.calculate_bid raised AttributeError "
+                f"when team lacks initial_budget: {exc}"
+            )
+
+
+# ===========================================================================
+# Track C — #146  SigmoidStrategy unguarded attributes
+# ===========================================================================
+
+class TestSigmoidStrategyUnguardedAttributes(unittest.TestCase):
+    """#146 — SigmoidStrategy must not crash on zero initial_budget or empty requirements."""
+
+    def test_no_zero_division_when_initial_budget_is_zero(self):
+        from strategies.sigmoid_strategy import SigmoidStrategy
+
+        strategy = SigmoidStrategy()
+        team = _make_team(budget=0)
+        team.initial_budget = 0    # Override after construction
+
+        owner = MagicMock()
+        owner.get_risk_tolerance.return_value = 0.7
+        player = _make_player("p1", "QB", auction_value=25.0)
+
+        try:
+            strategy.calculate_bid(player, team, owner, 1.0, 0.0, [player])
+        except ZeroDivisionError:
+            self.fail(
+                "SigmoidStrategy.calculate_bid raised ZeroDivisionError "
+                "when team.initial_budget == 0"
+            )
+
+    def test_no_zero_division_when_roster_requirements_empty(self):
+        from strategies.sigmoid_strategy import SigmoidStrategy
+
+        strategy = SigmoidStrategy()
+        team = MagicMock()
+        team.initial_budget = 200
+        team.budget = 200
+        team.roster = []
+        team.roster_config = {}
+        team.roster_requirements = {}     # sum({}.values()) == 0 → ZeroDivisionError
+        team.get_needs.return_value = []
+        team.get_remaining_roster_slots.return_value = 0
+        team.enforce_budget_constraint.return_value = 1
+        team.calculate_position_priority.return_value = 0.5
+
+        owner = MagicMock()
+        owner.get_risk_tolerance.return_value = 0.7
+        player = _make_player("p1", "QB", auction_value=25.0)
+
+        try:
+            strategy.calculate_bid(player, team, owner, 1.0, 200.0, [player])
+        except ZeroDivisionError:
+            self.fail(
+                "SigmoidStrategy.calculate_bid raised ZeroDivisionError "
+                "when roster_requirements is empty"
+            )
+
+
+# ===========================================================================
+# Track C — #147  VorStrategy local var shadows self._vor_scaling_factor
+# ===========================================================================
+
+class TestVorStrategyScalingFactorShadowing(unittest.TestCase):
+    """#147 — calculate_bid local `vor_scaling_factor = 0.25` shadows the instance
+    attribute; subclass overrides are silently discarded."""
+
+    def test_subclass_vor_scaling_factor_is_respected(self):
+        """A subclass setting _vor_scaling_factor=10.0 must produce a higher bid
+        than the default 0.25 factor.  Currently FAILS because the local variable
+        always wins."""
+        from strategies.vor_strategy import VorStrategy
+
+        class HighScaleVorStrategy(VorStrategy):
+            def __init__(self):
+                super().__init__()
+                self._vor_scaling_factor = 10.0  # 40× the default
+
+        default_strategy = VorStrategy()
+        high_strategy = HighScaleVorStrategy()
+
+        # Confirm the subclass attribute is actually set
+        self.assertEqual(
+            high_strategy._vor_scaling_factor, 10.0,
+            "Subclass _vor_scaling_factor must be 10.0 after __init__",
+        )
+
+        team = MagicMock()
+        team.budget = 200
+        team.initial_budget = 200
+        team.roster = []
+        team.roster_config = {"QB": 1, "RB": 2, "WR": 2, "TE": 1, "K": 1, "DST": 1}
+        team.roster_requirements = team.roster_config.copy()
+        team.get_needs.return_value = ["QB"]
+        team.get_remaining_roster_slots.return_value = 6
+        team.enforce_budget_constraint.side_effect = lambda bid, *a, **kw: int(bid)
+        team.calculate_position_priority.return_value = 0.8
+
+        owner = MagicMock()
+        owner.get_risk_tolerance.return_value = 0.7
+
+        player = _make_player("p1", "QB", "Patrick Mahomes",
+                              auction_value=50.0, projected_points=300.0)
+        player.vor = 50.0   # must be positive to reach the scaling-factor code path
+        remaining = [player]
+
+        default_bid = default_strategy.calculate_bid(
+            player, team, owner, 1.0, 200.0, remaining
+        )
+        high_bid = high_strategy.calculate_bid(
+            player, team, owner, 1.0, 200.0, remaining
+        )
+
+        self.assertGreater(
+            high_bid, default_bid,
+            f"Custom _vor_scaling_factor (10.0) should produce a higher bid than "
+            f"the default (0.25), but got high={high_bid}, default={default_bid}.  "
+            f"The local variable `vor_scaling_factor = 0.25` is shadowing the "
+            f"instance attribute.",
+        )
+
+
+# ===========================================================================
+# Track D — #157  get_data_file doubles data/ path segment
+# ===========================================================================
+
+class TestGetDataFileDoubledPath(unittest.TestCase):
+    """#157 — get_data_file("data/sheets/x.csv") silently returns data/data/sheets/x.csv."""
+
+    def test_data_prefix_not_doubled_in_returned_path(self):
+        """get_data_file must not produce a path containing data/data/."""
+        from utils.path_utils import get_data_file
+
+        # Callers occasionally pass the full relative path including "data/".
+        # The function prepends get_data_dir() (which already ends in "data"),
+        # silently doubling the prefix.
+        try:
+            result = get_data_file("data/sheets/players.csv")
+            self.assertNotIn(
+                "data/data",
+                str(result),
+                f"get_data_file doubled the data/ prefix: got {result}",
+            )
+        except ValueError:
+            pass  # Also acceptable — explicit rejection of a doubled prefix
+
+
+# ===========================================================================
+# Track D — #158  handle_tournament_command unhandled ValueError on non-numeric args
+# ===========================================================================
+
+class TestHandleTournamentCommandNonNumericArgs(unittest.TestCase):
+    """#158 — handle_tournament_command must not crash on non-numeric arguments."""
+
+    def _make_cli(self):
+        from cli.main import AuctionDraftCLI
+        cli = AuctionDraftCLI.__new__(AuctionDraftCLI)
+        cli.command_processor = MagicMock()
+        cli.command_processor.run_elimination_tournament.return_value = {
+            "success": True,
+            "tournament_winner": "value",
+            "total_rounds": 1,
+        }
+        return cli
+
+    def test_non_numeric_rounds_returns_error_code_not_exception(self):
+        """Passing a non-numeric rounds argument must return 1, not raise ValueError."""
+        cli = self._make_cli()
+        try:
+            return_code = cli.handle_tournament_command(["not_a_number"])
+        except ValueError as exc:
+            self.fail(
+                f"handle_tournament_command raised ValueError on non-numeric arg: {exc}"
+            )
+        self.assertNotEqual(return_code, None)
+
+    def test_non_numeric_teams_per_draft_returns_error_code_not_exception(self):
+        """Non-numeric teams_per_draft arg must not raise ValueError."""
+        cli = self._make_cli()
+        try:
+            return_code = cli.handle_tournament_command(["10", "not_a_number"])
+        except ValueError as exc:
+            self.fail(
+                f"handle_tournament_command raised ValueError on non-numeric "
+                f"teams_per_draft: {exc}"
+            )
+
+
+# ===========================================================================
+# Track D — #159  _display_ping_results KeyError when 'tests' key missing
+# ===========================================================================
+
+class TestDisplayPingResultsMissingTestsKey(unittest.TestCase):
+    """#159 — _display_ping_results must not raise KeyError when 'tests' is absent."""
+
+    def _make_cli(self):
+        from cli.main import AuctionDraftCLI
+        cli = AuctionDraftCLI.__new__(AuctionDraftCLI)
+        return cli
+
+    def test_no_key_error_when_tests_key_absent(self):
+        """Error response without 'tests' key must not crash _display_ping_results."""
+        cli = self._make_cli()
+        error_result = {
+            "success": False,
+            "error": "Connection timed out",
+            "overall_status": "UNHEALTHY",
+            "summary": "API unreachable",
+        }
+        try:
+            cli._display_ping_results(error_result)
+        except KeyError as exc:
+            self.fail(
+                f"_display_ping_results raised KeyError({exc}) when 'tests' key "
+                f"was absent from the result dict"
+            )
+
+    def test_no_key_error_on_completely_empty_result(self):
+        """Completely empty result dict must not crash _display_ping_results."""
+        cli = self._make_cli()
+        try:
+            cli._display_ping_results({})
+        except KeyError as exc:
+            self.fail(
+                f"_display_ping_results raised KeyError({exc}) on empty result dict"
+            )
+
+
+# ===========================================================================
+# Track D — #161  run_elimination_tournament uses hardcoded strategy list
+# ===========================================================================
+
+class TestRunEliminationTournamentUsesAvailableStrategies(unittest.TestCase):
+    """#161 — run_elimination_tournament must use AVAILABLE_STRATEGIES, not a hardcoded list."""
+
+    def test_dynamically_added_strategy_included_in_tournament(self):
+        """A strategy added to AVAILABLE_STRATEGIES at runtime must appear in the
+        strategy list passed to _run_elimination_rounds.
+
+        Currently FAILS because run_elimination_tournament has its own hardcoded list.
+        """
+        from strategies import AVAILABLE_STRATEGIES
+        from cli.commands import CommandProcessor
+
+        sentinel_key = "_qa_sentinel_strategy_xyz_"
+
+        # Record which strategies _run_elimination_rounds is called with
+        captured: list = []
+
+        def capture(strategies, *args, **kwargs):
+            captured.extend(strategies)
+            return {"success": True, "tournament_winner": strategies[0], "total_rounds": 1}
+
+        proc = CommandProcessor.__new__(CommandProcessor)
+        proc.config_manager = MagicMock()
+
+        mock_strategy_cls = MagicMock(return_value=MagicMock())
+
+        with patch.dict(AVAILABLE_STRATEGIES, {sentinel_key: mock_strategy_cls}):
+            with patch.object(proc, "_run_elimination_rounds", side_effect=capture):
+                proc.run_elimination_tournament(rounds_per_group=1, teams_per_draft=2)
+
+        self.assertIn(
+            sentinel_key, captured,
+            f"run_elimination_tournament used a hardcoded strategy list and did not "
+            f"include the dynamically-registered strategy '{sentinel_key}'.  "
+            f"Fix: replace the hardcoded list with list(AVAILABLE_STRATEGIES.keys()).",
+        )
+
+
+# ===========================================================================
+# Track D — #156  Dead code after return in _run_elimination_rounds
+# ===========================================================================
+
+class TestRunEliminationRoundsDeadCode(unittest.TestCase):
+    """#156 — dead code block after unconditional `return` must be removed.
+
+    The dead block references `AVAILABLE_STRATEGIES` and prints to stdout; after
+    the fix it should be absent.  This test verifies the method returns the
+    expected structure without printing unexpected 'comprehensive tournament'
+    messages.
+    """
+
+    def test_elimination_rounds_returns_correct_structure(self):
+        """_run_elimination_rounds must return {success, tournament_winner, total_rounds}."""
+        from cli.commands import CommandProcessor
+        import io
+
+        proc = CommandProcessor.__new__(CommandProcessor)
+        proc.config_manager = MagicMock()
+
+        def fake_draft(strategies, verbose=False):
+            return {
+                "success": True,
+                "strategy_results": {s: float(i * 10) for i, s in enumerate(strategies)},
+            }
+
+        with patch.object(proc, "_run_elimination_draft", side_effect=fake_draft):
+            with patch("sys.stdout", new_callable=io.StringIO) as mock_out:
+                result = proc._run_elimination_rounds(
+                    ["value", "aggressive"], rounds_per_group=1,
+                    teams_per_draft=2, verbose=False,
+                )
+                output = mock_out.getvalue()
+
+        self.assertIn("success", result)
+        self.assertTrue(result["success"])
+        self.assertIn("tournament_winner", result)
+        # The dead block would print "Starting comprehensive tournament with statistical testing..."
+        self.assertNotIn(
+            "Starting comprehensive tournament with statistical testing",
+            output,
+            "Dead code after `return` is somehow executing and printing to stdout",
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/unit/cli/test_commands.py
+++ b/tests/unit/cli/test_commands.py
@@ -1,6 +1,6 @@
 """Unit tests for CLI commands — cheatsheet_parser integration."""
 
-from unittest.mock import MagicMock, AsyncMock, patch
+from unittest.mock import MagicMock, AsyncMock, patch, mock_open
 
 
 class TestAnalyzeUndervaluedPlayersCommands:
@@ -1549,7 +1549,9 @@ class TestRunDetailedSimulation:
 
         mock_auction = MagicMock()
 
-        with patch('classes.auction.Auction', return_value=mock_auction):
+        with patch('classes.auction.Auction', return_value=mock_auction), \
+             patch('os.makedirs'), \
+             patch('builtins.open', mock_open()):
             result = cp._run_detailed_simulation(mock_draft, 'balanced')
 
         assert 'total_players_drafted' in result
@@ -1587,7 +1589,9 @@ class TestRunDetailedSimulation:
 
         mock_auction = MagicMock()
 
-        with patch('classes.auction.Auction', return_value=mock_auction):
+        with patch('classes.auction.Auction', return_value=mock_auction), \
+             patch('os.makedirs'), \
+             patch('builtins.open', mock_open()):
             result = cp._run_detailed_simulation(mock_draft, 'balanced')
 
         assert 'total_players_drafted' in result

--- a/tests/unit/cli/test_commands.py
+++ b/tests/unit/cli/test_commands.py
@@ -1,6 +1,6 @@
 """Unit tests for CLI commands — cheatsheet_parser integration."""
 
-from unittest.mock import MagicMock, AsyncMock, patch, mock_open
+from unittest.mock import MagicMock, AsyncMock, patch
 
 
 class TestAnalyzeUndervaluedPlayersCommands:
@@ -1549,9 +1549,7 @@ class TestRunDetailedSimulation:
 
         mock_auction = MagicMock()
 
-        with patch('classes.auction.Auction', return_value=mock_auction), \
-             patch('os.makedirs'), \
-             patch('builtins.open', mock_open()):
+        with patch('classes.auction.Auction', return_value=mock_auction):
             result = cp._run_detailed_simulation(mock_draft, 'balanced')
 
         assert 'total_players_drafted' in result
@@ -1589,9 +1587,7 @@ class TestRunDetailedSimulation:
 
         mock_auction = MagicMock()
 
-        with patch('classes.auction.Auction', return_value=mock_auction), \
-             patch('os.makedirs'), \
-             patch('builtins.open', mock_open()):
+        with patch('classes.auction.Auction', return_value=mock_auction):
             result = cp._run_detailed_simulation(mock_draft, 'balanced')
 
         assert 'total_players_drafted' in result

--- a/utils/path_utils.py
+++ b/utils/path_utils.py
@@ -39,10 +39,18 @@ def get_config_file() -> Path:
 def get_data_file(filename: str) -> Path:
     """Get a data file path in the data directory.
 
-    Raises ValueError if the resolved path escapes the data directory.
+    Strips a leading ``data/`` prefix from *filename* if present so that
+    callers passing the full relative path (e.g. ``"data/sheets/x.csv"``)
+    do not get a doubled segment (``data/data/sheets/x.csv``).  Raises
+    ValueError if the resolved path escapes the data directory.
     """
+    # Normalise: strip a redundant "data/" prefix supplied by callers (#157)
+    filename_path = Path(filename)
+    parts = filename_path.parts
+    if parts and parts[0] == "data":
+        filename_path = Path(*parts[1:]) if len(parts) > 1 else Path(".")
     base = get_data_dir().resolve()
-    resolved = (get_data_dir() / filename).resolve()
+    resolved = (get_data_dir() / filename_path).resolve()
     if not str(resolved).startswith(str(base) + "/") and resolved != base:
         raise ValueError(f"Path traversal detected: {filename!r}")
     return resolved


### PR DESCRIPTION
## Summary

Resolves all 15 P1 bugs from Sprint 8 milestone. All changes are covered by the QA-first regression tests in `tests/test_sprint8_regressions.py`.

## Changes by Track

### Track A — `api/sleeper_api.py`
- **#94** Wrap `response.json()` `JSONDecodeError` in `SleeperAPIError` so callers always get a typed exception
- **#95** Copy player dicts before injecting `player_id` — eliminates mutation of the shared players cache

### Track B — Services & Classes
- **#111** Remove unreachable dead QB-bench-constraint block in `team.py`
- **#127** Copy `player_data` in `_get_sleeper_draft_context` instead of mutating the shared cache
- **#129** Fix FLEX triple-counting in `_calculate_position_limits` — FLEX adds once to the shared pool, not once per eligible position
- **#130** Guard `os.path.exists(config.data_path)` against `None` in `get_draft_status`

### Track C — Strategies
- **#143** Fix dead K/DST mandatory-bid branch (threshold was `>= 2.0` but `_calculate_position_priority` caps at `1.0`)
- **#145** Guard `team.initial_budget` division in `aggressive_strategy` against zero/missing
- **#146** Guard both unguarded zero-division paths in `sigmoid_strategy._calculate_budget_pressure`
- **#147** Use `self._vor_scaling_factor` instead of shadowing local variable so subclass overrides are respected

### Track D — CLI & Utils
- **#156** Remove dead code block after unconditional `return` in `_run_elimination_rounds`
- **#157** Strip redundant `data/` prefix in `get_data_file` (prevents `data/data/` doubled path)
- **#158** Wrap `int()` calls in `try/except ValueError` in `handle_tournament_command`
- **#159** Guard all `result[key]` accesses in `_display_ping_results` with `.get()`
- **#161** Replace hardcoded strategy list with `list(AVAILABLE_STRATEGIES.keys())`

## Test Results

```
22/22 sprint8 regression tests PASSED
1671 total tests PASSED, 0 failures
```

Closes #94, #95, #111, #127, #129, #130, #143, #145, #146, #147, #156, #157, #158, #159, #161