### PR TITLE
fix(security): encode API keys to UTF-8 before compare_digest (#350)

### DIFF
--- a/api/deps.py
+++ b/api/deps.py
@@ -27,7 +27,17 @@ def require_api_key(
             headers={"WWW-Authenticate": "ApiKey"},
         )
     configured_key = settings.api_key
-    if not configured_key or not secrets.compare_digest(api_key, configured_key):
+    try:
+        keys_match = bool(
+            configured_key
+            and secrets.compare_digest(
+                api_key.encode("utf-8"), configured_key.encode("utf-8")
+            )
+        )
+    except (UnicodeEncodeError, TypeError):
+        # Non-encodable or incompatible types — treat as invalid key (403)
+        keys_match = False
+    if not keys_match:
         raise HTTPException(
             status_code=status.HTTP_403_FORBIDDEN,
             detail="Invalid API key",

--- a/tests/property/test_api_deps_properties.py
+++ b/tests/property/test_api_deps_properties.py
@@ -21,12 +21,17 @@ from config.settings import Settings
 # Helpers
 # ---------------------------------------------------------------------------
 
-# secrets.compare_digest requires ASCII-only strings; restrict to printable ASCII.
+# Now that api/deps.py encodes to UTF-8 before compare_digest, we can test
+# arbitrary unicode including non-ASCII inputs.  API keys should be printable
+# ASCII in practice, but the code must not crash on anything else.
 _ASCII_TEXT = st.text(
     alphabet=st.characters(min_codepoint=0x21, max_codepoint=0x7E),  # printable ASCII (no space)
     min_size=1,
     max_size=64,
 )
+
+# Any non-empty text (including unicode) must never crash — worst case 403.
+_ANY_TEXT = st.text(min_size=1, max_size=64)
 
 
 def _settings(api_key: str) -> Settings:
@@ -102,3 +107,26 @@ def test_wrong_key_never_raises_401(api_key, configured_key):
         assert exc.status_code != 401, (
             f"Expected 403 for wrong key, got 401. api_key={api_key!r}"
         )
+
+
+# ---------------------------------------------------------------------------
+# Non-ASCII robustness invariants (regression for #350)
+# ---------------------------------------------------------------------------
+
+@given(
+    api_key=_ANY_TEXT,
+    configured_key=_ASCII_TEXT,
+)
+@settings(max_examples=50)
+def test_non_ascii_key_never_crashes(api_key, configured_key):
+    """Any non-empty api_key (including unicode) must never raise a 500-level error.
+
+    It must either pass silently (matching key) or raise HTTP 401/403.
+    A TypeError / UnicodeEncodeError must never propagate — regression for #350.
+    """
+    try:
+        _call(api_key=api_key, configured_key=configured_key)
+        # If it didn't raise, key must exactly match
+        assert api_key == configured_key
+    except HTTPException as exc:
+        assert exc.status_code in (401, 403)


### PR DESCRIPTION
## Security Fix — Issue #350

### Problem
`secrets.compare_digest(str, str)` raises `TypeError` in Python 3.12 when either string contains non-ASCII characters. Any non-ASCII `X-API-Key` header caused a **500 Internal Server Error** (with potential stack trace leakage) instead of a clean 403 Forbidden.

This was discovered by Hypothesis property testing during Sprint 10 (Track H).

### Fix
Encode both operands with `.encode('utf-8')` before calling `compare_digest`. Catch `UnicodeEncodeError` and `TypeError` as a 403 (treat as invalid key, never crash).

### Regression Guard
Added `test_non_ascii_key_never_crashes` to `tests/property/test_api_deps_properties.py` — a permanent Hypothesis property test covering arbitrary unicode inputs.

### Closes
closes #350

### CI
Pre-push gate: ruff ✓ · mypy ✓ · bandit ✓ · pytest 95.21% coverage ✓