### PR TITLE
feat(cicd): sprint-branch workflow enforcement (closes #278, #279, #280)

### DIFF
--- a/.agents/development/backend.agent.md
+++ b/.agents/development/backend.agent.md
@@ -84,10 +84,11 @@ gh project item-edit --project-id "PVT_kwHOABhKAM4BVbFX" --id "$ITEM_ID" \
    gh issue view <ISSUE_NUMBER> --json labels | jq '.labels[].name' | grep "qa:tests-defined"
    ```
    If the label is missing, do not start. Comment: "Waiting for QA Phase 1 (test definition) before starting implementation."
-3. **Create a feature branch from `develop`** — never work directly on `develop` or `main`:
+3. **Create a feature branch from the current sprint branch** — never branch from `develop` directly:
    ```bash
-   git checkout develop && git pull origin develop
-   git checkout -b feat/<slug>   # or fix/<slug>, refactor/<slug>, etc.
+   SPRINT="sprint/8"   # update to current sprint number
+   git fetch origin
+   git checkout -b feat/<slug> origin/$SPRINT   # or fix/<slug>, refactor/<slug>, etc.
    ```
 4. Move the issue to **In Progress** on the project board (see commands above) and comment:
    ```bash

--- a/.agents/development/frontend.agent.md
+++ b/.agents/development/frontend.agent.md
@@ -71,7 +71,9 @@ After implementation, hand off to the QA Agent for Phase 2 verification before m
    If the label is missing, do not start. Comment: "Waiting for QA Phase 1 (test definition) before starting implementation."
 3. **Create a feature branch from `develop`** — never work directly on `develop` or `main`:
    ```bash
-   git checkout develop && git pull origin develop
+   SPRINT="sprint/8"   # update to current sprint number
+   git fetch origin
+   git checkout -b feat/<slug> origin/$SPRINT
    git checkout -b feat/<slug>   # or fix/<slug>, etc.
    ```
 4. Check `launch_draft_ui.py` for server setup and route registration

--- a/.agents/development/git-workflow.agent.md
+++ b/.agents/development/git-workflow.agent.md
@@ -23,18 +23,38 @@ You are the **Git Workflow Agent** for the **Pigskin Fantasy Football Draft Assi
 
 ## Branching Strategy
 
-Two-branch integration model:
+Three-tier sprint branch model:
 ```
-main ─────────────────────────●──── (always deployable, production releases only)
-                             /
-develop ──●────●────●────●──●──────  (integration branch, all PRs target here)
-           \  /      \  /
-            ●         ●             (short-lived feature branches)
+main ─────────────────────────────────────────●──── (production releases only)
+                                             /
+develop ──●──────────────────────────────●──●──────  (integration; sprint branches merge here)
+           \                            /
+            sprint/8 ──●──────────────●              (sprint integration branch)
+                        \  /      \  /
+                         ●         ●                 (short-lived feature branches)
 ```
 
-**Branch from `develop`. PR into `develop`. DevOps promotes `develop` → `main` for releases.**
+**Branching hierarchy:**
+```
+feature/<slug>  →  sprint/N  →  develop  →  main
+```
 
-Branch naming patterns:
+- **Feature branches** are cut from `sprint/N`, never from `develop` directly
+- **Sprint branches** (`sprint/8`, `sprint/9`, …) are cut from `develop` at sprint start
+- **Sprint branches** merge into `develop` when the sprint closes and all issues are Done/Closed
+- **`develop`** is promoted to `main` at release checkpoints (DevOps handles this)
+- **Direct pushes** to `develop` and `main` are blocked by the `pre-push` hook
+
+> ⚠️ **Never branch from `develop` for day-to-day feature work.**  
+> Always cut feature branches from the current sprint branch.
+
+### Sprint branch naming
+```
+sprint/8          Sprint 8 integration branch
+sprint/9          Sprint 9 integration branch
+```
+
+### Feature branch naming patterns
 ```
 feat/<slug>         New feature or strategy implementation
 fix/<slug>          Bug fix (include bug ID if available)
@@ -116,8 +136,11 @@ git push origin v1.2.3
 
 ### Starting a New Feature
 ```bash
+# 1. Determine the current sprint branch (e.g., sprint/8)
+SPRINT_BRANCH="sprint/8"
+
 git fetch origin
-git checkout -b feat/my-feature origin/develop
+git checkout -b feat/my-feature origin/$SPRINT_BRANCH
 # ... make changes ...
 git add -p  # stage hunks, not whole files
 git commit -m "feat(scope): description"
@@ -126,16 +149,16 @@ git commit -m "feat(scope): description"
 ### Before Opening a PR
 ```bash
 git fetch origin
-git rebase origin/develop       # Clean rebase on latest
+git rebase origin/sprint/8      # Clean rebase on sprint branch
 make ci                         # lint + typecheck + security + coverage must all pass
-git log origin/develop..HEAD --oneline  # Review your commits
+git log origin/sprint/8..HEAD --oneline  # Review your commits
 ```
 
 ### Opening a Pull Request
 ```bash
-# Standard PR — targets develop (DevOps handles develop → main promotions)
+# Feature PR — targets the current sprint branch (NOT develop directly)
 gh pr create \
-  --base develop \
+  --base sprint/8 \
   --title "<type>(<scope>): <short description>" \
   --body "Closes #<ISSUE_NUMBER>" \
   --assignee "@me"

--- a/.agents/orchestration/orchestrator.agent.md
+++ b/.agents/orchestration/orchestrator.agent.md
@@ -53,14 +53,16 @@ READY  ←───────────────────────�
 IN PROGRESS                                               │
   Owner: Development Agents                               │
   • Dev picks up only after qa:tests-defined is present   │
-  • Dev creates a feature branch from `develop`:          │
-      git checkout develop && git pull origin develop     │
-      git checkout -b feat/<slug>  (fix/, refactor/, …)  │
+  • Dev creates a feature branch from the SPRINT BRANCH:  │
+      SPRINT="sprint/8"  # or current sprint              │
+      git checkout origin/$SPRINT -b feat/<slug>          │
+        (or fix/, refactor/, …)                           │
+  • Never branch from `develop` for feature work          │
   • All work happens on the feature branch — never        │
-    commit directly to `develop` or `main`               │
+    commit directly to `develop`, `sprint/N`, or `main`  │
   • If a question arises: move back to Ready →────────────┘
   • When implementation complete: open a PR targeting
-    `develop`, move to In Review
+    the current `sprint/N` branch, move to In Review
     ↓
 IN REVIEW
   Owner: QA + Planning
@@ -217,6 +219,41 @@ For a complex workflow:
 - Monitor delegated tasks for blockers
 - Collect outputs from each agent
 - Produce a summary when all subtasks complete
+
+### Mandatory Board-Sync Checkpoints
+
+The Orchestrator **must** update the project board at every status transition. Run these commands at the checkpoints listed below:
+
+```bash
+# Get the project item ID for an issue
+get_item_id() {
+  local issue_num="$1"
+  gh project item-list 2 --owner TylerJWhit --format json --limit 300 \
+    | jq -r --argjson num "$issue_num" '.items[] | select(.content.number == $num) | .id'
+}
+
+# Move issue to a status
+move_status() {
+  local issue_num="$1"
+  local option_id="$2"   # see Project Board ID Reference above
+  local item_id
+  item_id=$(get_item_id "$issue_num")
+  gh project item-edit \
+    --project-id PVT_kwHOABhKAM4BVbFX \
+    --id "$item_id" \
+    --field-id PVTSSF_lAHOABhKAM4BVbFXzhQ2_HU \
+    --single-select-option-id "$option_id"
+}
+```
+
+| Checkpoint | Board Action | Option ID |
+|------------|-------------|-----------|
+| QA Agent applies `qa:tests-defined` label | Ready → In Progress | `16cf461f` |
+| Developer opens PR | In Progress → In Review | `68c4a78a` |
+| QA Phase 2 + Planning approve PR | In Review → Done | `7fefbd66` |
+| DevOps merges PR and deletes branch | Done → Closed | `a0358230` |
+
+**Rule**: No agent may change their working status without also executing the corresponding board sync. The board must reflect reality within one action of any state change.
 
 ## Common Workflows
 

--- a/.githooks/commit-msg
+++ b/.githooks/commit-msg
@@ -1,0 +1,57 @@
+#!/usr/bin/env bash
+# commit-msg — enforce Conventional Commits format
+#
+# Valid format: <type>(<scope>): <description>
+# The <scope> is optional: <type>: <description> is also accepted.
+#
+# Valid types: feat, fix, chore, docs, refactor, test, perf, style, build, ci, revert
+#
+# Examples:
+#   feat(api): add POST /recommend/bid endpoint
+#   fix(strategies): guard ZeroDivisionError in sigmoid_strategy
+#   chore: update dependencies
+#   docs(adr): add ADR-008 GitHub Actions strategy
+#
+# Install: make install-hooks
+
+set -euo pipefail
+
+COMMIT_MSG_FILE="$1"
+COMMIT_MSG=$(cat "$COMMIT_MSG_FILE")
+
+# Allow merge commits (they start with "Merge")
+if echo "$COMMIT_MSG" | grep -qE "^Merge "; then
+  exit 0
+fi
+
+# Allow revert commits
+if echo "$COMMIT_MSG" | grep -qE "^[Rr]evert"; then
+  exit 0
+fi
+
+# Conventional Commits pattern
+PATTERN="^(feat|fix|chore|docs|refactor|test|perf|style|build|ci|revert)(\([a-zA-Z0-9_/-]+\))?: .{1,}"
+
+if ! echo "$COMMIT_MSG" | grep -qE "$PATTERN"; then
+  echo ""
+  echo "╔═══════════════════════════════════════════════════════════════╗"
+  echo "║  commit-msg: Invalid commit message format                    ║"
+  echo "╠═══════════════════════════════════════════════════════════════╣"
+  echo "║  Required: <type>(<scope>): <description>                     ║"
+  echo "║                                                               ║"
+  echo "║  Valid types: feat, fix, chore, docs, refactor, test,         ║"
+  echo "║               perf, style, build, ci, revert                  ║"
+  echo "║                                                               ║"
+  echo "║  Examples:                                                    ║"
+  echo "║    feat(api): add POST /recommend/bid endpoint                ║"
+  echo "║    fix(strategies): guard ZeroDivisionError in sigmoid        ║"
+  echo "║    chore: update dependencies                                 ║"
+  echo "║    docs(adr): add ADR-008 GitHub Actions strategy             ║"
+  echo "╚═══════════════════════════════════════════════════════════════╝"
+  echo ""
+  echo "Your message: $COMMIT_MSG"
+  echo ""
+  exit 1
+fi
+
+exit 0

--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -1,8 +1,12 @@
 #!/usr/bin/env bash
-# pre-push — full CI suite before any push
+# pre-push — sprint-branch guard + full CI suite before any push
 #
 # Mirrors the App CI workflow (app-ci.yml):
 #   flake8 (lint) → mypy (type check) → bandit (security) → pytest (unit + 85% coverage)
+#
+# Also enforces the 3-tier sprint branch workflow:
+#   feature/<slug>  →  sprint/N  →  develop  →  main
+#   Direct pushes to `develop` and `main` are blocked.
 #
 # Integration tests are intentionally excluded here to keep push latency
 # reasonable; they run in CI after the push lands.
@@ -16,6 +20,30 @@ set -euo pipefail
 
 ROOT=$(git rev-parse --show-toplevel)
 cd "$ROOT"
+
+# ── Sprint-branch workflow guard ──────────────────────────────────────────────
+CURRENT_BRANCH=$(git rev-parse --abbrev-ref HEAD)
+PROTECTED_BRANCHES=("develop" "main")
+
+for protected in "${PROTECTED_BRANCHES[@]}"; do
+  if [ "$CURRENT_BRANCH" = "$protected" ]; then
+    echo ""
+    echo "╔═══════════════════════════════════════════════════════════════╗"
+    echo "║  pre-push: Direct push to '$protected' is blocked            ║"
+    echo "╠═══════════════════════════════════════════════════════════════╣"
+    echo "║  The sprint branch workflow requires:                        ║"
+    echo "║                                                               ║"
+    echo "║    feature/<slug>  →  sprint/N  →  develop  →  main          ║"
+    echo "║                                                               ║"
+    echo "║  Create a feature or sprint branch and open a PR instead:    ║"
+    echo "║    git checkout -b feature/my-change                         ║"
+    echo "║    git push origin feature/my-change                         ║"
+    echo "║    gh pr create --base sprint/8                              ║"
+    echo "╚═══════════════════════════════════════════════════════════════╝"
+    echo ""
+    exit 1
+  fi
+done
 
 # ── helper: resolve binary from venv or PATH ─────────────────────────────────
 resolve() {

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 # Makefile for Pigskin Auction Draft Tool
 
-.PHONY: setup install dev-install test clean help run-tests format lint typecheck coverage security audit ci standup lab-bench lab-gate install-hooks
+.PHONY: setup install dev-install test clean help run-tests format lint typecheck coverage security audit ci standup lab-bench lab-gate install-hooks hooks
 
 # Default target
 help:
@@ -28,7 +28,7 @@ help:
 	@echo "Operations:"
 	@echo "  standup     - Print daily standup summary (git log + project board)"
 	@echo "  clean       - Clean up cache and temporary files"
-	@echo "  install-hooks - Install shared git hooks from .githooks/"
+	@echo "  install-hooks - Install shared git hooks from .githooks/ (aliases: hooks)"
 	@echo ""
 	@echo "Lab (pigskin-lab — ADR-001/Sprint 5 migration required):"
 	@echo "  lab-bench   - Run simulation benchmark batch (STRATEGY=all or STRATEGY=<name>)"
@@ -134,9 +134,14 @@ ci: lint typecheck security coverage
 install-hooks:
 	@echo "Installing git hooks from .githooks/..."
 	git config core.hooksPath .githooks
-	chmod +x .githooks/pre-commit .githooks/pre-push
-	@echo "Git hooks installed. pre-commit (lint) and pre-push (full CI) are active."
+	chmod +x .githooks/pre-commit .githooks/pre-push .githooks/commit-msg
+	@echo "Git hooks installed:"
+	@echo "  pre-commit  — flake8 lint on staged files"
+	@echo "  commit-msg  — Conventional Commits format validation"
+	@echo "  pre-push    — sprint-branch guard + full CI (lint/mypy/bandit/tests)"
 	@echo "To bypass in an emergency: git push --no-verify"
+
+hooks: install-hooks
 
 # Lab targets (pigskin-lab — requires ADR-001 Sprint 5 migration: lab/ directory must exist)
 # Usage:


### PR DESCRIPTION
## Summary

Implements full sprint-branch workflow governance for Sprint 8 issues #278, #279, and #280.

## Changes

### #279 — Git Hooks: commit-msg + pre-push sprint-branch guard
- `.githooks/commit-msg`: validates Conventional Commits format — rejects anything outside `feat|fix|chore|docs|refactor|test|perf|style|build|ci|revert`
- `.githooks/pre-push`: blocks direct pushes to `develop` and `main` with clear error explaining the 3-tier model

### #278 — Enforce Sprint Branch Workflow
- `git-workflow.agent.md`: updated from 2-tier to 3-tier model (`feature/<slug> → sprint/N → develop → main`)
- `orchestrator.agent.md`: agents now branch from `sprint/N`, never from `develop`
- `backend.agent.md`, `frontend.agent.md`: updated branching instructions

### #280 — Orchestrator Board-Sync Checkpoints
- `orchestrator.agent.md`: added **Mandatory Board-Sync Checkpoints** section with helper bash functions and a checkpoint table mapping lifecycle transitions to `gh project item-edit` commands

### Makefile
- Added `hooks` alias for `install-hooks`
- Updated `chmod` to include `commit-msg`
- Updated help text

## Acceptance Criteria
- [x] `commit-msg` hook rejects malformed messages, accepts valid ones
- [x] `pre-push` blocks pushes to `develop`/`main`
- [x] 3-tier branching model documented in agent files
- [x] `make hooks` / `make install-hooks` installs all three hooks
- [x] Mandatory board-sync checkpoints in orchestrator