### PR TITLE
fix(ci): add explicit GITHUB_TOKEN permissions to all workflow jobs

### DIFF
--- a/.github/workflows/add-to-project.yml
+++ b/.github/workflows/add-to-project.yml
@@ -16,6 +16,7 @@ on:
 jobs:
   add-to-project:
     runs-on: ubuntu-latest
+    permissions: {}
     steps:
       - name: Add issue to project
         id: add-to-project

--- a/.github/workflows/app-ci.yml
+++ b/.github/workflows/app-ci.yml
@@ -32,6 +32,8 @@ jobs:
   lint:
     name: Lint & Static Analysis
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
 
     steps:
       - uses: actions/checkout@v4
@@ -68,6 +70,8 @@ jobs:
     name: Tests & Coverage Gate
     runs-on: ubuntu-latest
     needs: lint
+    permissions:
+      contents: read
 
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,6 +8,8 @@ on:
 jobs:
   test:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
 
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/lab-ci.yml
+++ b/.github/workflows/lab-ci.yml
@@ -42,6 +42,8 @@ jobs:
     runs-on: ubuntu-latest
     # Hard cap: simulation batch must not exceed 60 minutes (ADR-003 / lab-design.md)
     timeout-minutes: 60
+    permissions:
+      contents: read
 
     steps:
       - uses: actions/checkout@v4
@@ -110,6 +112,8 @@ jobs:
     runs-on: ubuntu-latest
     needs: simulate
     if: always() && needs.simulate.result == 'success'
+    permissions:
+      contents: read
 
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -19,6 +19,8 @@ jobs:
   lint:
     name: ruff logic-error gate
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
 
     steps:
       - uses: actions/checkout@v4
@@ -42,6 +44,8 @@ jobs:
   dead-code:
     name: vulture dead-code gate
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
 
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/promotion.yml
+++ b/.github/workflows/promotion.yml
@@ -40,6 +40,8 @@ jobs:
     runs-on: ubuntu-latest
     # Allow 90 min: 500-sim batch + gate evaluation (larger than lab-ci single-run cap)
     timeout-minutes: 90
+    permissions:
+      contents: read
     outputs:
       gate_result: ${{ steps.gate.outputs.gate_result }}
 
@@ -132,6 +134,9 @@ jobs:
     # Only proceeds if gate PASSED and this is not a dry run.
     # NEVER auto-merges — human review is always required (ADR-003 §4).
     if: needs.promotion-gate.outputs.gate_result == 'PASS' && !inputs.dry_run
+    permissions:
+      contents: write
+      pull-requests: write
 
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -25,6 +25,8 @@ jobs:
   release-gates:
     name: Verify Release Gates
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
 
     steps:
       - uses: actions/checkout@v4
@@ -59,6 +61,8 @@ jobs:
     name: Build Distribution
     needs: release-gates
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
 
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
## Summary

Resolves all 11 open GitHub Advanced Security (GHAS) code-scanning alerts flagged as `actions/missing-workflow-permissions`. Every workflow job that lacked an explicit `permissions:` block now declares the minimal token scope it actually requires, following the principle of least privilege.

## Type of Change

- [x] Bug fix (`fix/`)

## Changes

| Workflow | Job | Permissions added |
|---|---|---|
| `ci.yml` | `test` | `contents: read` |
| `app-ci.yml` | `lint` | `contents: read` |
| `app-ci.yml` | `test` | `contents: read` |
| `lab-ci.yml` | `simulate` | `contents: read` |
| `lab-ci.yml` | `benchmark` | `contents: read` |
| `lint.yml` | `lint` | `contents: read` |
| `lint.yml` | `dead-code` | `contents: read` |
| `release.yml` | `release-gates` | `contents: read` |
| `release.yml` | `build` | `contents: read` |
| `add-to-project.yml` | `add-to-project` | `{}` (uses PAT; GITHUB_TOKEN unused) |
| `promotion.yml` | `promotion-gate` | `contents: read` |
| `promotion.yml` | `create-promotion-pr` | `contents: write` + `pull-requests: write` |

The `create-release` job in `release.yml` already had `permissions: contents: write` and was not changed.

## Testing

- [x] No logic changes — workflow behaviour is identical; only token scope is restricted
- [x] Each job granted only the minimum GITHUB_TOKEN permissions needed