### PR TITLE
feat(api): POST /recommend/bid endpoint (closes #179)

### DIFF
--- a/api/main.py
+++ b/api/main.py
@@ -5,7 +5,7 @@ from typing import AsyncGenerator
 from fastapi import FastAPI, Depends
 
 from api.deps import require_api_key
-from api.routers import auction, draft, players, strategies
+from api.routers import auction, draft, players, recommend, strategies
 
 
 @asynccontextmanager
@@ -36,6 +36,7 @@ def create_app() -> FastAPI:
     app.include_router(players.router, dependencies=_auth)
     app.include_router(draft.router, dependencies=_auth)
     app.include_router(auction.router, dependencies=_auth)
+    app.include_router(recommend.router, dependencies=_auth)
 
     return app
 

--- a/api/routers/recommend.py
+++ b/api/routers/recommend.py
@@ -1,0 +1,48 @@
+"""Recommend router — bid recommendation endpoint (ADR-002, issue #179)."""
+from fastapi import APIRouter, HTTPException
+
+from api.schemas.recommend import BidRecommendationRequest, BidRecommendationResponse
+from services.bid_recommendation_service import BidRecommendationService
+
+router = APIRouter(prefix="/recommend", tags=["recommend"])
+
+_service = BidRecommendationService()
+
+
+@router.post(
+    "/bid",
+    response_model=BidRecommendationResponse,
+    summary="Get a bid recommendation for a player",
+    description=(
+        "Returns a recommended bid amount, confidence score, and rationale "
+        "for the requested player based on the configured bidding strategy. "
+        "Returns HTTP 503 if no draft context is available."
+    ),
+)
+def recommend_bid(request: BidRecommendationRequest) -> BidRecommendationResponse:
+    """POST /recommend/bid — ADR-002."""
+    team_context = {
+        "budget": request.team_budget,
+        "roster_spots_remaining": request.roster_spots_remaining,
+    }
+
+    result = _service.recommend_bid(
+        player_name=request.player_name,
+        current_bid=request.current_bid,
+        team_context=team_context,
+        strategy_override=request.strategy_override,
+        sleeper_draft_id=request.sleeper_draft_id,
+    )
+
+    # Service signals failure with success=False
+    if not result.get("success", True) or result.get("error"):
+        raise HTTPException(
+            status_code=503,
+            detail=result.get("error", "Draft context unavailable"),
+        )
+
+    return BidRecommendationResponse(
+        recommended_bid=float(result.get("recommended_bid", 1.0)),
+        confidence=float(result.get("confidence", 0.5)),
+        rationale=str(result.get("rationale", result.get("reasoning", ""))),
+    )

--- a/api/schemas/recommend.py
+++ b/api/schemas/recommend.py
@@ -1,0 +1,30 @@
+"""Bid recommendation DTO schemas (ADR-002)."""
+from typing import Optional
+
+from pydantic import BaseModel, Field
+
+
+class BidRecommendationRequest(BaseModel):
+    """Request body for POST /recommend/bid."""
+
+    player_name: str = Field(..., min_length=1, description="Name of the player to bid on")
+    current_bid: float = Field(..., ge=0.0, description="Current highest bid (0 if no bids yet)")
+    team_budget: float = Field(..., ge=0.0, description="Remaining team budget in dollars")
+    roster_spots_remaining: int = Field(
+        default=1, ge=1, description="Number of roster spots still to fill"
+    )
+    player_id: Optional[str] = Field(default=None, description="Sleeper player ID (optional)")
+    strategy_override: Optional[str] = Field(
+        default=None, description="Override the configured strategy"
+    )
+    sleeper_draft_id: Optional[str] = Field(
+        default=None, description="Sleeper draft ID for live draft context"
+    )
+
+
+class BidRecommendationResponse(BaseModel):
+    """Response body for POST /recommend/bid."""
+
+    recommended_bid: float = Field(..., description="Recommended bid amount in dollars")
+    confidence: float = Field(..., ge=0.0, le=1.0, description="Confidence score [0, 1]")
+    rationale: str = Field(..., description="Human-readable explanation for the recommendation")

--- a/tests/unit/api/test_recommend_bid.py
+++ b/tests/unit/api/test_recommend_bid.py
@@ -15,7 +15,7 @@ Scenarios:
   7. request/response schema round-trips (field names, types)
 """
 import pytest
-from unittest.mock import patch, MagicMock
+from unittest.mock import patch
 from fastapi.testclient import TestClient
 
 from api.main import create_app

--- a/tests/unit/api/test_recommend_bid.py
+++ b/tests/unit/api/test_recommend_bid.py
@@ -1,0 +1,267 @@
+"""QA Phase 1 regression tests for issue #179.
+
+POST /api/v1/recommend/bid endpoint (ADR-002)
+
+These tests define the contract for the endpoint. They are written BEFORE
+implementation so they fail until the feature is complete (QA-First lifecycle).
+
+Scenarios:
+  1. Valid request → 200 with BidRecommendationResponse fields
+  2. Missing required fields → 422 Unprocessable Entity
+  3. Service unavailable (no draft context) → 503
+  4. Auth required — missing key → 401
+  5. Response model enforced — no domain objects leak
+  6. Route is registered at /recommend/bid
+  7. request/response schema round-trips (field names, types)
+"""
+import pytest
+from unittest.mock import patch, MagicMock
+from fastapi.testclient import TestClient
+
+from api.main import create_app
+from config.settings import Settings
+
+_VALID_KEY = "test-secret-key-abc123"
+
+_VALID_REQUEST = {
+    "player_id": "1234",
+    "player_name": "Patrick Mahomes",
+    "current_bid": 10.0,
+    "team_budget": 200.0,
+    "roster_spots_remaining": 8,
+}
+
+_MOCK_RECOMMENDATION = {
+    "recommended_bid": 42.0,
+    "confidence": 0.85,
+    "rationale": "High VOR player with low scarcity risk.",
+}
+
+
+@pytest.fixture
+def app():
+    """Fresh app with test API key and mocked bid recommendation service."""
+    _app = create_app()
+
+    def _mock_settings() -> Settings:
+        return Settings(api_key=_VALID_KEY)
+
+    from config.settings import get_settings
+    _app.dependency_overrides[get_settings] = _mock_settings
+    return _app
+
+
+@pytest.fixture
+def client(app):
+    return TestClient(app, raise_server_exceptions=False)
+
+
+@pytest.fixture
+def auth_headers():
+    return {"X-API-Key": _VALID_KEY}
+
+
+# ---------------------------------------------------------------------------
+# Scenario 4: Auth required
+# ---------------------------------------------------------------------------
+
+class TestBidRecommendationAuth:
+    def test_missing_key_returns_401(self, client):
+        resp = client.post("/recommend/bid", json=_VALID_REQUEST)
+        assert resp.status_code == 401, f"Expected 401 without key, got {resp.status_code}"
+
+    def test_wrong_key_returns_403(self, client):
+        resp = client.post("/recommend/bid", json=_VALID_REQUEST,
+                           headers={"X-API-Key": "wrong-key"})
+        assert resp.status_code == 403, f"Expected 403 with wrong key, got {resp.status_code}"
+
+
+# ---------------------------------------------------------------------------
+# Scenario 6: Route is registered
+# ---------------------------------------------------------------------------
+
+class TestRouteRegistration:
+    def test_route_exists(self, client, auth_headers):
+        """Route must be registered — a 404 means the router is not wired up."""
+        with patch(
+            "services.bid_recommendation_service.BidRecommendationService.recommend_bid",
+            return_value=_MOCK_RECOMMENDATION,
+        ):
+            resp = client.post("/recommend/bid", json=_VALID_REQUEST,
+                               headers=auth_headers)
+        assert resp.status_code != 404, "/recommend/bid is not registered"
+
+    def test_route_accessible_with_prefix(self, client, auth_headers):
+        """Endpoint must be reachable at /recommend/bid (not /api/v1/... prefix in test)."""
+        with patch(
+            "services.bid_recommendation_service.BidRecommendationService.recommend_bid",
+            return_value=_MOCK_RECOMMENDATION,
+        ):
+            resp = client.post("/recommend/bid", json=_VALID_REQUEST,
+                               headers=auth_headers)
+        assert resp.status_code in (200, 503), (
+            f"Expected 200 or 503 but got {resp.status_code} — route likely missing"
+        )
+
+
+# ---------------------------------------------------------------------------
+# Scenario 1: Valid request → 200
+# ---------------------------------------------------------------------------
+
+class TestBidRecommendationSuccess:
+    def test_returns_200_with_valid_request(self, client, auth_headers):
+        with patch(
+            "services.bid_recommendation_service.BidRecommendationService.recommend_bid",
+            return_value=_MOCK_RECOMMENDATION,
+        ):
+            resp = client.post("/recommend/bid", json=_VALID_REQUEST,
+                               headers=auth_headers)
+        assert resp.status_code == 200, f"Expected 200, got {resp.status_code}: {resp.text}"
+
+    def test_response_contains_recommended_bid(self, client, auth_headers):
+        with patch(
+            "services.bid_recommendation_service.BidRecommendationService.recommend_bid",
+            return_value=_MOCK_RECOMMENDATION,
+        ):
+            resp = client.post("/recommend/bid", json=_VALID_REQUEST,
+                               headers=auth_headers)
+        assert resp.status_code == 200
+        body = resp.json()
+        assert "recommended_bid" in body, f"'recommended_bid' missing from response: {body}"
+
+    def test_response_contains_confidence(self, client, auth_headers):
+        with patch(
+            "services.bid_recommendation_service.BidRecommendationService.recommend_bid",
+            return_value=_MOCK_RECOMMENDATION,
+        ):
+            resp = client.post("/recommend/bid", json=_VALID_REQUEST,
+                               headers=auth_headers)
+        assert resp.status_code == 200
+        body = resp.json()
+        assert "confidence" in body, f"'confidence' missing from response: {body}"
+
+    def test_response_contains_rationale(self, client, auth_headers):
+        with patch(
+            "services.bid_recommendation_service.BidRecommendationService.recommend_bid",
+            return_value=_MOCK_RECOMMENDATION,
+        ):
+            resp = client.post("/recommend/bid", json=_VALID_REQUEST,
+                               headers=auth_headers)
+        assert resp.status_code == 200
+        body = resp.json()
+        assert "rationale" in body, f"'rationale' missing from response: {body}"
+
+    def test_recommended_bid_is_numeric(self, client, auth_headers):
+        with patch(
+            "services.bid_recommendation_service.BidRecommendationService.recommend_bid",
+            return_value=_MOCK_RECOMMENDATION,
+        ):
+            resp = client.post("/recommend/bid", json=_VALID_REQUEST,
+                               headers=auth_headers)
+        assert resp.status_code == 200
+        body = resp.json()
+        assert isinstance(body["recommended_bid"], (int, float)), (
+            f"recommended_bid must be numeric, got {type(body['recommended_bid'])}"
+        )
+
+    def test_confidence_is_float_between_0_and_1(self, client, auth_headers):
+        with patch(
+            "services.bid_recommendation_service.BidRecommendationService.recommend_bid",
+            return_value=_MOCK_RECOMMENDATION,
+        ):
+            resp = client.post("/recommend/bid", json=_VALID_REQUEST,
+                               headers=auth_headers)
+        assert resp.status_code == 200
+        body = resp.json()
+        confidence = body["confidence"]
+        assert isinstance(confidence, float), f"confidence must be float, got {type(confidence)}"
+        assert 0.0 <= confidence <= 1.0, f"confidence must be in [0, 1], got {confidence}"
+
+    def test_no_domain_objects_in_response(self, client, auth_headers):
+        """Response must be JSON-serializable plain data, not domain objects."""
+        with patch(
+            "services.bid_recommendation_service.BidRecommendationService.recommend_bid",
+            return_value=_MOCK_RECOMMENDATION,
+        ):
+            resp = client.post("/recommend/bid", json=_VALID_REQUEST,
+                               headers=auth_headers)
+        assert resp.status_code == 200
+        # If domain objects leaked, serialization would fail → non-200 or error body
+        body = resp.json()
+        assert isinstance(body, dict), "Response must be a plain JSON object"
+
+    def test_optional_sleeper_draft_id(self, client, auth_headers):
+        """sleeper_draft_id is optional — endpoint must accept request without it."""
+        payload = {k: v for k, v in _VALID_REQUEST.items()}
+        payload["sleeper_draft_id"] = "draft_abc123"
+        with patch(
+            "services.bid_recommendation_service.BidRecommendationService.recommend_bid",
+            return_value=_MOCK_RECOMMENDATION,
+        ):
+            resp = client.post("/recommend/bid", json=payload,
+                               headers=auth_headers)
+        assert resp.status_code == 200
+
+
+# ---------------------------------------------------------------------------
+# Scenario 2: Missing required fields → 422
+# ---------------------------------------------------------------------------
+
+class TestBidRecommendationValidation:
+    def test_missing_player_name_returns_422(self, client, auth_headers):
+        payload = {k: v for k, v in _VALID_REQUEST.items() if k != "player_name"}
+        resp = client.post("/recommend/bid", json=payload, headers=auth_headers)
+        assert resp.status_code == 422, f"Expected 422 for missing player_name, got {resp.status_code}"
+
+    def test_missing_current_bid_returns_422(self, client, auth_headers):
+        payload = {k: v for k, v in _VALID_REQUEST.items() if k != "current_bid"}
+        resp = client.post("/recommend/bid", json=payload, headers=auth_headers)
+        assert resp.status_code == 422, f"Expected 422 for missing current_bid, got {resp.status_code}"
+
+    def test_negative_budget_returns_422(self, client, auth_headers):
+        payload = {**_VALID_REQUEST, "team_budget": -50.0}
+        resp = client.post("/recommend/bid", json=payload, headers=auth_headers)
+        assert resp.status_code == 422, f"Expected 422 for negative budget, got {resp.status_code}"
+
+    def test_negative_current_bid_returns_422(self, client, auth_headers):
+        payload = {**_VALID_REQUEST, "current_bid": -1.0}
+        resp = client.post("/recommend/bid", json=payload, headers=auth_headers)
+        assert resp.status_code == 422, f"Expected 422 for negative current_bid, got {resp.status_code}"
+
+    def test_empty_player_name_returns_422(self, client, auth_headers):
+        payload = {**_VALID_REQUEST, "player_name": ""}
+        resp = client.post("/recommend/bid", json=payload, headers=auth_headers)
+        assert resp.status_code == 422, f"Expected 422 for empty player_name, got {resp.status_code}"
+
+    def test_empty_body_returns_422(self, client, auth_headers):
+        resp = client.post("/recommend/bid", json={}, headers=auth_headers)
+        assert resp.status_code == 422, f"Expected 422 for empty body, got {resp.status_code}"
+
+
+# ---------------------------------------------------------------------------
+# Scenario 3: No draft context → 503
+# ---------------------------------------------------------------------------
+
+class TestBidRecommendationServiceUnavailable:
+    def test_service_unavailable_returns_503(self, client, auth_headers):
+        """When BidRecommendationService returns no usable context, respond 503."""
+        with patch(
+            "services.bid_recommendation_service.BidRecommendationService.recommend_bid",
+            return_value={"success": False, "error": "No draft context available"},
+        ):
+            resp = client.post("/recommend/bid", json=_VALID_REQUEST,
+                               headers=auth_headers)
+        assert resp.status_code == 503, (
+            f"Expected 503 when service has no context, got {resp.status_code}"
+        )
+
+    def test_503_has_detail_message(self, client, auth_headers):
+        with patch(
+            "services.bid_recommendation_service.BidRecommendationService.recommend_bid",
+            return_value={"success": False, "error": "No draft context available"},
+        ):
+            resp = client.post("/recommend/bid", json=_VALID_REQUEST,
+                               headers=auth_headers)
+        assert resp.status_code == 503
+        body = resp.json()
+        assert "detail" in body, f"503 response must include 'detail', got: {body}"


### PR DESCRIPTION
## Summary

Implements the `POST /api/v1/recommend/bid` endpoint defined in ADR-002 (issue #179).

## Changes

- `api/schemas/recommend.py`: `BidRecommendationRequest` and `BidRecommendationResponse` Pydantic models with field-level validation (non-negative bids/budgets, min-length player name)
- `api/routers/recommend.py`: `/recommend/bid` route wiring `BidRecommendationService.recommend_bid()` behind the DTO boundary; returns `HTTP 503` when service has no draft context
- `api/main.py`: `recommend.router` registered with auth dependency
- `tests/unit/api/test_recommend_bid.py`: 20 QA Phase 1 regression tests — auth (401/403), route registration, success (200 + all response fields), validation (422), and service-unavailable (503)

## Acceptance Criteria
- [x] Route at `/recommend/bid`
- [x] Uses `BidRecommendationRequest` / `BidRecommendationResponse` schemas
- [x] `response_model` on decorator
- [x] Returns `HTTP 503` when draft context unavailable
- [x] Auth required (tested)
- [x] No domain objects in response (DTO boundary enforced)
- [x] All 20 regression tests pass

Closes #179