### PR TITLE
test(property): Track F — core domain property tests (#327, #328, #329, #330)

### DIFF
--- a/tests/property/test_auction_class_properties.py
+++ b/tests/property/test_auction_class_properties.py
@@ -1,0 +1,199 @@
+"""Property-based tests: Auction class — Vickrey pricing and sealed-bid invariants.
+
+Track F — Issue #329
+
+Sprint 10 · sprint/10 branch
+"""
+
+from __future__ import annotations
+
+from hypothesis import assume, given, settings
+from hypothesis import strategies as st
+
+from classes.auction import Auction
+from classes.draft import Draft
+from classes.player import Player
+from classes.team import Team
+from classes.owner import Owner
+from tests.property.conftest import draft_player
+
+
+# ---------------------------------------------------------------------------
+# Helper: build a started draft + Auction
+# ---------------------------------------------------------------------------
+
+def _make_auction(n_teams: int = 3, budget: int = 200, n_players: int = 30) -> Auction:
+    draft = Draft(name="test", budget_per_team=budget, roster_size=6, num_teams=n_teams)
+    for i in range(n_teams):
+        team = Team(f"team{i}", f"owner{i}", f"Team{i}", budget=budget)
+        owner = Owner(f"owner{i}", f"Owner{i}")
+        draft.add_team(team, owner)
+    players = [
+        Player(f"p{j}", f"Player{j}", ["QB", "RB", "WR", "TE"][j % 4], "NFL",
+               auction_value=float(j % 50))
+        for j in range(n_players)
+    ]
+    draft.add_players(players)
+    draft.start_draft()
+    return Auction(draft=draft)
+
+
+# ---------------------------------------------------------------------------
+# Property 1 — Vickrey: winner pays second-highest + 1 (single winner case)
+# ---------------------------------------------------------------------------
+
+@given(
+    bids=st.dictionaries(
+        keys=st.text(min_size=1, max_size=8),
+        values=st.floats(min_value=1.0, max_value=500.0, allow_nan=False, allow_infinity=False),
+        min_size=2,
+        max_size=6,
+    )
+)
+@settings(max_examples=100)
+def test_vickrey_price_second_highest_plus_one(bids):
+    """When there is a clear single top bidder, winner pays 2nd-highest + 1."""
+    auction = _make_auction()
+    sorted_vals = sorted(bids.values(), reverse=True)
+    assume(sorted_vals[0] != sorted_vals[1])  # no tie at the top
+
+    winner_id, price = auction._determine_auction_winner(bids)
+
+    # Winner must have submitted the top bid
+    assert bids[winner_id] == sorted_vals[0]
+    # Price must equal second-highest + 1
+    assert abs(price - (sorted_vals[1] + 1.0)) < 1e-9
+
+
+# ---------------------------------------------------------------------------
+# Property 2 — Vickrey: single bidder pays their own bid
+# ---------------------------------------------------------------------------
+
+@given(
+    team_id=st.text(min_size=1, max_size=8),
+    bid=st.floats(min_value=1.0, max_value=500.0, allow_nan=False, allow_infinity=False),
+)
+@settings(max_examples=50)
+def test_vickrey_single_bidder_pays_own_bid(team_id, bid):
+    """When only one team bids, they win and pay their own bid."""
+    auction = _make_auction()
+    winner_id, price = auction._determine_auction_winner({team_id: bid})
+
+    assert winner_id == team_id
+    assert abs(price - bid) < 1e-9
+
+
+# ---------------------------------------------------------------------------
+# Property 3 — empty bids returns no winner
+# ---------------------------------------------------------------------------
+
+@given(st.just(None))
+@settings(max_examples=10)
+def test_no_bids_returns_no_winner(_):
+    """_determine_auction_winner({}) returns (None, 0.0)."""
+    auction = _make_auction()
+    winner_id, price = auction._determine_auction_winner({})
+    assert winner_id is None
+    assert price == 0.0
+
+
+# ---------------------------------------------------------------------------
+# Property 4 — tie-breaking: winner is one of the tied teams
+# ---------------------------------------------------------------------------
+
+@given(
+    tied_ids=st.lists(
+        st.text(min_size=1, max_size=8),
+        min_size=2, max_size=5, unique=True
+    ),
+    tied_bid=st.floats(min_value=1.0, max_value=500.0, allow_nan=False, allow_infinity=False),
+)
+@settings(max_examples=50)
+def test_tie_winner_belongs_to_tied_set(tied_ids, tied_bid):
+    """When multiple teams share the top bid, the winner is one of them."""
+    auction = _make_auction()
+    bids = {tid: tied_bid for tid in tied_ids}
+    winner_id, _ = auction._determine_auction_winner(bids)
+    assert winner_id in tied_ids
+
+
+# ---------------------------------------------------------------------------
+# Property 5 — team receives player only if budget allows
+# ---------------------------------------------------------------------------
+
+@given(
+    player=draft_player(),
+    budget=st.integers(min_value=1, max_value=200),
+    price=st.integers(min_value=1, max_value=300),
+)
+@settings(max_examples=50)
+def test_award_player_respects_budget(player, budget, price):
+    """_award_player_to_team only adds player to team when price ≤ budget."""
+    auction = _make_auction(budget=budget)
+    team = auction.draft.teams[0]
+    # Reset budget to the drawn value
+    team.budget = budget
+    team.initial_budget = budget
+    team.roster_config = {player.position: 5}
+    team.position_limits = {player.position: 5}
+
+    # Ensure player is in available list
+    if player not in auction.draft.available_players:
+        auction.draft.available_players.append(player)
+
+    before_roster = len(team.roster)
+    auction._award_player_to_team(player, team.owner_id, float(price))
+
+    if price <= budget:
+        # Player should be on roster
+        assert len(team.roster) == before_roster + 1
+    else:
+        # Budget exceeded — no change
+        assert len(team.roster) == before_roster
+
+
+# ---------------------------------------------------------------------------
+# Property 6 — player moves from available to drafted after nominate_player
+# ---------------------------------------------------------------------------
+
+@given(st.just(None))
+@settings(max_examples=20, deadline=None)
+def test_nominate_player_removes_from_available(_):
+    """nominate_player() removes the player from draft.available_players."""
+    auction = _make_auction(n_teams=2, budget=200, n_players=10)
+    player = auction.draft.available_players[0]
+    before = len(auction.draft.available_players)
+
+    auction.nominate_player(player, "owner0", initial_bid=1.0)
+
+    assert player not in auction.draft.available_players
+    assert len(auction.draft.available_players) == before - 1
+    assert player in auction.draft.drafted_players
+
+
+# ---------------------------------------------------------------------------
+# Property 7 — on_auction_completed fires exactly once per nominate_player
+# ---------------------------------------------------------------------------
+
+@given(st.just(None))
+@settings(max_examples=20, deadline=None)
+def test_auction_completed_callback_fires_once(_):
+    """on_auction_completed callback fires exactly once per nomination.
+
+    Teams need a calculate_bid method so _collect_sealed_bids returns bids;
+    without bids the winner is None and _award_player_to_team (which fires
+    the callback) is never reached.
+    """
+    auction = _make_auction(n_teams=2, budget=200, n_players=10)
+
+    # Give every team a callable bid so bids are collected
+    for team in auction.draft.teams:
+        team.calculate_bid = lambda **kwargs: 10.0  # noqa: E731
+
+    calls = []
+    auction.on_auction_completed.append(lambda p, t, price: calls.append(1))
+
+    player = auction.draft.available_players[0]
+    auction.nominate_player(player, "owner0", initial_bid=1.0)
+
+    assert len(calls) == 1

--- a/tests/property/test_draft_properties.py
+++ b/tests/property/test_draft_properties.py
@@ -1,0 +1,204 @@
+"""Property-based tests: Draft class state machine and auction invariants.
+
+Track F — Issue #328
+
+Sprint 10 · sprint/10 branch
+"""
+
+from __future__ import annotations
+
+from hypothesis import assume, given, settings
+from hypothesis import strategies as st
+
+from classes.draft import Draft
+from classes.player import Player
+from classes.team import Team
+from classes.owner import Owner
+
+
+# ---------------------------------------------------------------------------
+# Helper: build a minimal 2-team draft with players ready to start
+# ---------------------------------------------------------------------------
+
+def _make_started_draft(n_players: int = 20) -> Draft:
+    """Return a started 2-team draft pre-loaded with n_players."""
+    draft = Draft(name="test", budget_per_team=200.0, roster_size=6, num_teams=2)
+    for i in range(2):
+        team = Team(f"team{i}", f"owner{i}", f"Team {i}", budget=200)
+        owner = Owner(f"owner{i}", f"Owner {i}")
+        draft.add_team(team, owner)
+    players = [
+        Player(f"p{j}", f"Player {j}", ["QB", "RB", "WR", "TE"][j % 4], "NFL")
+        for j in range(n_players)
+    ]
+    draft.add_players(players)
+    draft.start_draft()
+    return draft
+
+
+# ---------------------------------------------------------------------------
+# Property 1 — state machine: only valid transitions
+# ---------------------------------------------------------------------------
+
+@given(st.just(None))
+@settings(max_examples=10)
+def test_draft_starts_in_created_status(_):
+    """A freshly constructed Draft is always in 'created' status."""
+    draft = Draft()
+    assert draft.status == "created"
+
+
+@given(st.just(None))
+@settings(max_examples=10)
+def test_start_draft_transitions_to_started(_):
+    """start_draft() moves status from 'created' to 'started'."""
+    draft = Draft(num_teams=2, budget_per_team=100, roster_size=4)
+    for i in range(2):
+        team = Team(f"t{i}", f"o{i}", f"Team{i}", budget=100)
+        owner = Owner(f"o{i}", f"Owner{i}")
+        draft.add_team(team, owner)
+    players = [Player(f"p{j}", f"P{j}", "RB", "NFL") for j in range(12)]
+    draft.add_players(players)
+    draft.start_draft()
+    assert draft.status == "started"
+
+
+@given(st.just(None))
+@settings(max_examples=10)
+def test_status_cannot_go_backwards(_):
+    """Once 'started', calling start_draft() again raises ValueError."""
+    draft = _make_started_draft()
+    try:
+        draft.start_draft()
+        assert False, "Expected ValueError"
+    except ValueError:
+        pass  # correct
+    assert draft.status in ("started", "paused", "completed")
+
+
+# ---------------------------------------------------------------------------
+# Property 2 — nominator rotation is cyclic
+# ---------------------------------------------------------------------------
+
+@given(n_advances=st.integers(min_value=1, max_value=50))
+@settings(max_examples=50)
+def test_nominator_rotation_is_cyclic(n_advances):
+    """After num_teams advances the index returns to its starting value."""
+    draft = _make_started_draft()
+    num_teams = len(draft.teams)
+    start_index = draft.current_nominator_index
+
+    for _ in range(num_teams * n_advances):
+        draft._advance_nominator()
+
+    assert draft.current_nominator_index == start_index
+
+
+@given(n_advances=st.integers(min_value=0, max_value=100))
+@settings(max_examples=50)
+def test_nominator_index_always_valid(n_advances):
+    """current_nominator_index is always in [0, len(teams) - 1]."""
+    draft = _make_started_draft()
+    for _ in range(n_advances):
+        draft._advance_nominator()
+
+    assert 0 <= draft.current_nominator_index < len(draft.teams)
+
+
+# ---------------------------------------------------------------------------
+# Property 3 — bid monotonicity
+# ---------------------------------------------------------------------------
+
+@given(
+    first_bid=st.floats(min_value=1.0, max_value=50.0, allow_nan=False, allow_infinity=False),
+    low_bid_delta=st.floats(min_value=0.0, max_value=50.0, allow_nan=False, allow_infinity=False),
+)
+@settings(max_examples=50)
+def test_place_bid_rejects_non_increasing(first_bid, low_bid_delta):
+    """place_bid returns False if bid_amount <= current_bid."""
+    draft = _make_started_draft()
+    player = draft.available_players[0]
+    draft.nominate_player(player, "owner0", initial_bid=first_bid)
+
+    low_bid = first_bid - low_bid_delta  # always ≤ current bid
+    result = draft.place_bid("owner1", low_bid)
+    assert result is False
+
+
+@given(
+    first_bid=st.floats(min_value=1.0, max_value=100.0, allow_nan=False, allow_infinity=False),
+    increment=st.floats(min_value=0.01, max_value=50.0, allow_nan=False, allow_infinity=False),
+)
+@settings(max_examples=50)
+def test_place_bid_accepts_higher(first_bid, increment):
+    """place_bid returns True when bid_amount > current_bid and team has budget."""
+    assume(first_bid + increment <= 200.0)
+    draft = _make_started_draft()
+    player = draft.available_players[0]
+    draft.nominate_player(player, "owner0", initial_bid=first_bid)
+
+    result = draft.place_bid("owner1", first_bid + increment)
+    assert result is True
+    assert draft.current_bid == first_bid + increment
+
+
+# ---------------------------------------------------------------------------
+# Property 4 — auction resolution moves player between pools
+# ---------------------------------------------------------------------------
+
+@given(st.just(None))
+@settings(max_examples=20)
+def test_complete_auction_moves_player(_):
+    """complete_auction() removes player from available and adds to drafted."""
+    draft = _make_started_draft()
+    player = draft.available_players[0]
+    before_available = len(draft.available_players)
+    before_drafted = len(draft.drafted_players)
+
+    draft.nominate_player(player, "owner0", initial_bid=1.0)
+    draft.place_bid("owner1", 2.0)
+    draft.complete_auction()
+
+    # Player moved pools (or auction was voided — either way it left available)
+    assert len(draft.available_players) == before_available - 1
+    assert len(draft.drafted_players) == before_drafted + 1
+
+
+# ---------------------------------------------------------------------------
+# Property 5 — team count never exceeds num_teams cap
+# ---------------------------------------------------------------------------
+
+@given(extra=st.integers(min_value=1, max_value=10))
+@settings(max_examples=50)
+def test_team_count_capped(extra):
+    """Adding more than num_teams teams raises ValueError."""
+    num_teams = 2
+    draft = Draft(num_teams=num_teams, budget_per_team=100, roster_size=4)
+    for i in range(num_teams):
+        draft.add_team(Team(f"t{i}", f"o{i}", f"Team{i}", budget=100))
+
+    for i in range(extra):
+        try:
+            draft.add_team(Team(f"extra{i}", f"eo{i}", f"Extra{i}", budget=100))
+            assert False, "Expected ValueError"
+        except ValueError:
+            pass
+
+    assert len(draft.teams) == num_teams
+
+
+# ---------------------------------------------------------------------------
+# Property 6 — get_leaderboard returns all teams sorted descending
+# ---------------------------------------------------------------------------
+
+@given(st.just(None))
+@settings(max_examples=20)
+def test_leaderboard_ordering(_):
+    """get_leaderboard() returns team dicts in descending projected_points order."""
+    draft = _make_started_draft()
+    leaderboard = draft.get_leaderboard()  # returns List[Dict]
+    assert len(leaderboard) == len(draft.teams)
+    for i in range(len(leaderboard) - 1):
+        pts_a = leaderboard[i]["projected_points"]
+        pts_b = leaderboard[i + 1]["projected_points"]
+        assert pts_a >= pts_b

--- a/tests/property/test_draft_setup_properties.py
+++ b/tests/property/test_draft_setup_properties.py
@@ -1,0 +1,168 @@
+"""Property-based tests: DraftSetup — bidirectionality and participant invariants.
+
+Track F — Issue #330
+
+Sprint 10 · sprint/10 branch
+"""
+
+from __future__ import annotations
+
+from hypothesis import given, settings
+from hypothesis import strategies as st
+
+from classes.draft_setup import DraftSetup
+from tests.property.conftest import _ALPHANUM, _LETTERS_SPACE
+
+
+# ---------------------------------------------------------------------------
+# Composite strategy for participant dicts
+# ---------------------------------------------------------------------------
+
+@st.composite
+def participant_dict(draw, owner_id: str | None = None) -> dict:
+    oid = owner_id or draw(st.text(min_size=1, max_size=16, alphabet=_ALPHANUM))
+    name = draw(
+        st.text(min_size=1, max_size=40, alphabet=_LETTERS_SPACE).filter(
+            lambda n: n.strip() != ""
+        )
+    )
+    team_name = draw(
+        st.text(min_size=1, max_size=40, alphabet=_LETTERS_SPACE).filter(
+            lambda n: n.strip() != ""
+        )
+    )
+    return {"owner_id": oid, "owner_name": name, "team_name": team_name}
+
+
+@st.composite
+def participant_list(draw, min_size: int = 2, max_size: int = 8) -> list[dict]:
+    n = draw(st.integers(min_value=min_size, max_value=max_size))
+    ids = draw(
+        st.lists(
+            st.text(min_size=1, max_size=16, alphabet=_ALPHANUM),
+            min_size=n,
+            max_size=n,
+            unique=True,
+        )
+    )
+    parts = []
+    for oid in ids:
+        parts.append(draw(participant_dict(owner_id=oid)))
+    return parts
+
+
+# ---------------------------------------------------------------------------
+# Property 1 — create_owner_with_team establishes bidirectionality
+# ---------------------------------------------------------------------------
+
+@given(
+    owner_id=st.text(min_size=1, max_size=16, alphabet=_ALPHANUM),
+    budget=st.floats(min_value=10.0, max_value=500.0, allow_nan=False, allow_infinity=False),
+)
+@settings(max_examples=50)
+def test_create_owner_with_team_bidirectionality(owner_id, budget):
+    """After create_owner_with_team, owner.get_team() is the created team."""
+    owner, team = DraftSetup.create_owner_with_team(
+        owner_id=owner_id,
+        owner_name="Test Owner",
+        team_name="Test Team",
+        budget=budget,
+    )
+
+    assert owner.get_team() is team
+    assert owner.has_team() is True
+    assert team.owner_id == owner.owner_id
+
+
+# ---------------------------------------------------------------------------
+# Property 2 — all teams initialized with the given budget
+# ---------------------------------------------------------------------------
+
+@given(
+    n_participants=st.integers(min_value=2, max_value=8),
+    budget=st.integers(min_value=10, max_value=500),
+)
+@settings(max_examples=50)
+def test_all_teams_get_same_budget(n_participants, budget):
+    """Every team in the returned draft has budget == budget_per_team.
+
+    Team.budget is stored as int, so we use integer budgets here to
+    avoid implicit truncation masking the actual budget value.
+    """
+    participants = [
+        {"owner_id": f"o{i}", "owner_name": f"Owner {i}", "team_name": f"Team {i}"}
+        for i in range(n_participants)
+    ]
+    draft = DraftSetup.setup_draft_with_participants(
+        draft_name="test",
+        participants=participants,
+        budget_per_team=float(budget),
+    )
+
+    for team in draft.teams:
+        assert team.budget == budget
+        assert team.initial_budget == budget
+
+
+# ---------------------------------------------------------------------------
+# Property 3 — no duplicate owner_ids in the returned draft
+# ---------------------------------------------------------------------------
+
+@given(n_participants=st.integers(min_value=2, max_value=10))
+@settings(max_examples=50)
+def test_no_duplicate_owner_ids(n_participants):
+    """setup_draft_with_participants never produces duplicate owner_ids."""
+    participants = [
+        {"owner_id": f"owner_{i}", "owner_name": f"Name {i}", "team_name": f"Team {i}"}
+        for i in range(n_participants)
+    ]
+    draft = DraftSetup.setup_draft_with_participants(
+        draft_name="test",
+        participants=participants,
+    )
+
+    owner_ids = [o.owner_id for o in draft.owners]
+    assert len(owner_ids) == len(set(owner_ids))
+
+
+# ---------------------------------------------------------------------------
+# Property 4 — owner_id matches between owner and team for every participant
+# ---------------------------------------------------------------------------
+
+@given(n_participants=st.integers(min_value=2, max_value=8))
+@settings(max_examples=50)
+def test_owner_team_id_consistency(n_participants):
+    """For every owner in the draft, the linked team has matching owner_id."""
+    participants = [
+        {"owner_id": f"owner_{i}", "owner_name": f"Name {i}", "team_name": f"Team {i}"}
+        for i in range(n_participants)
+    ]
+    draft = DraftSetup.setup_draft_with_participants(
+        draft_name="test",
+        participants=participants,
+    )
+
+    for owner in draft.owners:
+        if owner.has_team():
+            assert owner.get_team().owner_id == owner.owner_id
+
+
+# ---------------------------------------------------------------------------
+# Property 5 — budget preserved through create_owner_with_team round-trip
+# ---------------------------------------------------------------------------
+
+@given(
+    owner_id=st.text(min_size=1, max_size=16, alphabet=_ALPHANUM),
+    budget=st.integers(min_value=10, max_value=1000),
+)
+@settings(max_examples=50)
+def test_budget_preserved(owner_id, budget):
+    """The team returned by create_owner_with_team has budget == supplied budget."""
+    owner, team = DraftSetup.create_owner_with_team(
+        owner_id=owner_id,
+        owner_name="Owner",
+        team_name="Team",
+        budget=float(budget),
+    )
+    assert team.budget == float(budget)
+    assert team.initial_budget == float(budget)

--- a/tests/property/test_owner_properties.py
+++ b/tests/property/test_owner_properties.py
@@ -1,0 +1,143 @@
+"""Property-based tests: Owner class invariants.
+
+Track F — Issue #327
+
+Sprint 10 · sprint/10 branch
+"""
+
+from __future__ import annotations
+
+from hypothesis import given, settings
+from hypothesis import strategies as st
+
+from classes.owner import Owner
+from tests.property.conftest import draft_team, _ALPHANUM, _LETTERS_SPACE
+
+
+# ---------------------------------------------------------------------------
+# Composite strategy for Owner instances
+# ---------------------------------------------------------------------------
+
+@st.composite
+def draft_owner(draw, owner_id: str | None = None) -> Owner:
+    """Generate a valid Owner with a random id and name."""
+    oid = owner_id or draw(st.text(min_size=1, max_size=20, alphabet=_ALPHANUM))
+    name = draw(
+        st.text(min_size=1, max_size=40, alphabet=_LETTERS_SPACE).filter(
+            lambda n: n.strip() != ""
+        )
+    )
+    return Owner(owner_id=oid, name=name)
+
+
+# ---------------------------------------------------------------------------
+# Property 1 — target player deduplication
+# ---------------------------------------------------------------------------
+
+@given(owner=draft_owner(), player_id=st.text(min_size=1, max_size=20, alphabet=_ALPHANUM))
+@settings(max_examples=50)
+def test_add_target_player_deduplication(owner, player_id):
+    """Adding the same player_id twice yields exactly one entry in target_players."""
+    owner.add_target_player(player_id)
+    owner.add_target_player(player_id)
+
+    targets = owner.preferences["target_players"]
+    assert targets.count(player_id) == 1
+
+
+# ---------------------------------------------------------------------------
+# Property 2 — avoid player deduplication
+# ---------------------------------------------------------------------------
+
+@given(owner=draft_owner(), player_id=st.text(min_size=1, max_size=20, alphabet=_ALPHANUM))
+@settings(max_examples=50)
+def test_add_avoid_player_deduplication(owner, player_id):
+    """Adding the same player_id twice yields exactly one entry in avoid_players."""
+    owner.add_avoid_player(player_id)
+    owner.add_avoid_player(player_id)
+
+    avoids = owner.preferences["avoid_players"]
+    assert avoids.count(player_id) == 1
+
+
+# ---------------------------------------------------------------------------
+# Property 3 — risk tolerance bounds
+# ---------------------------------------------------------------------------
+
+@given(
+    owner=draft_owner(),
+    risk=st.floats(min_value=0.0, max_value=1.0, allow_nan=False, allow_infinity=False),
+)
+@settings(max_examples=50)
+def test_risk_tolerance_bounds(owner, risk):
+    """get_risk_tolerance() always returns a value in [0.0, 1.0] after update."""
+    owner.update_preferences(risk_tolerance=risk)
+    result = owner.get_risk_tolerance()
+    assert 0.0 <= result <= 1.0
+
+
+# ---------------------------------------------------------------------------
+# Property 4 — draft history append-only
+# ---------------------------------------------------------------------------
+
+@given(
+    owner=draft_owner(),
+    n_actions=st.integers(min_value=1, max_value=20),
+)
+@settings(max_examples=50)
+def test_draft_history_append_only(owner, n_actions):
+    """Each add_draft_action() appends exactly one entry; history never shrinks."""
+    for i in range(n_actions):
+        before = len(owner.draft_history)
+        owner.add_draft_action({"action": "bid", "round": i})
+        assert len(owner.draft_history) == before + 1
+
+
+# ---------------------------------------------------------------------------
+# Property 5 — owner↔team bidirectionality
+# ---------------------------------------------------------------------------
+
+@given(owner=draft_owner(), team=draft_team())
+@settings(max_examples=50)
+def test_assign_team_bidirectionality(owner, team):
+    """After assign_team(t), owner.get_team() is t."""
+    owner.assign_team(team)
+
+    assert owner.get_team() is team
+    assert owner.has_team() is True
+
+
+# ---------------------------------------------------------------------------
+# Property 6 — preference persistence across multiple reads
+# ---------------------------------------------------------------------------
+
+@given(
+    owner=draft_owner(),
+    max_bid_pct=st.floats(min_value=0.0, max_value=1.0, allow_nan=False, allow_infinity=False),
+    n_reads=st.integers(min_value=2, max_value=10),
+)
+@settings(max_examples=50)
+def test_preference_persistence(owner, max_bid_pct, n_reads):
+    """update_preferences(max_bid_percentage=v) survives multiple reads."""
+    owner.update_preferences(max_bid_percentage=max_bid_pct)
+    for _ in range(n_reads):
+        assert owner.get_max_bid_percentage() == max_bid_pct
+
+
+# ---------------------------------------------------------------------------
+# Property 7 — target/avoid lists are mutually independent
+# ---------------------------------------------------------------------------
+
+@given(
+    owner=draft_owner(),
+    player_id=st.text(min_size=1, max_size=20, alphabet=_ALPHANUM),
+)
+@settings(max_examples=50)
+def test_target_avoid_independence(owner, player_id):
+    """Adding a player to targets does not add them to avoids, and vice versa."""
+    owner.add_target_player(player_id)
+    assert not owner.is_avoid_player(player_id)
+
+    owner2 = Owner(owner_id="o2", name="Other")
+    owner2.add_avoid_player(player_id)
+    assert not owner2.is_target_player(player_id)


### PR DESCRIPTION
## Summary

Implements P1 Sprint 10 Hypothesis property tests for the four core domain classes that previously had zero property-based coverage.

## New Test Files

| File | Issue | Tests |
|---|---|---|
| `tests/property/test_owner_properties.py` | #327 | 7 (deduplication, bounds, append-only, bidirectionality, persistence, independence) |
| `tests/property/test_draft_properties.py` | #328 | 10 (status transitions, rotation invariants, bid validation, leaderboard ordering) |
| `tests/property/test_auction_class_properties.py` | #329 | 7 (Vickrey pricing, tie-breaking, no-bid path, callback correctness) |
| `tests/property/test_draft_setup_properties.py` | #330 | 5 (bidirectionality, budget uniformity, id uniqueness, round-trip preservation) |

**29 tests total — all pass under the `ci` Hypothesis profile.**

## Issues Closed
- Closes #327
- Closes #328
- Closes #329
- Closes #330