### PR TITLE
Develop

### DIFF
--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -110,7 +110,8 @@ echo "[4/4] Unit tests + coverage gate (≥ 85%)..."
 "$PYTEST" tests/ -x -q --timeout=60 \
   --cov=. --cov-fail-under=85 \
   --cov-report=term-missing \
-  --ignore=tests/test_integration.py
+  --ignore=tests/test_integration.py \
+  --ignore=tests/property
 echo "      ✓ tests passed"
 echo ""
 

--- a/.github/workflows/add-to-project.yml
+++ b/.github/workflows/add-to-project.yml
@@ -16,6 +16,7 @@ on:
 jobs:
   add-to-project:
     runs-on: ubuntu-latest
+    permissions: {}
     steps:
       - name: Add issue to project
         id: add-to-project

--- a/.github/workflows/app-ci.yml
+++ b/.github/workflows/app-ci.yml
@@ -92,6 +92,7 @@ jobs:
       - name: Unit tests + coverage gate (≥ 90%)
         run: |
           pytest tests/ -x -q --timeout=60 \
+            --ignore=tests/property \
             --cov=. --cov-fail-under=90 \
             --cov-report=xml
 

--- a/.github/workflows/app-ci.yml
+++ b/.github/workflows/app-ci.yml
@@ -32,6 +32,8 @@ jobs:
   lint:
     name: Lint & Static Analysis
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
 
     steps:
       - uses: actions/checkout@v4
@@ -68,6 +70,8 @@ jobs:
     name: Tests & Coverage Gate
     runs-on: ubuntu-latest
     needs: lint
+    permissions:
+      contents: read
 
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,7 +41,7 @@ jobs:
         run: bandit -r . -ll --exclude ./venv,./.venv,./tests,./pigskin_auction_draft.egg-info
 
       - name: Run unit tests with coverage
-        run: pytest tests/ -x -q --timeout=60 --cov=. --cov-fail-under=90 --cov-report=xml
+        run: pytest tests/ -x -q --timeout=60 --cov=. --cov-fail-under=90 --cov-report=xml --ignore=tests/property
 
       - name: Upload coverage report
         uses: actions/upload-artifact@v4
@@ -52,3 +52,40 @@ jobs:
 
       - name: Run integration tests
         run: pytest tests/test_integration.py -v --timeout=120
+
+  property-tests:
+    runs-on: ubuntu-latest
+    # Stubs are intentionally failing until Dev implements each track (Sprint 10).
+    # Remove continue-on-error once all NotImplementedError stubs are replaced.
+    continue-on-error: true
+    permissions:
+      contents: read
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Python 3.11
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+
+      - name: Install uv
+        run: pip install uv
+
+      - name: Install dependencies
+        run: |
+          uv sync --frozen
+          echo "$PWD/.venv/bin" >> $GITHUB_PATH
+
+      - name: Cache Hypothesis database
+        uses: actions/cache@v4
+        with:
+          path: .hypothesis
+          key: hypothesis-${{ hashFiles('requirements-dev.txt') }}
+          restore-keys: |
+            hypothesis-
+
+      - name: Run property tests
+        env:
+          HYPOTHESIS_PROFILE: ci
+        run: pytest tests/property/ -v --timeout=300

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,6 +8,8 @@ on:
 jobs:
   test:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
 
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/lab-ci.yml
+++ b/.github/workflows/lab-ci.yml
@@ -42,6 +42,8 @@ jobs:
     runs-on: ubuntu-latest
     # Hard cap: simulation batch must not exceed 60 minutes (ADR-003 / lab-design.md)
     timeout-minutes: 60
+    permissions:
+      contents: read
 
     steps:
       - uses: actions/checkout@v4
@@ -110,6 +112,8 @@ jobs:
     runs-on: ubuntu-latest
     needs: simulate
     if: always() && needs.simulate.result == 'success'
+    permissions:
+      contents: read
 
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -19,6 +19,8 @@ jobs:
   lint:
     name: ruff logic-error gate
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
 
     steps:
       - uses: actions/checkout@v4
@@ -42,6 +44,8 @@ jobs:
   dead-code:
     name: vulture dead-code gate
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
 
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/promotion.yml
+++ b/.github/workflows/promotion.yml
@@ -40,6 +40,8 @@ jobs:
     runs-on: ubuntu-latest
     # Allow 90 min: 500-sim batch + gate evaluation (larger than lab-ci single-run cap)
     timeout-minutes: 90
+    permissions:
+      contents: read
     outputs:
       gate_result: ${{ steps.gate.outputs.gate_result }}
 
@@ -132,6 +134,9 @@ jobs:
     # Only proceeds if gate PASSED and this is not a dry run.
     # NEVER auto-merges — human review is always required (ADR-003 §4).
     if: needs.promotion-gate.outputs.gate_result == 'PASS' && !inputs.dry_run
+    permissions:
+      contents: write
+      pull-requests: write
 
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -25,6 +25,8 @@ jobs:
   release-gates:
     name: Verify Release Gates
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
 
     steps:
       - uses: actions/checkout@v4
@@ -59,6 +61,8 @@ jobs:
     name: Build Distribution
     needs: release-gates
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
 
     steps:
       - uses: actions/checkout@v4

--- a/api/deps.py
+++ b/api/deps.py
@@ -27,7 +27,17 @@ def require_api_key(
             headers={"WWW-Authenticate": "ApiKey"},
         )
     configured_key = settings.api_key
-    if not configured_key or not secrets.compare_digest(api_key, configured_key):
+    try:
+        keys_match = bool(
+            configured_key
+            and secrets.compare_digest(
+                api_key.encode("utf-8"), configured_key.encode("utf-8")
+            )
+        )
+    except (UnicodeEncodeError, TypeError):
+        # Non-encodable or incompatible types — treat as invalid key (403)
+        keys_match = False
+    if not keys_match:
         raise HTTPException(
             status_code=status.HTTP_403_FORBIDDEN,
             detail="Invalid API key",

--- a/classes/team.py
+++ b/classes/team.py
@@ -72,7 +72,11 @@ class Team:
         """Add a player to the team if budget allows and roster space is available."""
         if price > self.budget:
             return False
-        
+
+        # Prevent drafting the same player twice
+        if player.is_drafted:
+            return False
+
         # Check if we have roster space
         if not self._can_add_player(player):
             return False

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -47,6 +47,7 @@ dev = [
     "bandit>=1.7.0",
     "vulture>=2.11",
     "ruff>=0.3",
+    "hypothesis>=6.100",
 ]
 
 [build-system]

--- a/pytest.ini
+++ b/pytest.ini
@@ -12,3 +12,8 @@ markers =
     unit: marks tests as unit tests
     simulation: marks tests as simulation tests
     slow: marks tests as slow-running
+    property: marks tests as property-based (Hypothesis)
+
+[hypothesis]
+suppress_health_check = too_slow
+deriving_strategies_from_schemas = always

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -11,6 +11,10 @@ pytest-asyncio>=0.21
 pytest-httpx>=0.30
 pytest-timeout>=2.0
 
+# Property-based testing (Sprint 10)
+hypothesis>=6.100
+hypothesis[numpy]>=6.100
+
 # Lab test dependencies (tests/test_lab_results_db.py imports lab.results_db.models)
 sqlalchemy[asyncio]>=2.0
 aiosqlite>=0.19

--- a/strategies/sigmoid_strategy.py
+++ b/strategies/sigmoid_strategy.py
@@ -35,7 +35,10 @@ class SigmoidStrategy(Strategy):
         if midpoint is None:
             midpoint = self.parameters['midpoint']
             
-        return 1 / (1 + math.exp(-steepness * (x - midpoint)))
+        try:
+            return 1 / (1 + math.exp(-steepness * (x - midpoint)))
+        except OverflowError:
+            return 0.0 if steepness * (x - midpoint) < 0 else 1.0
         
     def _calculate_draft_progress(self, remaining_players: List['Player']) -> float:
         """Calculate how far we are through the draft (0.0 to 1.0)."""

--- a/tests/property/conftest.py
+++ b/tests/property/conftest.py
@@ -1,0 +1,163 @@
+"""Shared Hypothesis composite strategies and settings profiles.
+
+All tests/property/ modules import from here. The composite strategies
+(draft_player, draft_team, draft_state) are the building blocks used
+across every track (B–E).
+
+Hypothesis settings profiles
+------------------------------
+* ``ci``      – max_examples=50, deadline=None  (used in GitHub Actions)
+* ``dev``     – max_examples=200, deadline=None (local full runs)
+* ``default`` – max_examples=100               (fallback)
+
+Set the active profile via the HYPOTHESIS_PROFILE environment variable.
+CI workflow sets ``HYPOTHESIS_PROFILE=ci``.
+"""
+
+from __future__ import annotations
+
+import os
+
+from hypothesis import HealthCheck, settings
+from hypothesis import strategies as st
+
+from classes.player import Player
+from classes.team import Team
+
+# ---------------------------------------------------------------------------
+# Settings profiles
+# ---------------------------------------------------------------------------
+settings.register_profile(
+    "ci",
+    max_examples=50,
+    deadline=None,
+    suppress_health_check=[HealthCheck.too_slow],
+)
+settings.register_profile(
+    "dev",
+    max_examples=200,
+    deadline=None,
+)
+settings.register_profile(
+    "default",
+    max_examples=100,
+    deadline=None,
+)
+
+settings.load_profile(os.environ.get("HYPOTHESIS_PROFILE", "default"))
+
+# ---------------------------------------------------------------------------
+# Reusable constants
+# ---------------------------------------------------------------------------
+_POSITIONS = ["QB", "RB", "WR", "TE", "K", "DST"]
+
+_ALPHANUM = st.characters(whitelist_categories=["Lu", "Ll", "Nd"])
+_LETTERS_SPACE = st.characters(
+    whitelist_categories=["Lu", "Ll"], whitelist_characters=" "
+)
+_UPPERCASE = st.characters(whitelist_categories=["Lu"])
+
+
+# ---------------------------------------------------------------------------
+# Composite strategies
+# ---------------------------------------------------------------------------
+
+
+@st.composite
+def draft_player(draw, position: str | None = None) -> Player:
+    """Generate a valid Player with plausible fantasy-football values.
+
+    Args:
+        position: Force a specific position string; drawn randomly if None.
+
+    Returns:
+        A Player instance with non-negative projected_points and auction_value.
+    """
+    pos = position or draw(st.sampled_from(_POSITIONS))
+    player_id = draw(st.text(min_size=1, max_size=20, alphabet=_ALPHANUM))
+    name = draw(
+        st.text(min_size=1, max_size=40, alphabet=_LETTERS_SPACE).filter(
+            lambda n: n.strip() != ""
+        )
+    )
+    team_abbr = draw(st.text(min_size=2, max_size=4, alphabet=_UPPERCASE))
+    projected = draw(
+        st.floats(min_value=0.0, max_value=500.0, allow_nan=False, allow_infinity=False)
+    )
+    auction_val = draw(
+        st.floats(min_value=0.0, max_value=500.0, allow_nan=False, allow_infinity=False)
+    )
+    return Player(
+        player_id=player_id,
+        name=name,
+        position=pos,
+        nfl_team=team_abbr,
+        projected_points=projected,
+        auction_value=auction_val,
+    )
+
+
+@st.composite
+def draft_team(draw, budget: int | None = None) -> Team:
+    """Generate a valid Team with a given or randomly drawn integer budget.
+
+    Args:
+        budget: Fixed budget; drawn from [10, 500] if None.
+
+    Returns:
+        A Team instance with a positive budget and empty roster.
+    """
+    b = budget if budget is not None else draw(st.integers(min_value=10, max_value=500))
+    team_id = draw(st.text(min_size=1, max_size=20, alphabet=_ALPHANUM))
+    owner_id = draw(st.text(min_size=1, max_size=20, alphabet=_ALPHANUM))
+    team_name = draw(
+        st.text(min_size=1, max_size=40, alphabet=_LETTERS_SPACE).filter(
+            lambda n: n.strip() != ""
+        )
+    )
+    return Team(
+        team_id=team_id,
+        owner_id=owner_id,
+        team_name=team_name,
+        budget=b,
+    )
+
+
+@st.composite
+def draft_state(
+    draw,
+    n_teams: int | None = None,
+    n_rounds: int | None = None,
+) -> tuple[list[Team], list[Player]]:
+    """Generate a plausible draft state as (teams, player_pool).
+
+    The player pool contains 3× as many players as roster slots to allow
+    realistic simulation tests without exhausting the supply.
+
+    Args:
+        n_teams:  Number of teams; drawn from [2, 12] if None.
+        n_rounds: Rounds (≈ roster depth); drawn from [1, 5] if None.
+
+    Returns:
+        Tuple of (List[Team], List[Player]).
+    """
+    num_teams = n_teams or draw(st.integers(min_value=2, max_value=12))
+    num_rounds = n_rounds or draw(st.integers(min_value=1, max_value=5))
+    budget = draw(st.integers(min_value=num_rounds * 2, max_value=300))
+
+    teams = [
+        Team(
+            team_id=f"team_{i}",
+            owner_id=f"owner_{i}",
+            team_name=f"Team {i}",
+            budget=budget,
+        )
+        for i in range(num_teams)
+    ]
+
+    n_players = num_teams * num_rounds * 3
+    players = draw(
+        st.lists(draft_player(), min_size=n_players, max_size=n_players)
+    )
+
+    return teams, players

--- a/tests/property/test_api_deps_properties.py
+++ b/tests/property/test_api_deps_properties.py
@@ -1,0 +1,104 @@
+"""Property tests for api/deps.py — API key authentication invariants (#339).
+
+Tests:
+- Missing / empty api_key always raises HTTP 401
+- A key that does not match configured_key always raises HTTP 403
+- A key that matches configured_key passes without raising
+- The status codes are mutually exclusive: wrong-key always 403, never 401
+"""
+from __future__ import annotations
+
+import pytest
+from fastapi import HTTPException
+from hypothesis import given, settings
+from hypothesis import strategies as st
+
+from api.deps import require_api_key
+from config.settings import Settings
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+# secrets.compare_digest requires ASCII-only strings; restrict to printable ASCII.
+_ASCII_TEXT = st.text(
+    alphabet=st.characters(min_codepoint=0x21, max_codepoint=0x7E),  # printable ASCII (no space)
+    min_size=1,
+    max_size=64,
+)
+
+
+def _settings(api_key: str) -> Settings:
+    """Create a Settings instance with a specific api_key value."""
+    return Settings(api_key=api_key)
+
+
+def _call(api_key, configured_key: str):
+    """Invoke require_api_key directly (bypassing FastAPI DI)."""
+    require_api_key(api_key=api_key, settings=_settings(configured_key))
+
+
+# ---------------------------------------------------------------------------
+# Valid-key invariants
+# ---------------------------------------------------------------------------
+
+@given(key=_ASCII_TEXT)
+@settings(max_examples=50)
+def test_matching_key_does_not_raise(key):
+    """When api_key == configured_key, require_api_key must not raise."""
+    _call(api_key=key, configured_key=key)  # should complete silently
+
+
+# ---------------------------------------------------------------------------
+# Missing-key invariants
+# ---------------------------------------------------------------------------
+
+@given(configured_key=_ASCII_TEXT)
+@settings(max_examples=30)
+def test_missing_key_raises_401(configured_key):
+    """None api_key always raises HTTP 401 regardless of configured key."""
+    with pytest.raises(HTTPException) as exc_info:
+        _call(api_key=None, configured_key=configured_key)
+    assert exc_info.value.status_code == 401
+
+
+@given(configured_key=_ASCII_TEXT)
+@settings(max_examples=30)
+def test_empty_string_key_raises_401(configured_key):
+    """Empty string api_key always raises HTTP 401 (treated as missing)."""
+    with pytest.raises(HTTPException) as exc_info:
+        _call(api_key="", configured_key=configured_key)
+    assert exc_info.value.status_code == 401
+
+
+# ---------------------------------------------------------------------------
+# Wrong-key invariants
+# ---------------------------------------------------------------------------
+
+@given(
+    api_key=_ASCII_TEXT,
+    configured_key=_ASCII_TEXT,
+)
+@settings(max_examples=50)
+def test_wrong_key_raises_403(api_key, configured_key):
+    """When api_key != configured_key, require_api_key raises HTTP 403."""
+    if api_key == configured_key:
+        return  # skip matching pairs — they are valid
+    with pytest.raises(HTTPException) as exc_info:
+        _call(api_key=api_key, configured_key=configured_key)
+    assert exc_info.value.status_code == 403
+
+
+@given(api_key=_ASCII_TEXT, configured_key=_ASCII_TEXT)
+@settings(max_examples=30)
+def test_wrong_key_never_raises_401(api_key, configured_key):
+    """A non-empty, wrong api_key must raise 403, never 401."""
+    if api_key == configured_key:
+        return  # skip valid pairs
+    try:
+        _call(api_key=api_key, configured_key=configured_key)
+    except HTTPException as exc:
+        assert exc.status_code != 401, (
+            f"Expected 403 for wrong key, got 401. api_key={api_key!r}"
+        )

--- a/tests/property/test_api_deps_properties.py
+++ b/tests/property/test_api_deps_properties.py
@@ -21,12 +21,17 @@ from config.settings import Settings
 # Helpers
 # ---------------------------------------------------------------------------
 
-# secrets.compare_digest requires ASCII-only strings; restrict to printable ASCII.
+# Now that api/deps.py encodes to UTF-8 before compare_digest, we can test
+# arbitrary unicode including non-ASCII inputs.  API keys should be printable
+# ASCII in practice, but the code must not crash on anything else.
 _ASCII_TEXT = st.text(
     alphabet=st.characters(min_codepoint=0x21, max_codepoint=0x7E),  # printable ASCII (no space)
     min_size=1,
     max_size=64,
 )
+
+# Any non-empty text (including unicode) must never crash — worst case 403.
+_ANY_TEXT = st.text(min_size=1, max_size=64)
 
 
 def _settings(api_key: str) -> Settings:
@@ -102,3 +107,26 @@ def test_wrong_key_never_raises_401(api_key, configured_key):
         assert exc.status_code != 401, (
             f"Expected 403 for wrong key, got 401. api_key={api_key!r}"
         )
+
+
+# ---------------------------------------------------------------------------
+# Non-ASCII robustness invariants (regression for #350)
+# ---------------------------------------------------------------------------
+
+@given(
+    api_key=_ANY_TEXT,
+    configured_key=_ASCII_TEXT,
+)
+@settings(max_examples=50)
+def test_non_ascii_key_never_crashes(api_key, configured_key):
+    """Any non-empty api_key (including unicode) must never raise a 500-level error.
+
+    It must either pass silently (matching key) or raise HTTP 401/403.
+    A TypeError / UnicodeEncodeError must never propagate — regression for #350.
+    """
+    try:
+        _call(api_key=api_key, configured_key=configured_key)
+        # If it didn't raise, key must exactly match
+        assert api_key == configured_key
+    except HTTPException as exc:
+        assert exc.status_code in (401, 403)

--- a/tests/property/test_auction_class_properties.py
+++ b/tests/property/test_auction_class_properties.py
@@ -1,0 +1,199 @@
+"""Property-based tests: Auction class — Vickrey pricing and sealed-bid invariants.
+
+Track F — Issue #329
+
+Sprint 10 · sprint/10 branch
+"""
+
+from __future__ import annotations
+
+from hypothesis import assume, given, settings
+from hypothesis import strategies as st
+
+from classes.auction import Auction
+from classes.draft import Draft
+from classes.player import Player
+from classes.team import Team
+from classes.owner import Owner
+from tests.property.conftest import draft_player
+
+
+# ---------------------------------------------------------------------------
+# Helper: build a started draft + Auction
+# ---------------------------------------------------------------------------
+
+def _make_auction(n_teams: int = 3, budget: int = 200, n_players: int = 30) -> Auction:
+    draft = Draft(name="test", budget_per_team=budget, roster_size=6, num_teams=n_teams)
+    for i in range(n_teams):
+        team = Team(f"team{i}", f"owner{i}", f"Team{i}", budget=budget)
+        owner = Owner(f"owner{i}", f"Owner{i}")
+        draft.add_team(team, owner)
+    players = [
+        Player(f"p{j}", f"Player{j}", ["QB", "RB", "WR", "TE"][j % 4], "NFL",
+               auction_value=float(j % 50))
+        for j in range(n_players)
+    ]
+    draft.add_players(players)
+    draft.start_draft()
+    return Auction(draft=draft)
+
+
+# ---------------------------------------------------------------------------
+# Property 1 — Vickrey: winner pays second-highest + 1 (single winner case)
+# ---------------------------------------------------------------------------
+
+@given(
+    bids=st.dictionaries(
+        keys=st.text(min_size=1, max_size=8),
+        values=st.floats(min_value=1.0, max_value=500.0, allow_nan=False, allow_infinity=False),
+        min_size=2,
+        max_size=6,
+    )
+)
+@settings(max_examples=100)
+def test_vickrey_price_second_highest_plus_one(bids):
+    """When there is a clear single top bidder, winner pays 2nd-highest + 1."""
+    auction = _make_auction()
+    sorted_vals = sorted(bids.values(), reverse=True)
+    assume(sorted_vals[0] != sorted_vals[1])  # no tie at the top
+
+    winner_id, price = auction._determine_auction_winner(bids)
+
+    # Winner must have submitted the top bid
+    assert bids[winner_id] == sorted_vals[0]
+    # Price must equal second-highest + 1
+    assert abs(price - (sorted_vals[1] + 1.0)) < 1e-9
+
+
+# ---------------------------------------------------------------------------
+# Property 2 — Vickrey: single bidder pays their own bid
+# ---------------------------------------------------------------------------
+
+@given(
+    team_id=st.text(min_size=1, max_size=8),
+    bid=st.floats(min_value=1.0, max_value=500.0, allow_nan=False, allow_infinity=False),
+)
+@settings(max_examples=50)
+def test_vickrey_single_bidder_pays_own_bid(team_id, bid):
+    """When only one team bids, they win and pay their own bid."""
+    auction = _make_auction()
+    winner_id, price = auction._determine_auction_winner({team_id: bid})
+
+    assert winner_id == team_id
+    assert abs(price - bid) < 1e-9
+
+
+# ---------------------------------------------------------------------------
+# Property 3 — empty bids returns no winner
+# ---------------------------------------------------------------------------
+
+@given(st.just(None))
+@settings(max_examples=10)
+def test_no_bids_returns_no_winner(_):
+    """_determine_auction_winner({}) returns (None, 0.0)."""
+    auction = _make_auction()
+    winner_id, price = auction._determine_auction_winner({})
+    assert winner_id is None
+    assert price == 0.0
+
+
+# ---------------------------------------------------------------------------
+# Property 4 — tie-breaking: winner is one of the tied teams
+# ---------------------------------------------------------------------------
+
+@given(
+    tied_ids=st.lists(
+        st.text(min_size=1, max_size=8),
+        min_size=2, max_size=5, unique=True
+    ),
+    tied_bid=st.floats(min_value=1.0, max_value=500.0, allow_nan=False, allow_infinity=False),
+)
+@settings(max_examples=50)
+def test_tie_winner_belongs_to_tied_set(tied_ids, tied_bid):
+    """When multiple teams share the top bid, the winner is one of them."""
+    auction = _make_auction()
+    bids = {tid: tied_bid for tid in tied_ids}
+    winner_id, _ = auction._determine_auction_winner(bids)
+    assert winner_id in tied_ids
+
+
+# ---------------------------------------------------------------------------
+# Property 5 — team receives player only if budget allows
+# ---------------------------------------------------------------------------
+
+@given(
+    player=draft_player(),
+    budget=st.integers(min_value=1, max_value=200),
+    price=st.integers(min_value=1, max_value=300),
+)
+@settings(max_examples=50)
+def test_award_player_respects_budget(player, budget, price):
+    """_award_player_to_team only adds player to team when price ≤ budget."""
+    auction = _make_auction(budget=budget)
+    team = auction.draft.teams[0]
+    # Reset budget to the drawn value
+    team.budget = budget
+    team.initial_budget = budget
+    team.roster_config = {player.position: 5}
+    team.position_limits = {player.position: 5}
+
+    # Ensure player is in available list
+    if player not in auction.draft.available_players:
+        auction.draft.available_players.append(player)
+
+    before_roster = len(team.roster)
+    auction._award_player_to_team(player, team.owner_id, float(price))
+
+    if price <= budget:
+        # Player should be on roster
+        assert len(team.roster) == before_roster + 1
+    else:
+        # Budget exceeded — no change
+        assert len(team.roster) == before_roster
+
+
+# ---------------------------------------------------------------------------
+# Property 6 — player moves from available to drafted after nominate_player
+# ---------------------------------------------------------------------------
+
+@given(st.just(None))
+@settings(max_examples=20, deadline=None)
+def test_nominate_player_removes_from_available(_):
+    """nominate_player() removes the player from draft.available_players."""
+    auction = _make_auction(n_teams=2, budget=200, n_players=10)
+    player = auction.draft.available_players[0]
+    before = len(auction.draft.available_players)
+
+    auction.nominate_player(player, "owner0", initial_bid=1.0)
+
+    assert player not in auction.draft.available_players
+    assert len(auction.draft.available_players) == before - 1
+    assert player in auction.draft.drafted_players
+
+
+# ---------------------------------------------------------------------------
+# Property 7 — on_auction_completed fires exactly once per nominate_player
+# ---------------------------------------------------------------------------
+
+@given(st.just(None))
+@settings(max_examples=20, deadline=None)
+def test_auction_completed_callback_fires_once(_):
+    """on_auction_completed callback fires exactly once per nomination.
+
+    Teams need a calculate_bid method so _collect_sealed_bids returns bids;
+    without bids the winner is None and _award_player_to_team (which fires
+    the callback) is never reached.
+    """
+    auction = _make_auction(n_teams=2, budget=200, n_players=10)
+
+    # Give every team a callable bid so bids are collected
+    for team in auction.draft.teams:
+        team.calculate_bid = lambda **kwargs: 10.0  # noqa: E731
+
+    calls = []
+    auction.on_auction_completed.append(lambda p, t, price: calls.append(1))
+
+    player = auction.draft.available_players[0]
+    auction.nominate_player(player, "owner0", initial_bid=1.0)
+
+    assert len(calls) == 1

--- a/tests/property/test_auction_properties.py
+++ b/tests/property/test_auction_properties.py
@@ -1,0 +1,150 @@
+"""Property-based tests: auction bid invariants.
+
+Track B — Issue #315
+The real budget-enforcement point is Team.add_player (Auction.place_bid is a
+legacy stub that always returns False). These properties test the core invariant
+that drives every auction: money paid for drafted players must stay within the
+team's initial budget.
+
+Sprint 10 · sprint/10 branch
+"""
+
+from hypothesis import assume, given, settings
+from hypothesis import strategies as st
+
+from tests.property.conftest import draft_player, draft_team
+
+
+# ---------------------------------------------------------------------------
+# Property 1 — valid bids never violate budget
+# ---------------------------------------------------------------------------
+
+
+@given(
+    team=draft_team(),
+    player=draft_player(),
+    bid_fraction=st.floats(min_value=0.01, max_value=1.0, allow_nan=False),
+)
+@settings(max_examples=50)
+def test_bid_bounded_by_budget(team, player, bid_fraction):
+    """add_player with any 1 <= amount <= remaining_budget never leaves budget < 0.
+
+    Invariant:
+        forall team, player, amount where 1 <= amount <= team.budget:
+            after add_player(player, amount): team.budget >= 0
+    """
+    assume(team.budget >= 1)
+    amount = max(1, int(bid_fraction * team.budget))
+    amount = min(amount, team.budget)
+    team.add_player(player, amount)
+    assert team.budget >= 0
+
+
+# ---------------------------------------------------------------------------
+# Property 2 — overbids are always rejected
+# ---------------------------------------------------------------------------
+
+
+@given(
+    team=draft_team(),
+    player=draft_player(),
+    overage=st.integers(min_value=1, max_value=1000),
+)
+@settings(max_examples=50)
+def test_overbid_always_rejected(team, player, overage):
+    """add_player with amount > remaining_budget always returns False.
+
+    Invariant:
+        forall team, player, overage > 0:
+            add_player(team.budget + overage) returns False and budget unchanged
+    """
+    overbid = team.budget + overage
+    budget_before = team.budget
+    result = team.add_player(player, overbid)
+    assert result is False
+    assert team.budget == budget_before
+
+
+# ---------------------------------------------------------------------------
+# Property 3 — bidding exactly the budget succeeds and drains it to zero
+# ---------------------------------------------------------------------------
+
+
+@given(team=draft_team(), player=draft_player())
+@settings(max_examples=50)
+def test_bid_at_exactly_budget(team, player):
+    """add_player with price == team.budget succeeds and leaves team.budget == 0.
+
+    Assumes team has at least $1 and a free roster slot for the player's position.
+
+    Invariant:
+        forall team with budget >= 1, player with a free position slot:
+            add_player(player, budget) is True and team.budget == 0
+    """
+    assume(team.budget >= 1)
+    # Ensure the team has a slot for this position by clearing roster and resetting config
+    team.roster_config = {player.position: 1}
+    team.position_limits = {player.position: 1}
+    result = team.add_player(player, team.budget)
+    assert result is True
+    assert team.budget == 0
+
+
+# ---------------------------------------------------------------------------
+# Property 4 — sequential valid bids maintain the budget invariant
+# ---------------------------------------------------------------------------
+
+
+@given(
+    initial_budget=st.integers(min_value=10, max_value=500),
+    n_bids=st.integers(min_value=1, max_value=6),
+)
+@settings(max_examples=50)
+def test_sequential_bids_maintain_budget(initial_budget, n_bids):
+    """Any sequence of valid bids keeps sum(paid prices) <= initial_budget.
+
+    Invariant:
+        forall initial_budget, sequence of add_player calls where each price <= current budget:
+            initial_budget - team.budget == sum of accepted prices
+    """
+    from classes.team import Team
+    from classes.player import Player
+
+    team = Team("t", "o", "Test", initial_budget)
+    positions = ["QB", "RB", "WR", "TE", "K", "DST", "RB", "WR"]
+    total_paid = 0
+
+    for i in range(n_bids):
+        if team.budget < 1:
+            break
+        bid = max(1, team.budget // (n_bids - i))
+        bid = min(bid, team.budget)
+        p = Player(f"p{i}", f"Player {i}", positions[i % len(positions)], "NFL")
+        if team.add_player(p, bid):
+            total_paid += bid
+
+    assert team.initial_budget - team.budget == total_paid
+    assert total_paid <= initial_budget
+
+
+# ---------------------------------------------------------------------------
+# Property 5 — team state reads are idempotent
+# ---------------------------------------------------------------------------
+
+
+@given(team=draft_team())
+@settings(max_examples=50)
+def test_auction_state_idempotent(team):
+    """Calling get_state() twice without mutations returns equal TeamState objects.
+
+    Invariant:
+        forall team:
+            team.get_state() == team.get_state()  (no side effects)
+    """
+    s1 = team.get_state()
+    s2 = team.get_state()
+    assert s1 == s2
+    assert s1.team_id == s2.team_id
+    assert s1.budget == s2.budget
+    assert s1.roster_player_ids == s2.roster_player_ids
+

--- a/tests/property/test_base_strategy_properties.py
+++ b/tests/property/test_base_strategy_properties.py
@@ -1,0 +1,216 @@
+"""Property tests for strategies/base_strategy.py — Strategy ABC (#331).
+
+Tests:
+- set_parameter / get_parameter round-trip
+- get_parameter returns default when key absent
+- __init_subclass__ wrapping: calculate_bid returns 0 when raw <= current_bid
+- __init_subclass__ wrapping: calculate_bid returns positive when raw beats bid
+- __init_subclass__ wrapping: should_nominate blocks when slots<=2 & priority<0.3
+- _calculate_safe_bid_limit always returns a positive integer
+- str(strategy) contains strategy name
+"""
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+from hypothesis import given, settings
+from hypothesis import strategies as st
+
+from strategies.base_strategy import Strategy
+
+
+# ---------------------------------------------------------------------------
+# Minimal concrete subclasses — defined at module level so __init_subclass__
+# fires once at class-definition time (not per test invocation).
+# ---------------------------------------------------------------------------
+
+class _HighBidStrategy(Strategy):
+    """Always returns a very high raw bid (999.0), used to test clamping."""
+
+    def __init__(self, raw_bid: float = 999.0):
+        super().__init__("test-high", "test strategy high bid")
+        self._raw_bid = raw_bid
+
+    def calculate_bid(self, player, team, owner, current_bid, remaining_budget, remaining_players):  # noqa: D102
+        return self._raw_bid
+
+    def should_nominate(self, player, team, owner, remaining_budget):  # noqa: D102
+        return True
+
+
+class _ZeroBidStrategy(Strategy):
+    """Always returns 0 as the raw bid — wrapper must short-circuit to 0."""
+
+    def __init__(self):
+        super().__init__("test-zero", "test strategy zero bid")
+
+    def calculate_bid(self, player, team, owner, current_bid, remaining_budget, remaining_players):  # noqa: D102
+        return 0
+
+    def should_nominate(self, player, team, owner, remaining_budget):  # noqa: D102
+        return True
+
+
+# ---------------------------------------------------------------------------
+# Shared helpers
+# ---------------------------------------------------------------------------
+
+def _make_team(remaining_slots: int = 10, priority: float = 0.8) -> MagicMock:
+    """Return a minimal MagicMock team with the delegation methods configured."""
+    team = MagicMock()
+    team.get_remaining_roster_slots.return_value = remaining_slots
+    team.calculate_position_priority.return_value = priority
+    # enforce_budget_constraint: clamp bid to remaining_budget
+    team.enforce_budget_constraint.side_effect = lambda bid, budget: min(bid, budget)
+    # calculate_minimum_budget_needed: no reservation by default
+    team.calculate_minimum_budget_needed.return_value = 0.0
+    team.budget = 200
+    team.initial_budget = 200
+    team.roster = []
+    return team
+
+
+# ---------------------------------------------------------------------------
+# Tests — parameter persistence
+# ---------------------------------------------------------------------------
+
+@given(
+    key=st.text(min_size=1, max_size=30),
+    value=st.one_of(
+        st.integers(),
+        st.floats(allow_nan=False, allow_infinity=False),
+        st.text(),
+    ),
+)
+@settings(max_examples=50)
+def test_set_get_parameter_round_trip(key, value):
+    """set_parameter(k, v) → get_parameter(k) returns v unchanged."""
+    s = _HighBidStrategy()
+    s.set_parameter(key, value)
+    assert s.get_parameter(key) == value
+
+
+@given(
+    key=st.text(min_size=1, max_size=30),
+    default=st.one_of(st.none(), st.integers(), st.text()),
+)
+@settings(max_examples=30)
+def test_get_missing_parameter_returns_default(key, default):
+    """get_parameter on an absent key returns the supplied default."""
+    s = _HighBidStrategy()
+    s.parameters = {}
+    assert s.get_parameter(key, default) == default
+
+
+# ---------------------------------------------------------------------------
+# Tests — __init_subclass__ calculate_bid wrapping
+# ---------------------------------------------------------------------------
+
+@given(
+    current_bid=st.floats(min_value=0.0, max_value=100.0, allow_nan=False, allow_infinity=False),
+)
+@settings(max_examples=50)
+def test_wrapped_calculate_bid_returns_zero_when_raw_is_zero(current_bid):
+    """When raw bid is 0 (<= any current_bid), the wrapped result is 0."""
+    s = _ZeroBidStrategy()
+    team = _make_team()
+    result = s.calculate_bid(
+        player=MagicMock(position="QB"),
+        team=team,
+        owner=MagicMock(),
+        current_bid=current_bid,
+        remaining_budget=200.0,
+        remaining_players=[],
+    )
+    assert result == 0
+
+
+@given(
+    current_bid=st.floats(min_value=0.0, max_value=50.0, allow_nan=False, allow_infinity=False),
+)
+@settings(max_examples=50)
+def test_wrapped_calculate_bid_returns_positive_when_raw_beats_current(current_bid):
+    """When raw bid (999) > current_bid, the wrapped result is > 0."""
+    s = _HighBidStrategy(raw_bid=999.0)
+    team = _make_team()
+    result = s.calculate_bid(
+        player=MagicMock(position="RB"),
+        team=team,
+        owner=MagicMock(),
+        current_bid=current_bid,
+        remaining_budget=200.0,
+        remaining_players=[],
+    )
+    assert result > 0
+
+
+# ---------------------------------------------------------------------------
+# Tests — __init_subclass__ should_nominate wrapping
+# ---------------------------------------------------------------------------
+
+@given(
+    slots=st.integers(min_value=0, max_value=2),
+    priority=st.floats(min_value=0.0, max_value=0.29, allow_nan=False, allow_infinity=False),
+)
+@settings(max_examples=30)
+def test_wrapped_should_nominate_blocks_when_few_slots_low_priority(slots, priority):
+    """slots<=2 AND priority<0.3 → should_nominate returns False via wrapper."""
+    s = _HighBidStrategy()
+    team = _make_team(remaining_slots=slots, priority=priority)
+    result = s.should_nominate(
+        player=MagicMock(position="K"),
+        team=team,
+        owner=MagicMock(),
+        remaining_budget=50.0,
+    )
+    assert result is False
+
+
+@given(
+    slots=st.integers(min_value=3, max_value=15),
+    priority=st.floats(min_value=0.3, max_value=1.0, allow_nan=False, allow_infinity=False),
+)
+@settings(max_examples=30)
+def test_wrapped_should_nominate_delegates_when_slots_ok(slots, priority):
+    """When slots>2 or priority>=0.3, should_nominate delegates to the original (True)."""
+    s = _HighBidStrategy()
+    team = _make_team(remaining_slots=slots, priority=priority)
+    result = s.should_nominate(
+        player=MagicMock(position="WR"),
+        team=team,
+        owner=MagicMock(),
+        remaining_budget=100.0,
+    )
+    # The original always returns True, so wrapped result should also be True
+    assert result is True
+
+
+# ---------------------------------------------------------------------------
+# Tests — _calculate_safe_bid_limit
+# ---------------------------------------------------------------------------
+
+@given(
+    remaining_budget=st.floats(min_value=10.0, max_value=500.0, allow_nan=False, allow_infinity=False),
+    max_pct=st.floats(min_value=0.1, max_value=1.0, allow_nan=False, allow_infinity=False),
+)
+@settings(max_examples=50)
+def test_calculate_safe_bid_limit_is_positive_integer(remaining_budget, max_pct):
+    """_calculate_safe_bid_limit always returns an int >= 1."""
+    s = _HighBidStrategy()
+    team = _make_team()
+    result = s._calculate_safe_bid_limit(team, remaining_budget, max_pct)
+    assert isinstance(result, int)
+    assert result >= 1
+
+
+# ---------------------------------------------------------------------------
+# Tests — str representation
+# ---------------------------------------------------------------------------
+
+@given(name=st.text(min_size=1, max_size=30))
+@settings(max_examples=20)
+def test_str_representation_contains_name(name):
+    """str(strategy) contains the strategy name."""
+    s = _HighBidStrategy()
+    s.name = name
+    assert name in str(s)

--- a/tests/property/test_bid_recommendation_service_properties.py
+++ b/tests/property/test_bid_recommendation_service_properties.py
@@ -1,0 +1,72 @@
+"""Property tests for services/bid_recommendation_service.py (#336).
+
+Tests:
+- _get_strategy(key) returns a Strategy for any valid strategy key
+- _get_strategy returns the same cached object on repeated calls
+- _get_strategy with an unknown key raises ValueError
+"""
+from __future__ import annotations
+
+import pytest
+from hypothesis import given, settings
+from hypothesis import strategies as st
+
+from strategies import AVAILABLE_STRATEGIES
+from strategies.base_strategy import Strategy
+from services.bid_recommendation_service import BidRecommendationService
+
+_VALID_KEYS = sorted(AVAILABLE_STRATEGIES.keys())
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _service() -> BidRecommendationService:
+    """Create a fresh BidRecommendationService with minimal config."""
+    from unittest.mock import MagicMock
+    from config.config_manager import DraftConfig
+
+    mock_cfg = MagicMock(spec=DraftConfig)
+    mock_cfg.strategy_type = "balanced"
+    mock_cfg.sleeper_draft_id = None
+    mock_cfg.data_source = "fantasypros"
+
+    mock_manager = MagicMock()
+    mock_manager.load_config.return_value = mock_cfg
+
+    return BidRecommendationService(config_manager=mock_manager)
+
+
+# ---------------------------------------------------------------------------
+# Tests — strategy creation
+# ---------------------------------------------------------------------------
+
+@given(key=st.sampled_from(_VALID_KEYS))
+@settings(max_examples=len(_VALID_KEYS))
+def test_get_strategy_valid_key_returns_strategy(key):
+    """_get_strategy(key) returns a Strategy instance for any registered key."""
+    svc = _service()
+    result = svc._get_strategy(key)
+    assert isinstance(result, Strategy)
+
+
+@given(key=st.sampled_from(_VALID_KEYS))
+@settings(max_examples=len(_VALID_KEYS))
+def test_get_strategy_caches_instance(key):
+    """Calling _get_strategy() twice with the same key returns the same object."""
+    svc = _service()
+    first = svc._get_strategy(key)
+    second = svc._get_strategy(key)
+    assert first is second
+
+
+@given(
+    key=st.text(min_size=1, max_size=40).filter(lambda k: k not in AVAILABLE_STRATEGIES)
+)
+@settings(max_examples=30)
+def test_get_strategy_unknown_key_raises_value_error(key):
+    """_get_strategy() with an unknown key raises ValueError."""
+    svc = _service()
+    with pytest.raises(ValueError):
+        svc._get_strategy(key)

--- a/tests/property/test_cheatsheet_parser_properties.py
+++ b/tests/property/test_cheatsheet_parser_properties.py
@@ -1,0 +1,75 @@
+"""Property tests for utils/cheatsheet_parser.py — stub interface invariants (#342).
+
+Tests:
+- get_cheatsheet_parser() always returns a CheatsheetParser instance
+- find_undervalued_players_simple(threshold) raises NotImplementedError for any threshold
+- find_undervalued_players(threshold) raises NotImplementedError for any threshold
+- get_all_players() raises NotImplementedError
+"""
+from __future__ import annotations
+
+import pytest
+from hypothesis import given, settings
+from hypothesis import strategies as st
+
+from utils.cheatsheet_parser import CheatsheetParser, get_cheatsheet_parser
+
+
+# ---------------------------------------------------------------------------
+# Factory invariants
+# ---------------------------------------------------------------------------
+
+@given(st.just(None))
+@settings(max_examples=5)
+def test_factory_returns_cheatsheet_parser(_):
+    """get_cheatsheet_parser() always returns a CheatsheetParser instance."""
+    parser = get_cheatsheet_parser()
+    assert isinstance(parser, CheatsheetParser)
+
+
+@given(st.just(None))
+@settings(max_examples=3)
+def test_factory_returns_new_instance_each_call(_):
+    """Each get_cheatsheet_parser() call returns a distinct object."""
+    p1 = get_cheatsheet_parser()
+    p2 = get_cheatsheet_parser()
+    assert p1 is not p2
+
+
+# ---------------------------------------------------------------------------
+# Stub method invariants — all public methods raise NotImplementedError
+# ---------------------------------------------------------------------------
+
+@given(
+    threshold=st.floats(
+        min_value=-1e6, max_value=1e6, allow_nan=False, allow_infinity=False
+    )
+)
+@settings(max_examples=30)
+def test_find_undervalued_players_simple_not_implemented(threshold):
+    """find_undervalued_players_simple() raises NotImplementedError for any threshold."""
+    parser = get_cheatsheet_parser()
+    with pytest.raises(NotImplementedError):
+        parser.find_undervalued_players_simple(threshold)
+
+
+@given(
+    threshold=st.floats(
+        min_value=-1e6, max_value=1e6, allow_nan=False, allow_infinity=False
+    )
+)
+@settings(max_examples=30)
+def test_find_undervalued_players_not_implemented(threshold):
+    """find_undervalued_players() raises NotImplementedError for any threshold."""
+    parser = get_cheatsheet_parser()
+    with pytest.raises(NotImplementedError):
+        parser.find_undervalued_players(threshold)
+
+
+@given(st.just(None))
+@settings(max_examples=5)
+def test_get_all_players_not_implemented(_):
+    """get_all_players() raises NotImplementedError."""
+    parser = get_cheatsheet_parser()
+    with pytest.raises(NotImplementedError):
+        parser.get_all_players()

--- a/tests/property/test_config_properties.py
+++ b/tests/property/test_config_properties.py
@@ -1,0 +1,100 @@
+"""Property-based tests: config round-trip invariants.
+
+Track D — Issue #317
+
+Sprint 10 · sprint/10 branch
+"""
+
+from hypothesis import given, settings
+from hypothesis import strategies as st
+
+
+_ROSTER_POSITIONS = st.fixed_dictionaries(
+    {
+        "QB": st.integers(min_value=1, max_value=3),
+        "RB": st.integers(min_value=2, max_value=8),
+        "WR": st.integers(min_value=2, max_value=8),
+        "TE": st.integers(min_value=1, max_value=3),
+        "K": st.integers(min_value=0, max_value=2),
+        "DST": st.integers(min_value=0, max_value=2),
+        "FLEX": st.integers(min_value=0, max_value=4),
+        "BENCH": st.integers(min_value=0, max_value=8),
+    }
+)
+
+_draft_config_kwargs = st.fixed_dictionaries(
+    {
+        "budget": st.integers(min_value=1, max_value=1000),
+        "num_teams": st.integers(min_value=2, max_value=20),
+        "strategy_type": st.sampled_from(["value", "vor", "aggressive", "conservative"]),
+        "refresh_interval": st.integers(min_value=5, max_value=300),
+        "roster_positions": _ROSTER_POSITIONS,
+    }
+)
+
+
+@given(kwargs=_draft_config_kwargs)
+@settings(max_examples=50)
+def test_draft_config_round_trip(kwargs):
+    """DraftConfig.from_dict(cfg.to_dict()) equals cfg field-by-field.
+
+    Invariant:
+        forall valid DraftConfig cfg:
+            DraftConfig.from_dict(cfg.to_dict()).budget == cfg.budget
+            and all other scalar fields match
+    """
+    from config.config_manager import DraftConfig
+
+    cfg = DraftConfig(**kwargs)
+    d = cfg.to_dict()
+    restored = DraftConfig.from_dict(d)
+
+    assert restored.budget == cfg.budget
+    assert restored.num_teams == cfg.num_teams
+    assert restored.strategy_type == cfg.strategy_type
+    assert restored.refresh_interval == cfg.refresh_interval
+    assert restored.roster_positions == cfg.roster_positions
+
+
+@given(n_calls=st.integers(min_value=2, max_value=10))
+@settings(max_examples=20)
+def test_settings_immutable_after_init(n_calls):
+    """Calling get_settings() N times always returns the same cached object (is).
+
+    Invariant:
+        forall n >= 2:
+            all get_settings() calls return the same object by identity
+    """
+    from config.settings import get_settings
+
+    first = get_settings()
+    for _ in range(n_calls - 1):
+        assert get_settings() is first
+
+
+@given(kwargs=_draft_config_kwargs)
+@settings(max_examples=50)
+def test_config_budget_non_negative(kwargs):
+    """Any valid DraftConfig always has budget > 0.
+
+    Invariant:
+        forall valid DraftConfig cfg:  cfg.budget > 0
+    """
+    from config.config_manager import DraftConfig
+
+    cfg = DraftConfig(**kwargs)
+    assert cfg.budget > 0
+
+
+@given(kwargs=_draft_config_kwargs)
+@settings(max_examples=50)
+def test_config_team_count_positive(kwargs):
+    """Any valid DraftConfig always has num_teams >= 2.
+
+    Invariant:
+        forall valid DraftConfig cfg:  cfg.num_teams >= 2
+    """
+    from config.config_manager import DraftConfig
+
+    cfg = DraftConfig(**kwargs)
+    assert cfg.num_teams >= 2

--- a/tests/property/test_data_properties.py
+++ b/tests/property/test_data_properties.py
@@ -1,0 +1,99 @@
+"""Property-based tests: data layer invariants (Player schema, VOR, auction values).
+
+Track D — Issue #317
+
+Sprint 10 · sprint/10 branch
+"""
+
+
+from hypothesis import assume, given, settings
+from hypothesis import strategies as st
+
+from tests.property.conftest import draft_player
+
+_POSITIONS = ["QB", "RB", "WR", "TE", "K", "DST"]
+
+
+@given(player=draft_player())
+@settings(max_examples=50)
+def test_player_schema_complete(player):
+    """Any Player built from valid input has non-None required fields.
+
+    Invariant:
+        forall valid player:
+            player_id, name, position, nfl_team are all non-None
+    """
+    assert player.player_id is not None
+    assert player.name is not None
+    assert player.position is not None
+    assert player.nfl_team is not None
+
+
+@given(
+    projected_points=st.floats(min_value=0.0, max_value=500.0, allow_nan=False, allow_infinity=False),
+    baseline_points=st.floats(min_value=0.0, max_value=499.0, allow_nan=False, allow_infinity=False),
+)
+@settings(max_examples=100)
+def test_vor_non_negative_for_starters(projected_points, baseline_points):
+    """VOR is always >= 0 for any player ranked above the position baseline.
+
+    VOR is defined as: max(0, projected_points - baseline_points).
+
+    Invariant:
+        forall projected_points >= baseline_points:
+            VOR(projected_points, baseline_points) >= 0
+    """
+    assume(projected_points >= baseline_points)
+    vor = projected_points - baseline_points
+    assert vor >= 0.0
+
+
+@given(
+    total_budget=st.integers(min_value=100, max_value=2000),
+    n_players=st.integers(min_value=5, max_value=30),
+)
+@settings(max_examples=30)
+def test_auction_values_sum_to_budget(total_budget, n_players):
+    """Budget-normalised auction values sum to exactly total_budget (within floating-point).
+
+    Normalisation: v_i = raw_i / sum(raw) * total_budget.
+
+    Invariant:
+        forall total_budget, n_players >= 1:
+            abs(sum(normalised_values) - total_budget) < 1e-6
+    """
+    import random
+
+    rng = random.Random(total_budget * 31 + n_players)
+    raw = [rng.uniform(1.0, 100.0) for _ in range(n_players)]
+    raw_sum = sum(raw)
+    normalised = [v / raw_sum * total_budget for v in raw]
+    assert abs(sum(normalised) - total_budget) < 1e-6
+
+
+@given(n_rows=st.integers(min_value=1, max_value=20))
+@settings(max_examples=20)
+def test_csv_parse_idempotent(n_rows):
+    """Parsing the same CSV data twice produces identical player lists.
+
+    Invariant:
+        forall csv_data:
+            _parse_csv_file(data, pos) == _parse_csv_file(data, pos)
+    """
+    from data.fantasypros_loader import _parse_csv_file
+
+    header = "Rank,Player Name,Team,Bye,Projected Points,Auction Value"
+    rows = [
+        f"{i},Player{i},NFL,7,{10.0 + i * 2.5},{5 + i}"
+        for i in range(1, n_rows + 1)
+    ]
+    csv_content = "\n".join([header] + rows)
+
+    result1 = _parse_csv_file(csv_content, "RB")
+    result2 = _parse_csv_file(csv_content, "RB")
+
+    assert len(result1) == len(result2)
+    for p1, p2 in zip(result1, result2):
+        assert p1.player_id == p2.player_id
+        assert p1.name == p2.name
+        assert p1.projected_points == p2.projected_points

--- a/tests/property/test_draft_loading_service_properties.py
+++ b/tests/property/test_draft_loading_service_properties.py
@@ -1,0 +1,53 @@
+"""Property tests for services/draft_loading_service.py (#338).
+
+Tests:
+- DraftLoadingService constructor succeeds with explicit config_manager
+- DraftLoadingService constructor succeeds without config_manager (uses default)
+- config_manager attribute is always set after construction
+- sleeper_api attribute is always set after construction
+"""
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+from hypothesis import given, settings
+from hypothesis import strategies as st
+
+from services.draft_loading_service import DraftLoadingService
+from api.sleeper_api import SleeperAPI
+
+
+# ---------------------------------------------------------------------------
+# Tests — constructor invariants
+# ---------------------------------------------------------------------------
+
+@given(st.just(None))
+@settings(max_examples=5)
+def test_constructor_with_mock_config_manager(_):
+    """DraftLoadingService constructs successfully with a mock config_manager."""
+    mock_manager = MagicMock()
+    svc = DraftLoadingService(config_manager=mock_manager)
+    assert svc.config_manager is mock_manager
+
+
+@given(st.just(None))
+@settings(max_examples=3)
+def test_constructor_sets_sleeper_api(_):
+    """DraftLoadingService always sets a sleeper_api attribute after construction."""
+    mock_manager = MagicMock()
+    svc = DraftLoadingService(config_manager=mock_manager)
+    assert hasattr(svc, "sleeper_api")
+    assert isinstance(svc.sleeper_api, SleeperAPI)
+
+
+@given(st.just(None))
+@settings(max_examples=3)
+def test_two_instances_have_independent_config_managers(_):
+    """Two DraftLoadingService instances with different managers are independent."""
+    mgr1 = MagicMock()
+    mgr2 = MagicMock()
+    svc1 = DraftLoadingService(config_manager=mgr1)
+    svc2 = DraftLoadingService(config_manager=mgr2)
+    assert svc1.config_manager is mgr1
+    assert svc2.config_manager is mgr2
+    assert svc1.config_manager is not svc2.config_manager

--- a/tests/property/test_draft_properties.py
+++ b/tests/property/test_draft_properties.py
@@ -1,0 +1,204 @@
+"""Property-based tests: Draft class state machine and auction invariants.
+
+Track F — Issue #328
+
+Sprint 10 · sprint/10 branch
+"""
+
+from __future__ import annotations
+
+from hypothesis import assume, given, settings
+from hypothesis import strategies as st
+
+from classes.draft import Draft
+from classes.player import Player
+from classes.team import Team
+from classes.owner import Owner
+
+
+# ---------------------------------------------------------------------------
+# Helper: build a minimal 2-team draft with players ready to start
+# ---------------------------------------------------------------------------
+
+def _make_started_draft(n_players: int = 20) -> Draft:
+    """Return a started 2-team draft pre-loaded with n_players."""
+    draft = Draft(name="test", budget_per_team=200.0, roster_size=6, num_teams=2)
+    for i in range(2):
+        team = Team(f"team{i}", f"owner{i}", f"Team {i}", budget=200)
+        owner = Owner(f"owner{i}", f"Owner {i}")
+        draft.add_team(team, owner)
+    players = [
+        Player(f"p{j}", f"Player {j}", ["QB", "RB", "WR", "TE"][j % 4], "NFL")
+        for j in range(n_players)
+    ]
+    draft.add_players(players)
+    draft.start_draft()
+    return draft
+
+
+# ---------------------------------------------------------------------------
+# Property 1 — state machine: only valid transitions
+# ---------------------------------------------------------------------------
+
+@given(st.just(None))
+@settings(max_examples=10)
+def test_draft_starts_in_created_status(_):
+    """A freshly constructed Draft is always in 'created' status."""
+    draft = Draft()
+    assert draft.status == "created"
+
+
+@given(st.just(None))
+@settings(max_examples=10)
+def test_start_draft_transitions_to_started(_):
+    """start_draft() moves status from 'created' to 'started'."""
+    draft = Draft(num_teams=2, budget_per_team=100, roster_size=4)
+    for i in range(2):
+        team = Team(f"t{i}", f"o{i}", f"Team{i}", budget=100)
+        owner = Owner(f"o{i}", f"Owner{i}")
+        draft.add_team(team, owner)
+    players = [Player(f"p{j}", f"P{j}", "RB", "NFL") for j in range(12)]
+    draft.add_players(players)
+    draft.start_draft()
+    assert draft.status == "started"
+
+
+@given(st.just(None))
+@settings(max_examples=10)
+def test_status_cannot_go_backwards(_):
+    """Once 'started', calling start_draft() again raises ValueError."""
+    draft = _make_started_draft()
+    try:
+        draft.start_draft()
+        assert False, "Expected ValueError"
+    except ValueError:
+        pass  # correct
+    assert draft.status in ("started", "paused", "completed")
+
+
+# ---------------------------------------------------------------------------
+# Property 2 — nominator rotation is cyclic
+# ---------------------------------------------------------------------------
+
+@given(n_advances=st.integers(min_value=1, max_value=50))
+@settings(max_examples=50)
+def test_nominator_rotation_is_cyclic(n_advances):
+    """After num_teams advances the index returns to its starting value."""
+    draft = _make_started_draft()
+    num_teams = len(draft.teams)
+    start_index = draft.current_nominator_index
+
+    for _ in range(num_teams * n_advances):
+        draft._advance_nominator()
+
+    assert draft.current_nominator_index == start_index
+
+
+@given(n_advances=st.integers(min_value=0, max_value=100))
+@settings(max_examples=50)
+def test_nominator_index_always_valid(n_advances):
+    """current_nominator_index is always in [0, len(teams) - 1]."""
+    draft = _make_started_draft()
+    for _ in range(n_advances):
+        draft._advance_nominator()
+
+    assert 0 <= draft.current_nominator_index < len(draft.teams)
+
+
+# ---------------------------------------------------------------------------
+# Property 3 — bid monotonicity
+# ---------------------------------------------------------------------------
+
+@given(
+    first_bid=st.floats(min_value=1.0, max_value=50.0, allow_nan=False, allow_infinity=False),
+    low_bid_delta=st.floats(min_value=0.0, max_value=50.0, allow_nan=False, allow_infinity=False),
+)
+@settings(max_examples=50)
+def test_place_bid_rejects_non_increasing(first_bid, low_bid_delta):
+    """place_bid returns False if bid_amount <= current_bid."""
+    draft = _make_started_draft()
+    player = draft.available_players[0]
+    draft.nominate_player(player, "owner0", initial_bid=first_bid)
+
+    low_bid = first_bid - low_bid_delta  # always ≤ current bid
+    result = draft.place_bid("owner1", low_bid)
+    assert result is False
+
+
+@given(
+    first_bid=st.floats(min_value=1.0, max_value=100.0, allow_nan=False, allow_infinity=False),
+    increment=st.floats(min_value=0.01, max_value=50.0, allow_nan=False, allow_infinity=False),
+)
+@settings(max_examples=50)
+def test_place_bid_accepts_higher(first_bid, increment):
+    """place_bid returns True when bid_amount > current_bid and team has budget."""
+    assume(first_bid + increment <= 200.0)
+    draft = _make_started_draft()
+    player = draft.available_players[0]
+    draft.nominate_player(player, "owner0", initial_bid=first_bid)
+
+    result = draft.place_bid("owner1", first_bid + increment)
+    assert result is True
+    assert draft.current_bid == first_bid + increment
+
+
+# ---------------------------------------------------------------------------
+# Property 4 — auction resolution moves player between pools
+# ---------------------------------------------------------------------------
+
+@given(st.just(None))
+@settings(max_examples=20)
+def test_complete_auction_moves_player(_):
+    """complete_auction() removes player from available and adds to drafted."""
+    draft = _make_started_draft()
+    player = draft.available_players[0]
+    before_available = len(draft.available_players)
+    before_drafted = len(draft.drafted_players)
+
+    draft.nominate_player(player, "owner0", initial_bid=1.0)
+    draft.place_bid("owner1", 2.0)
+    draft.complete_auction()
+
+    # Player moved pools (or auction was voided — either way it left available)
+    assert len(draft.available_players) == before_available - 1
+    assert len(draft.drafted_players) == before_drafted + 1
+
+
+# ---------------------------------------------------------------------------
+# Property 5 — team count never exceeds num_teams cap
+# ---------------------------------------------------------------------------
+
+@given(extra=st.integers(min_value=1, max_value=10))
+@settings(max_examples=50)
+def test_team_count_capped(extra):
+    """Adding more than num_teams teams raises ValueError."""
+    num_teams = 2
+    draft = Draft(num_teams=num_teams, budget_per_team=100, roster_size=4)
+    for i in range(num_teams):
+        draft.add_team(Team(f"t{i}", f"o{i}", f"Team{i}", budget=100))
+
+    for i in range(extra):
+        try:
+            draft.add_team(Team(f"extra{i}", f"eo{i}", f"Extra{i}", budget=100))
+            assert False, "Expected ValueError"
+        except ValueError:
+            pass
+
+    assert len(draft.teams) == num_teams
+
+
+# ---------------------------------------------------------------------------
+# Property 6 — get_leaderboard returns all teams sorted descending
+# ---------------------------------------------------------------------------
+
+@given(st.just(None))
+@settings(max_examples=20)
+def test_leaderboard_ordering(_):
+    """get_leaderboard() returns team dicts in descending projected_points order."""
+    draft = _make_started_draft()
+    leaderboard = draft.get_leaderboard()  # returns List[Dict]
+    assert len(leaderboard) == len(draft.teams)
+    for i in range(len(leaderboard) - 1):
+        pts_a = leaderboard[i]["projected_points"]
+        pts_b = leaderboard[i + 1]["projected_points"]
+        assert pts_a >= pts_b

--- a/tests/property/test_draft_setup_properties.py
+++ b/tests/property/test_draft_setup_properties.py
@@ -1,0 +1,168 @@
+"""Property-based tests: DraftSetup — bidirectionality and participant invariants.
+
+Track F — Issue #330
+
+Sprint 10 · sprint/10 branch
+"""
+
+from __future__ import annotations
+
+from hypothesis import given, settings
+from hypothesis import strategies as st
+
+from classes.draft_setup import DraftSetup
+from tests.property.conftest import _ALPHANUM, _LETTERS_SPACE
+
+
+# ---------------------------------------------------------------------------
+# Composite strategy for participant dicts
+# ---------------------------------------------------------------------------
+
+@st.composite
+def participant_dict(draw, owner_id: str | None = None) -> dict:
+    oid = owner_id or draw(st.text(min_size=1, max_size=16, alphabet=_ALPHANUM))
+    name = draw(
+        st.text(min_size=1, max_size=40, alphabet=_LETTERS_SPACE).filter(
+            lambda n: n.strip() != ""
+        )
+    )
+    team_name = draw(
+        st.text(min_size=1, max_size=40, alphabet=_LETTERS_SPACE).filter(
+            lambda n: n.strip() != ""
+        )
+    )
+    return {"owner_id": oid, "owner_name": name, "team_name": team_name}
+
+
+@st.composite
+def participant_list(draw, min_size: int = 2, max_size: int = 8) -> list[dict]:
+    n = draw(st.integers(min_value=min_size, max_value=max_size))
+    ids = draw(
+        st.lists(
+            st.text(min_size=1, max_size=16, alphabet=_ALPHANUM),
+            min_size=n,
+            max_size=n,
+            unique=True,
+        )
+    )
+    parts = []
+    for oid in ids:
+        parts.append(draw(participant_dict(owner_id=oid)))
+    return parts
+
+
+# ---------------------------------------------------------------------------
+# Property 1 — create_owner_with_team establishes bidirectionality
+# ---------------------------------------------------------------------------
+
+@given(
+    owner_id=st.text(min_size=1, max_size=16, alphabet=_ALPHANUM),
+    budget=st.floats(min_value=10.0, max_value=500.0, allow_nan=False, allow_infinity=False),
+)
+@settings(max_examples=50)
+def test_create_owner_with_team_bidirectionality(owner_id, budget):
+    """After create_owner_with_team, owner.get_team() is the created team."""
+    owner, team = DraftSetup.create_owner_with_team(
+        owner_id=owner_id,
+        owner_name="Test Owner",
+        team_name="Test Team",
+        budget=budget,
+    )
+
+    assert owner.get_team() is team
+    assert owner.has_team() is True
+    assert team.owner_id == owner.owner_id
+
+
+# ---------------------------------------------------------------------------
+# Property 2 — all teams initialized with the given budget
+# ---------------------------------------------------------------------------
+
+@given(
+    n_participants=st.integers(min_value=2, max_value=8),
+    budget=st.integers(min_value=10, max_value=500),
+)
+@settings(max_examples=50)
+def test_all_teams_get_same_budget(n_participants, budget):
+    """Every team in the returned draft has budget == budget_per_team.
+
+    Team.budget is stored as int, so we use integer budgets here to
+    avoid implicit truncation masking the actual budget value.
+    """
+    participants = [
+        {"owner_id": f"o{i}", "owner_name": f"Owner {i}", "team_name": f"Team {i}"}
+        for i in range(n_participants)
+    ]
+    draft = DraftSetup.setup_draft_with_participants(
+        draft_name="test",
+        participants=participants,
+        budget_per_team=float(budget),
+    )
+
+    for team in draft.teams:
+        assert team.budget == budget
+        assert team.initial_budget == budget
+
+
+# ---------------------------------------------------------------------------
+# Property 3 — no duplicate owner_ids in the returned draft
+# ---------------------------------------------------------------------------
+
+@given(n_participants=st.integers(min_value=2, max_value=10))
+@settings(max_examples=50)
+def test_no_duplicate_owner_ids(n_participants):
+    """setup_draft_with_participants never produces duplicate owner_ids."""
+    participants = [
+        {"owner_id": f"owner_{i}", "owner_name": f"Name {i}", "team_name": f"Team {i}"}
+        for i in range(n_participants)
+    ]
+    draft = DraftSetup.setup_draft_with_participants(
+        draft_name="test",
+        participants=participants,
+    )
+
+    owner_ids = [o.owner_id for o in draft.owners]
+    assert len(owner_ids) == len(set(owner_ids))
+
+
+# ---------------------------------------------------------------------------
+# Property 4 — owner_id matches between owner and team for every participant
+# ---------------------------------------------------------------------------
+
+@given(n_participants=st.integers(min_value=2, max_value=8))
+@settings(max_examples=50)
+def test_owner_team_id_consistency(n_participants):
+    """For every owner in the draft, the linked team has matching owner_id."""
+    participants = [
+        {"owner_id": f"owner_{i}", "owner_name": f"Name {i}", "team_name": f"Team {i}"}
+        for i in range(n_participants)
+    ]
+    draft = DraftSetup.setup_draft_with_participants(
+        draft_name="test",
+        participants=participants,
+    )
+
+    for owner in draft.owners:
+        if owner.has_team():
+            assert owner.get_team().owner_id == owner.owner_id
+
+
+# ---------------------------------------------------------------------------
+# Property 5 — budget preserved through create_owner_with_team round-trip
+# ---------------------------------------------------------------------------
+
+@given(
+    owner_id=st.text(min_size=1, max_size=16, alphabet=_ALPHANUM),
+    budget=st.integers(min_value=10, max_value=1000),
+)
+@settings(max_examples=50)
+def test_budget_preserved(owner_id, budget):
+    """The team returned by create_owner_with_team has budget == supplied budget."""
+    owner, team = DraftSetup.create_owner_with_team(
+        owner_id=owner_id,
+        owner_name="Owner",
+        team_name="Team",
+        budget=float(budget),
+    )
+    assert team.budget == float(budget)
+    assert team.initial_budget == float(budget)

--- a/tests/property/test_owner_properties.py
+++ b/tests/property/test_owner_properties.py
@@ -1,0 +1,143 @@
+"""Property-based tests: Owner class invariants.
+
+Track F — Issue #327
+
+Sprint 10 · sprint/10 branch
+"""
+
+from __future__ import annotations
+
+from hypothesis import given, settings
+from hypothesis import strategies as st
+
+from classes.owner import Owner
+from tests.property.conftest import draft_team, _ALPHANUM, _LETTERS_SPACE
+
+
+# ---------------------------------------------------------------------------
+# Composite strategy for Owner instances
+# ---------------------------------------------------------------------------
+
+@st.composite
+def draft_owner(draw, owner_id: str | None = None) -> Owner:
+    """Generate a valid Owner with a random id and name."""
+    oid = owner_id or draw(st.text(min_size=1, max_size=20, alphabet=_ALPHANUM))
+    name = draw(
+        st.text(min_size=1, max_size=40, alphabet=_LETTERS_SPACE).filter(
+            lambda n: n.strip() != ""
+        )
+    )
+    return Owner(owner_id=oid, name=name)
+
+
+# ---------------------------------------------------------------------------
+# Property 1 — target player deduplication
+# ---------------------------------------------------------------------------
+
+@given(owner=draft_owner(), player_id=st.text(min_size=1, max_size=20, alphabet=_ALPHANUM))
+@settings(max_examples=50)
+def test_add_target_player_deduplication(owner, player_id):
+    """Adding the same player_id twice yields exactly one entry in target_players."""
+    owner.add_target_player(player_id)
+    owner.add_target_player(player_id)
+
+    targets = owner.preferences["target_players"]
+    assert targets.count(player_id) == 1
+
+
+# ---------------------------------------------------------------------------
+# Property 2 — avoid player deduplication
+# ---------------------------------------------------------------------------
+
+@given(owner=draft_owner(), player_id=st.text(min_size=1, max_size=20, alphabet=_ALPHANUM))
+@settings(max_examples=50)
+def test_add_avoid_player_deduplication(owner, player_id):
+    """Adding the same player_id twice yields exactly one entry in avoid_players."""
+    owner.add_avoid_player(player_id)
+    owner.add_avoid_player(player_id)
+
+    avoids = owner.preferences["avoid_players"]
+    assert avoids.count(player_id) == 1
+
+
+# ---------------------------------------------------------------------------
+# Property 3 — risk tolerance bounds
+# ---------------------------------------------------------------------------
+
+@given(
+    owner=draft_owner(),
+    risk=st.floats(min_value=0.0, max_value=1.0, allow_nan=False, allow_infinity=False),
+)
+@settings(max_examples=50)
+def test_risk_tolerance_bounds(owner, risk):
+    """get_risk_tolerance() always returns a value in [0.0, 1.0] after update."""
+    owner.update_preferences(risk_tolerance=risk)
+    result = owner.get_risk_tolerance()
+    assert 0.0 <= result <= 1.0
+
+
+# ---------------------------------------------------------------------------
+# Property 4 — draft history append-only
+# ---------------------------------------------------------------------------
+
+@given(
+    owner=draft_owner(),
+    n_actions=st.integers(min_value=1, max_value=20),
+)
+@settings(max_examples=50)
+def test_draft_history_append_only(owner, n_actions):
+    """Each add_draft_action() appends exactly one entry; history never shrinks."""
+    for i in range(n_actions):
+        before = len(owner.draft_history)
+        owner.add_draft_action({"action": "bid", "round": i})
+        assert len(owner.draft_history) == before + 1
+
+
+# ---------------------------------------------------------------------------
+# Property 5 — owner↔team bidirectionality
+# ---------------------------------------------------------------------------
+
+@given(owner=draft_owner(), team=draft_team())
+@settings(max_examples=50)
+def test_assign_team_bidirectionality(owner, team):
+    """After assign_team(t), owner.get_team() is t."""
+    owner.assign_team(team)
+
+    assert owner.get_team() is team
+    assert owner.has_team() is True
+
+
+# ---------------------------------------------------------------------------
+# Property 6 — preference persistence across multiple reads
+# ---------------------------------------------------------------------------
+
+@given(
+    owner=draft_owner(),
+    max_bid_pct=st.floats(min_value=0.0, max_value=1.0, allow_nan=False, allow_infinity=False),
+    n_reads=st.integers(min_value=2, max_value=10),
+)
+@settings(max_examples=50)
+def test_preference_persistence(owner, max_bid_pct, n_reads):
+    """update_preferences(max_bid_percentage=v) survives multiple reads."""
+    owner.update_preferences(max_bid_percentage=max_bid_pct)
+    for _ in range(n_reads):
+        assert owner.get_max_bid_percentage() == max_bid_pct
+
+
+# ---------------------------------------------------------------------------
+# Property 7 — target/avoid lists are mutually independent
+# ---------------------------------------------------------------------------
+
+@given(
+    owner=draft_owner(),
+    player_id=st.text(min_size=1, max_size=20, alphabet=_ALPHANUM),
+)
+@settings(max_examples=50)
+def test_target_avoid_independence(owner, player_id):
+    """Adding a player to targets does not add them to avoids, and vice versa."""
+    owner.add_target_player(player_id)
+    assert not owner.is_avoid_player(player_id)
+
+    owner2 = Owner(owner_id="o2", name="Other")
+    owner2.add_avoid_player(player_id)
+    assert not owner2.is_target_player(player_id)

--- a/tests/property/test_path_utils_properties.py
+++ b/tests/property/test_path_utils_properties.py
@@ -1,0 +1,125 @@
+"""Property tests for utils/path_utils.py — path safety invariants (#343).
+
+Tests:
+- get_project_root() returns an existing Path
+- get_data_dir(), get_config_dir(), get_results_dir() are all under project root
+- get_data_file() raises ValueError for path traversal attempts
+- get_data_file() strips a leading 'data/' prefix so result is same as without
+- safe_file_path() raises ValueError for paths escaping project root
+"""
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+from hypothesis import given, settings
+from hypothesis import strategies as st
+
+from utils.path_utils import (
+    get_project_root,
+    get_data_dir,
+    get_config_dir,
+    get_results_dir,
+    get_data_file,
+    safe_file_path,
+)
+
+_ROOT = get_project_root().resolve()
+_DATA = get_data_dir().resolve()
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _safe_filename(fname: str) -> bool:
+    """Return True if the filename is a simple safe name (no path traversal)."""
+    try:
+        p = Path(fname)
+        parts = p.parts
+        if not parts:
+            return False
+        return not any(part in ("..", ".") or "/" in part or "\\" in part for part in parts)
+    except Exception:
+        return False
+
+
+# ---------------------------------------------------------------------------
+# Tests — project layout invariants
+# ---------------------------------------------------------------------------
+
+@given(st.just(None))
+@settings(max_examples=1)
+def test_project_root_exists(_):
+    """get_project_root() returns a Path that exists on disk."""
+    root = get_project_root()
+    assert isinstance(root, Path)
+    assert root.exists()
+
+
+@given(st.just(None))
+@settings(max_examples=1)
+def test_data_dir_under_project_root(_):
+    """get_data_dir() resolves to a path inside the project root."""
+    data = get_data_dir().resolve()
+    assert str(data).startswith(str(_ROOT))
+
+
+@given(st.just(None))
+@settings(max_examples=1)
+def test_config_dir_under_project_root(_):
+    """get_config_dir() resolves to a path inside the project root."""
+    cfg = get_config_dir().resolve()
+    assert str(cfg).startswith(str(_ROOT))
+
+
+@given(st.just(None))
+@settings(max_examples=1)
+def test_results_dir_under_project_root(_):
+    """get_results_dir() resolves to a path inside the project root."""
+    res = get_results_dir().resolve()
+    assert str(res).startswith(str(_ROOT))
+
+
+# ---------------------------------------------------------------------------
+# Tests — get_data_file path traversal protection
+# ---------------------------------------------------------------------------
+
+@given(
+    prefix=st.sampled_from(["../", "../../", "../etc/", "../../etc/passwd"]),
+    suffix=st.text(min_size=1, max_size=20, alphabet="abcdefghijklmnopqrstuvwxyz_"),
+)
+@settings(max_examples=30)
+def test_get_data_file_traversal_raises_value_error(prefix, suffix):
+    """get_data_file() with any '../' traversal component raises ValueError."""
+    with pytest.raises(ValueError, match="Path traversal"):
+        get_data_file(prefix + suffix)
+
+
+@given(
+    filename=st.text(min_size=1, max_size=30, alphabet="abcdefghijklmnopqrstuvwxyz0123456789._"),
+)
+@settings(max_examples=30)
+def test_get_data_file_strips_data_prefix(filename):
+    """get_data_file('data/X') and get_data_file('X') resolve to the same path."""
+    bare = get_data_file(filename)
+    with_prefix = get_data_file("data/" + filename)
+    assert bare == with_prefix
+
+
+# ---------------------------------------------------------------------------
+# Tests — safe_file_path traversal protection
+# ---------------------------------------------------------------------------
+
+@given(
+    escape_path=st.sampled_from([
+        "/etc/passwd",
+        "/tmp/evil",
+        "/root/.ssh/id_rsa",
+    ]),
+)
+@settings(max_examples=3)
+def test_safe_file_path_absolute_outside_root_raises(escape_path):
+    """safe_file_path() raises ValueError for absolute paths outside project root."""
+    with pytest.raises(ValueError, match="Path traversal"):
+        safe_file_path(escape_path)

--- a/tests/property/test_placeholder.py
+++ b/tests/property/test_placeholder.py
@@ -1,0 +1,40 @@
+"""CI integration smoke test for the property test infrastructure.
+
+This test must pass before any Track B–E stubs are implemented.
+It confirms that:
+  - hypothesis is importable
+  - the conftest composite strategies generate valid objects
+  - pytest discovers tests/property/ correctly
+"""
+
+from hypothesis import given, settings
+
+from tests.property.conftest import draft_player, draft_team, draft_state
+
+
+@given(player=draft_player())
+@settings(max_examples=10)
+def test_draft_player_strategy_produces_valid_player(player):
+    """draft_player() always produces a Player with required fields."""
+    assert player.player_id
+    assert player.name.strip()
+    assert player.position in ("QB", "RB", "WR", "TE", "K", "DST")
+    assert player.projected_points >= 0.0
+    assert player.auction_value >= 0.0
+
+
+@given(team=draft_team())
+@settings(max_examples=10)
+def test_draft_team_strategy_produces_valid_team(team):
+    """draft_team() always produces a Team with non-negative budget and empty roster."""
+    assert team.budget >= 10
+    assert len(team.roster) == 0
+
+
+@given(state=draft_state())
+@settings(max_examples=5)
+def test_draft_state_strategy_produces_valid_state(state):
+    """draft_state() always produces a (teams, players) tuple with consistent sizes."""
+    teams, players = state
+    assert len(teams) >= 2
+    assert len(players) >= len(teams)

--- a/tests/property/test_recommend_schema_properties.py
+++ b/tests/property/test_recommend_schema_properties.py
@@ -1,0 +1,175 @@
+"""Property tests for api/schemas/recommend.py — Pydantic DTO invariants (#340).
+
+Tests:
+- BidRecommendationRequest: valid inputs always construct successfully
+- BidRecommendationRequest: current_bid < 0 raises ValidationError
+- BidRecommendationRequest: team_budget < 0 raises ValidationError
+- BidRecommendationRequest: roster_spots_remaining < 1 raises ValidationError
+- BidRecommendationRequest: model_dump() round-trip preserves all fields
+- BidRecommendationResponse: confidence in [0, 1] always constructs successfully
+- BidRecommendationResponse: confidence outside [0, 1] raises ValidationError
+- BidRecommendationResponse: recommended_bid is stored exactly
+"""
+from __future__ import annotations
+
+import pytest
+from hypothesis import given, settings
+from hypothesis import strategies as st
+from pydantic import ValidationError
+
+from api.schemas.recommend import BidRecommendationRequest, BidRecommendationResponse
+
+
+# ---------------------------------------------------------------------------
+# BidRecommendationRequest — valid construction
+# ---------------------------------------------------------------------------
+
+@given(
+    player_name=st.text(min_size=1, max_size=100),
+    current_bid=st.floats(min_value=0.0, max_value=10000.0, allow_nan=False, allow_infinity=False),
+    team_budget=st.floats(min_value=0.0, max_value=10000.0, allow_nan=False, allow_infinity=False),
+    roster_spots=st.integers(min_value=1, max_value=50),
+)
+@settings(max_examples=50)
+def test_request_valid_inputs_construct_successfully(player_name, current_bid, team_budget, roster_spots):
+    """BidRecommendationRequest with valid fields always constructs without error."""
+    req = BidRecommendationRequest(
+        player_name=player_name,
+        current_bid=current_bid,
+        team_budget=team_budget,
+        roster_spots_remaining=roster_spots,
+    )
+    assert req.player_name == player_name
+    assert req.current_bid == current_bid
+    assert req.team_budget == team_budget
+    assert req.roster_spots_remaining == roster_spots
+
+
+# ---------------------------------------------------------------------------
+# BidRecommendationRequest — invalid inputs rejected
+# ---------------------------------------------------------------------------
+
+@given(
+    player_name=st.text(min_size=1, max_size=50),
+    current_bid=st.floats(max_value=-0.001, allow_nan=False, allow_infinity=False),
+    team_budget=st.floats(min_value=0.0, max_value=1000.0, allow_nan=False, allow_infinity=False),
+)
+@settings(max_examples=30)
+def test_request_negative_current_bid_rejected(player_name, current_bid, team_budget):
+    """current_bid < 0 must raise ValidationError."""
+    with pytest.raises(ValidationError):
+        BidRecommendationRequest(
+            player_name=player_name,
+            current_bid=current_bid,
+            team_budget=team_budget,
+        )
+
+
+@given(
+    player_name=st.text(min_size=1, max_size=50),
+    current_bid=st.floats(min_value=0.0, max_value=1000.0, allow_nan=False, allow_infinity=False),
+    team_budget=st.floats(max_value=-0.001, allow_nan=False, allow_infinity=False),
+)
+@settings(max_examples=30)
+def test_request_negative_team_budget_rejected(player_name, current_bid, team_budget):
+    """team_budget < 0 must raise ValidationError."""
+    with pytest.raises(ValidationError):
+        BidRecommendationRequest(
+            player_name=player_name,
+            current_bid=current_bid,
+            team_budget=team_budget,
+        )
+
+
+@given(
+    player_name=st.text(min_size=1, max_size=50),
+    roster_spots=st.integers(max_value=0),
+)
+@settings(max_examples=30)
+def test_request_zero_or_negative_roster_spots_rejected(player_name, roster_spots):
+    """roster_spots_remaining < 1 must raise ValidationError."""
+    with pytest.raises(ValidationError):
+        BidRecommendationRequest(
+            player_name=player_name,
+            current_bid=0.0,
+            team_budget=100.0,
+            roster_spots_remaining=roster_spots,
+        )
+
+
+@given(
+    player_name=st.just(""),
+)
+@settings(max_examples=5)
+def test_request_empty_player_name_rejected(player_name):
+    """Empty player_name (min_length=1) must raise ValidationError."""
+    with pytest.raises(ValidationError):
+        BidRecommendationRequest(
+            player_name=player_name,
+            current_bid=0.0,
+            team_budget=100.0,
+        )
+
+
+# ---------------------------------------------------------------------------
+# BidRecommendationRequest — round-trip
+# ---------------------------------------------------------------------------
+
+@given(
+    player_name=st.text(min_size=1, max_size=50),
+    current_bid=st.floats(min_value=0.0, max_value=500.0, allow_nan=False, allow_infinity=False),
+    team_budget=st.floats(min_value=0.0, max_value=500.0, allow_nan=False, allow_infinity=False),
+    roster_spots=st.integers(min_value=1, max_value=20),
+)
+@settings(max_examples=30)
+def test_request_model_dump_round_trip(player_name, current_bid, team_budget, roster_spots):
+    """model.model_dump() → BidRecommendationRequest(**dict) preserves all fields."""
+    original = BidRecommendationRequest(
+        player_name=player_name,
+        current_bid=current_bid,
+        team_budget=team_budget,
+        roster_spots_remaining=roster_spots,
+    )
+    reconstructed = BidRecommendationRequest(**original.model_dump())
+    assert reconstructed.player_name == original.player_name
+    assert reconstructed.current_bid == original.current_bid
+    assert reconstructed.team_budget == original.team_budget
+    assert reconstructed.roster_spots_remaining == original.roster_spots_remaining
+
+
+# ---------------------------------------------------------------------------
+# BidRecommendationResponse — valid confidence range
+# ---------------------------------------------------------------------------
+
+@given(
+    recommended_bid=st.floats(min_value=0.0, max_value=500.0, allow_nan=False, allow_infinity=False),
+    confidence=st.floats(min_value=0.0, max_value=1.0, allow_nan=False, allow_infinity=False),
+    rationale=st.text(min_size=1, max_size=200),
+)
+@settings(max_examples=50)
+def test_response_valid_confidence_constructs(recommended_bid, confidence, rationale):
+    """BidRecommendationResponse with confidence in [0, 1] always constructs."""
+    resp = BidRecommendationResponse(
+        recommended_bid=recommended_bid,
+        confidence=confidence,
+        rationale=rationale,
+    )
+    assert resp.recommended_bid == recommended_bid
+    assert resp.confidence == confidence
+
+
+@given(
+    confidence=st.one_of(
+        st.floats(max_value=-0.001, allow_nan=False, allow_infinity=False),
+        st.floats(min_value=1.001, max_value=1e6, allow_nan=False, allow_infinity=False),
+    )
+)
+@settings(max_examples=30)
+def test_response_confidence_outside_unit_interval_rejected(confidence):
+    """confidence outside [0, 1] must raise ValidationError."""
+    with pytest.raises(ValidationError):
+        BidRecommendationResponse(
+            recommended_bid=10.0,
+            confidence=confidence,
+            rationale="test",
+        )

--- a/tests/property/test_sigmoid_strategy_properties.py
+++ b/tests/property/test_sigmoid_strategy_properties.py
@@ -1,0 +1,169 @@
+"""Property tests for strategies/sigmoid_strategy.py — output bounds (#334).
+
+Tests:
+- _sigmoid(x) always returns a value in [0.0, 1.0]
+- _sigmoid is monotone increasing (larger x → larger output)
+- _calculate_draft_progress always returns a float in [0.0, 1.0]
+- _calculate_budget_pressure always returns a float in [0.0, 1.0]
+- All default parameters are positive
+- calculate_bid always returns a numeric value
+- should_nominate always returns a bool
+"""
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+from hypothesis import given, settings
+from hypothesis import strategies as st
+
+from tests.property.conftest import draft_player
+from strategies.sigmoid_strategy import SigmoidStrategy
+
+_ROSTER_CONFIG = {"QB": 1, "RB": 2, "WR": 2, "TE": 1, "K": 1, "DST": 1}
+
+
+# ---------------------------------------------------------------------------
+# Shared mock helpers
+# ---------------------------------------------------------------------------
+
+def _make_team(remaining_budget: float = 100.0) -> MagicMock:
+    """Minimal team mock for SigmoidStrategy calls."""
+    team = MagicMock()
+    # Must be real dicts so sum() / .get() work correctly
+    team.roster_config = dict(_ROSTER_CONFIG)
+    team.roster_requirements = dict(_ROSTER_CONFIG)
+    team.roster = []
+    team.initial_budget = max(1, int(remaining_budget))
+    team.budget = max(1, int(remaining_budget))
+    team.get_needs.return_value = {"QB": 1, "RB": 2}
+    team.enforce_budget_constraint.side_effect = lambda bid, budget: min(bid, budget)
+    team.calculate_minimum_budget_needed.return_value = 0.0
+    team.get_remaining_roster_slots.return_value = 8
+    team.calculate_position_priority.return_value = 0.8
+    return team
+
+
+def _make_owner() -> MagicMock:
+    owner = MagicMock()
+    owner.get_risk_tolerance.return_value = 0.7
+    owner.is_target_player.return_value = False
+    return owner
+
+
+# ---------------------------------------------------------------------------
+# Tests — _sigmoid output bounds
+# ---------------------------------------------------------------------------
+
+@given(
+    x=st.floats(min_value=-20.0, max_value=20.0, allow_nan=False, allow_infinity=False),
+)
+@settings(max_examples=100)
+def test_sigmoid_output_in_unit_interval(x):
+    """_sigmoid(x) always returns a value in [0.0, 1.0]."""
+    s = SigmoidStrategy()
+    result = s._sigmoid(x)
+    assert 0.0 <= result <= 1.0
+
+
+@given(
+    x1=st.floats(min_value=-10.0, max_value=10.0, allow_nan=False, allow_infinity=False),
+    delta=st.floats(min_value=0.01, max_value=5.0, allow_nan=False, allow_infinity=False),
+)
+@settings(max_examples=100)
+def test_sigmoid_is_monotone_increasing(x1, delta):
+    """_sigmoid(x1 + delta) >= _sigmoid(x1) for any positive delta (monotone)."""
+    s = SigmoidStrategy()
+    x2 = x1 + delta
+    assert s._sigmoid(x2) >= s._sigmoid(x1)
+
+
+# ---------------------------------------------------------------------------
+# Tests — _calculate_draft_progress bounds
+# ---------------------------------------------------------------------------
+
+@given(
+    n_players=st.integers(min_value=0, max_value=200),
+    high_value_count=st.integers(min_value=0, max_value=50),
+)
+@settings(max_examples=50)
+def test_calculate_draft_progress_in_unit_interval(n_players, high_value_count):
+    """_calculate_draft_progress always returns a float in [0.0, 1.0]."""
+    s = SigmoidStrategy()
+    # Build a simple list of mock players, some with auction_value > 15
+    players = []
+    for i in range(n_players):
+        p = MagicMock()
+        p.auction_value = 20.0 if i < high_value_count else 5.0
+        players.append(p)
+    result = s._calculate_draft_progress(players)
+    assert 0.0 <= result <= 1.0
+
+
+# ---------------------------------------------------------------------------
+# Tests — _calculate_budget_pressure bounds
+# ---------------------------------------------------------------------------
+
+@given(
+    remaining_budget=st.floats(min_value=0.0, max_value=500.0, allow_nan=False, allow_infinity=False),
+)
+@settings(max_examples=50)
+def test_calculate_budget_pressure_in_unit_interval(remaining_budget):
+    """_calculate_budget_pressure always returns a float in [0.0, 1.0]."""
+    s = SigmoidStrategy()
+    team = _make_team(remaining_budget=max(remaining_budget, 1.0))
+    result = s._calculate_budget_pressure(remaining_budget, team)
+    assert 0.0 <= result <= 1.0
+
+
+# ---------------------------------------------------------------------------
+# Tests — default parameters
+# ---------------------------------------------------------------------------
+
+@given(st.just(None))
+@settings(max_examples=1)
+def test_default_parameters_all_positive(_):
+    """All default parameters in SigmoidStrategy are strictly positive."""
+    s = SigmoidStrategy()
+    for name, value in s.parameters.items():
+        assert value > 0, f"parameters[{name!r}] = {value} is not positive"
+
+
+# ---------------------------------------------------------------------------
+# Tests — calculate_bid and should_nominate
+# ---------------------------------------------------------------------------
+
+@given(
+    player=draft_player(),
+    remaining_budget=st.floats(min_value=20.0, max_value=500.0, allow_nan=False, allow_infinity=False),
+    current_bid=st.floats(min_value=0.0, max_value=30.0, allow_nan=False, allow_infinity=False),
+)
+@settings(max_examples=50, deadline=None)
+def test_calculate_bid_returns_numeric(player, remaining_budget, current_bid):
+    """calculate_bid always returns an int or float (never raises, never NaN)."""
+    s = SigmoidStrategy()
+    team = _make_team(remaining_budget=remaining_budget)
+    result = s.calculate_bid(
+        player=player,
+        team=team,
+        owner=_make_owner(),
+        current_bid=current_bid,
+        remaining_budget=remaining_budget,
+        remaining_players=[],
+    )
+    assert isinstance(result, (int, float))
+    assert result == result  # NaN check
+
+
+@given(player=draft_player())
+@settings(max_examples=50, deadline=None)
+def test_should_nominate_returns_bool(player):
+    """should_nominate always returns a bool (True or False, never raises)."""
+    s = SigmoidStrategy()
+    team = _make_team()
+    result = s.should_nominate(
+        player=player,
+        team=team,
+        owner=_make_owner(),
+        remaining_budget=100.0,
+    )
+    assert isinstance(result, bool)

--- a/tests/property/test_simulation_runner_properties.py
+++ b/tests/property/test_simulation_runner_properties.py
@@ -1,0 +1,118 @@
+"""Property tests for lab/simulation/runner.py — SimulationRunner invariants (#344).
+
+Tests:
+- SimulationRunner stores all constructor args correctly
+- experiment_id is auto-generated (non-empty string) when not provided
+- experiment_id is used exactly when provided
+- _git_sha() always returns a string
+- Gate invariant: win_rate >= 1/(num_opponents+1) ↔ gate_result == 'PASS'
+"""
+from __future__ import annotations
+
+from hypothesis import given, settings
+from hypothesis import strategies as st
+
+from lab.simulation.runner import SimulationRunner, _git_sha
+
+
+# ---------------------------------------------------------------------------
+# Tests — constructor parameter storage
+# ---------------------------------------------------------------------------
+
+@given(
+    runs=st.integers(min_value=1, max_value=500),
+    budget=st.floats(min_value=50.0, max_value=1000.0, allow_nan=False, allow_infinity=False),
+    roster_size=st.integers(min_value=4, max_value=30),
+    num_opponents=st.integers(min_value=1, max_value=20),
+)
+@settings(max_examples=30)
+def test_constructor_stores_params_correctly(runs, budget, roster_size, num_opponents):
+    """All numeric constructor args are stored exactly on the instance."""
+    runner = SimulationRunner(
+        strategies=["balanced"],
+        runs=runs,
+        budget=budget,
+        roster_size=roster_size,
+        num_opponents=num_opponents,
+    )
+    assert runner.runs == runs
+    assert runner.budget == budget
+    assert runner.roster_size == roster_size
+    assert runner.num_opponents == num_opponents
+
+
+@given(st.just(None))
+@settings(max_examples=5)
+def test_experiment_id_auto_generated(_):
+    """experiment_id is non-empty string when not explicitly provided."""
+    runner = SimulationRunner()
+    assert isinstance(runner.experiment_id, str)
+    assert len(runner.experiment_id) > 0
+
+
+@given(
+    exp_id=st.text(min_size=1, max_size=64),
+)
+@settings(max_examples=20)
+def test_experiment_id_preserved_when_provided(exp_id):
+    """experiment_id is stored exactly when explicitly provided."""
+    runner = SimulationRunner(experiment_id=exp_id)
+    assert runner.experiment_id == exp_id
+
+
+@given(st.just(None))
+@settings(max_examples=3)
+def test_two_runners_have_different_auto_ids(_):
+    """Two SimulationRunner instances auto-generate distinct experiment_ids."""
+    r1 = SimulationRunner()
+    r2 = SimulationRunner()
+    assert r1.experiment_id != r2.experiment_id
+
+
+# ---------------------------------------------------------------------------
+# Tests — _git_sha()
+# ---------------------------------------------------------------------------
+
+@given(st.just(None))
+@settings(max_examples=3)
+def test_git_sha_returns_string(_):
+    """_git_sha() always returns a string (either a commit SHA or 'unknown')."""
+    result = _git_sha()
+    assert isinstance(result, str)
+    assert len(result) > 0
+
+
+# ---------------------------------------------------------------------------
+# Tests — gate_result invariant
+# ---------------------------------------------------------------------------
+
+@given(
+    win_rate=st.floats(min_value=0.0, max_value=1.0, allow_nan=False, allow_infinity=False),
+    num_opponents=st.integers(min_value=1, max_value=20),
+)
+@settings(max_examples=100)
+def test_gate_result_pass_iff_win_rate_meets_threshold(win_rate, num_opponents):
+    """gate_result == 'PASS' if and only if win_rate >= 1/(num_opponents+1)."""
+    num_teams = num_opponents + 1
+    expected_win_rate = 1.0 / num_teams
+    gate_result = "PASS" if win_rate >= expected_win_rate else "FAIL"
+    
+    # Verify the invariant holds
+    if win_rate >= expected_win_rate:
+        assert gate_result == "PASS"
+    else:
+        assert gate_result == "FAIL"
+    
+    # Verify PASS and FAIL are mutually exclusive and exhaustive
+    assert gate_result in ("PASS", "FAIL")
+
+
+@given(
+    num_opponents=st.integers(min_value=1, max_value=20),
+)
+@settings(max_examples=30)
+def test_gate_threshold_decreases_with_more_opponents(num_opponents):
+    """The win-rate threshold to PASS decreases as more opponents are added."""
+    threshold_small = 1.0 / (num_opponents + 1)
+    threshold_large = 1.0 / (num_opponents + 2)
+    assert threshold_large < threshold_small

--- a/tests/property/test_sleeper_cache_properties.py
+++ b/tests/property/test_sleeper_cache_properties.py
@@ -1,0 +1,94 @@
+"""Property tests for utils/sleeper_cache.py — cache metadata invariants (#341).
+
+Tests:
+- SleeperPlayerCache stores cache_hours correctly for any value
+- _is_cache_valid() returns False when no cache file exists
+- _get_cache_metadata() always returns a dict with the required keys
+- Cache metadata keys are always present regardless of file existence
+"""
+from __future__ import annotations
+
+import tempfile
+from pathlib import Path
+
+from hypothesis import given, settings
+from hypothesis import strategies as st
+
+from utils.sleeper_cache import SleeperPlayerCache
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _make_cache(cache_hours: int = 24) -> SleeperPlayerCache:
+    """Create a SleeperPlayerCache that uses a fresh temp directory."""
+    return SleeperPlayerCache(cache_hours=cache_hours)
+
+
+_REQUIRED_METADATA_KEYS = {"last_updated", "player_count", "cache_version"}
+
+
+# ---------------------------------------------------------------------------
+# Tests — constructor parameter storage
+# ---------------------------------------------------------------------------
+
+@given(
+    cache_hours=st.integers(min_value=1, max_value=8760),  # 1 hour to 1 year
+)
+@settings(max_examples=30)
+def test_cache_hours_stored_correctly(cache_hours):
+    """cache_hours argument is stored exactly on the instance."""
+    cache = SleeperPlayerCache(cache_hours=cache_hours)
+    assert cache.cache_hours == cache_hours
+
+
+# ---------------------------------------------------------------------------
+# Tests — _is_cache_valid() returns False when no file
+# ---------------------------------------------------------------------------
+
+@given(
+    cache_hours=st.integers(min_value=1, max_value=168),
+)
+@settings(max_examples=20)
+def test_is_cache_valid_false_when_no_file(cache_hours):
+    """_is_cache_valid() must return False when the cache file does not exist."""
+    cache = SleeperPlayerCache(cache_hours=cache_hours)
+    # Redirect to a non-existent temp location
+    with tempfile.TemporaryDirectory() as tmpdir:
+        cache.cache_file = Path(tmpdir) / "nonexistent_players.json"
+        cache.meta_file = Path(tmpdir) / "nonexistent_meta.json"
+        cache._meta_cache = None  # reset in-memory cache
+        assert cache._is_cache_valid() is False
+
+
+# ---------------------------------------------------------------------------
+# Tests — _get_cache_metadata() always returns required keys
+# ---------------------------------------------------------------------------
+
+@given(st.just(None))
+@settings(max_examples=5)
+def test_get_cache_metadata_has_required_keys_no_file(_):
+    """_get_cache_metadata() returns a dict with all required keys when file is absent."""
+    cache = SleeperPlayerCache(cache_hours=24)
+    with tempfile.TemporaryDirectory() as tmpdir:
+        cache.meta_file = Path(tmpdir) / "nonexistent_meta.json"
+        cache._meta_cache = None
+        metadata = cache._get_cache_metadata()
+
+    assert isinstance(metadata, dict)
+    for key in _REQUIRED_METADATA_KEYS:
+        assert key in metadata, f"Missing key {key!r} in metadata"
+
+
+@given(st.just(None))
+@settings(max_examples=5)
+def test_get_cache_metadata_returns_none_last_updated_when_no_file(_):
+    """last_updated is None when there is no existing metadata file."""
+    cache = SleeperPlayerCache(cache_hours=24)
+    with tempfile.TemporaryDirectory() as tmpdir:
+        cache.meta_file = Path(tmpdir) / "nonexistent_meta.json"
+        cache._meta_cache = None
+        metadata = cache._get_cache_metadata()
+
+    assert metadata["last_updated"] is None

--- a/tests/property/test_spending_analyzer_properties.py
+++ b/tests/property/test_spending_analyzer_properties.py
@@ -1,0 +1,120 @@
+"""Property tests for strategies/spending_analyzer.py — efficiency invariants (#335).
+
+The SpendingAnalyzer is a pure-computation script module. Its mathematical
+relationships must hold for any valid inputs:
+
+Tests:
+- budget_usage = (avg_spent / max_budget) * 100 stays in [0, 100]
+- efficiency = typical_players / max(avg_spent, 1) * 100 is always non-negative
+- underspending = max_budget - avg_spent equals the budget surplus
+- After sorting by budget_usage the list is monotone non-decreasing
+- analyze_spending_patterns() runs to completion without raising an exception
+"""
+from __future__ import annotations
+
+import contextlib
+import io
+
+from hypothesis import given, settings
+from hypothesis import strategies as st
+
+from strategies.spending_analyzer import analyze_spending_patterns
+
+
+# ---------------------------------------------------------------------------
+# Tests — mathematical invariants
+# ---------------------------------------------------------------------------
+
+@given(
+    avg_spent=st.integers(min_value=0, max_value=1000),
+    max_budget=st.integers(min_value=1, max_value=1000),
+)
+@settings(max_examples=100)
+def test_budget_usage_in_valid_range(avg_spent, max_budget):
+    """budget_usage = (clamped_spent / max_budget) * 100 is in [0.0, 100.0]."""
+    # avg_spent cannot exceed max_budget in valid data; clamp for the formula check.
+    clamped_spent = min(avg_spent, max_budget)
+    budget_usage = (clamped_spent / max_budget) * 100
+    assert 0.0 <= budget_usage <= 100.0
+
+
+@given(
+    typical_players=st.integers(min_value=0, max_value=30),
+    avg_spent=st.integers(min_value=0, max_value=500),
+)
+@settings(max_examples=100)
+def test_efficiency_always_nonnegative(typical_players, avg_spent):
+    """efficiency = typical_players / max(avg_spent, 1) * 100 is always >= 0."""
+    efficiency = typical_players / max(avg_spent, 1) * 100
+    assert efficiency >= 0.0
+
+
+@given(
+    avg_spent=st.integers(min_value=0, max_value=500),
+    max_budget=st.integers(min_value=0, max_value=500),
+)
+@settings(max_examples=100)
+def test_underspending_is_nonnegative_when_within_budget(avg_spent, max_budget):
+    """underspending = max_budget - avg_spent is non-negative when avg_spent <= max_budget."""
+    clamped_spent = min(avg_spent, max_budget)
+    underspending = max_budget - clamped_spent
+    assert underspending >= 0
+
+
+@given(
+    avg_spent=st.integers(min_value=0, max_value=200),
+    max_budget=st.integers(min_value=1, max_value=200),
+)
+@settings(max_examples=100)
+def test_budget_usage_plus_underspend_equals_max_budget(avg_spent, max_budget):
+    """(budget_usage / 100) * max_budget + underspending == max_budget."""
+    clamped_spent = min(avg_spent, max_budget)
+    budget_usage_pct = (clamped_spent / max_budget) * 100
+    underspending = max_budget - clamped_spent
+    # Reconstruct: (budget_usage_pct / 100) * max_budget == clamped_spent
+    reconstructed = (budget_usage_pct / 100) * max_budget
+    assert abs(reconstructed + underspending - max_budget) < 1e-9
+
+
+# ---------------------------------------------------------------------------
+# Tests — sorting invariant
+# ---------------------------------------------------------------------------
+
+@given(
+    entries=st.lists(
+        st.fixed_dictionaries({
+            "avg_spent": st.integers(min_value=1, max_value=200),
+            "max_budget": st.integers(min_value=1, max_value=500),
+        }),
+        min_size=1,
+        max_size=20,
+    )
+)
+@settings(max_examples=50)
+def test_sorting_by_budget_usage_is_monotone_nondecreasing(entries):
+    """After sorting by budget_usage the resulting sequence is monotone non-decreasing."""
+    computed = [
+        {
+            **e,
+            "budget_usage": (min(e["avg_spent"], e["max_budget"]) / e["max_budget"]) * 100,
+        }
+        for e in entries
+    ]
+    sorted_entries = sorted(computed, key=lambda x: x["budget_usage"])
+    for i in range(len(sorted_entries) - 1):
+        assert sorted_entries[i]["budget_usage"] <= sorted_entries[i + 1]["budget_usage"]
+
+
+# ---------------------------------------------------------------------------
+# Tests — function smoke test
+# ---------------------------------------------------------------------------
+
+@given(st.just(None))
+@settings(max_examples=1)
+def test_analyze_spending_patterns_runs_without_error(_):
+    """analyze_spending_patterns() completes without raising any exception."""
+    buf = io.StringIO()
+    with contextlib.redirect_stdout(buf):
+        analyze_spending_patterns()
+    # If we reach here the function ran successfully; output should be non-empty.
+    assert len(buf.getvalue()) > 0

--- a/tests/property/test_strategy_properties.py
+++ b/tests/property/test_strategy_properties.py
@@ -237,7 +237,8 @@ def test_conservative_always_below_value(team, player, remaining_budget):
     from strategies.conservative_strategy import ConservativeStrategy
     from classes.owner import Owner
 
-    assume(player.auction_value > 0)
+    # Minimum bid is $1; invariant only meaningful when auction_value >= $1
+    assume(player.auction_value >= 1.0)
 
     strategy = ConservativeStrategy()
     team.budget = remaining_budget

--- a/tests/property/test_strategy_properties.py
+++ b/tests/property/test_strategy_properties.py
@@ -1,0 +1,281 @@
+"""Property-based tests: strategy bid recommendation invariants.
+
+Track C — Issue #316
+
+Base contract tests are parameterized across all 17 strategies via
+@pytest.mark.parametrize. A single failure identifies the violating strategy.
+
+NOTE on GridironSageStrategy: Instantiated with ``use_mcts=False`` to avoid
+MCTS overhead. The strategy still exercises the bid-calculation code path.
+
+Sprint 10 · sprint/10 branch
+"""
+
+from __future__ import annotations
+
+import pytest
+from hypothesis import assume, given, settings
+from hypothesis import strategies as st
+
+from tests.property.conftest import draft_player, draft_team
+
+# ---------------------------------------------------------------------------
+# Strategy import table
+# ---------------------------------------------------------------------------
+_STRATEGY_REGISTRY: list[tuple[str, str, dict]] = [
+    ("strategies.adaptive_strategy", "AdaptiveStrategy", {}),
+    ("strategies.aggressive_strategy", "AggressiveStrategy", {}),
+    ("strategies.balanced_strategy", "BalancedStrategy", {}),
+    ("strategies.basic_strategy", "BasicStrategy", {}),
+    ("strategies.conservative_strategy", "ConservativeStrategy", {}),
+    ("strategies.elite_hybrid_strategy", "EliteHybridStrategy", {}),
+    ("strategies.enhanced_vor_strategy", "InflationAwareVorStrategy", {}),
+    ("strategies.gridiron_sage_strategy", "GridironSageStrategy", {"use_mcts": False}),
+    ("strategies.hybrid_strategies", "ValueRandomStrategy", {}),
+    ("strategies.improved_value_strategy", "ImprovedValueStrategy", {}),
+    ("strategies.league_strategy", "LeagueStrategy", {}),
+    ("strategies.random_strategy", "RandomStrategy", {}),
+    ("strategies.refined_value_random_strategy", "RefinedValueRandomStrategy", {}),
+    ("strategies.sigmoid_strategy", "SigmoidStrategy", {}),
+    ("strategies.smart_strategy", "SmartStrategy", {}),
+    ("strategies.value_based_strategy", "ValueBasedStrategy", {}),
+    ("strategies.vor_strategy", "VorStrategy", {}),
+]
+
+
+def _load_strategy(module_path: str, class_name: str, kwargs: dict):
+    import importlib
+    module = importlib.import_module(module_path)
+    cls = getattr(module, class_name)
+    return cls(**kwargs)
+
+
+_STRATEGY_PARAMS = [
+    pytest.param(mp, cn, kw, id=cn) for mp, cn, kw in _STRATEGY_REGISTRY
+]
+
+
+# ---------------------------------------------------------------------------
+# Base contract: max_bid_bounded_above
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("module_path,class_name,kwargs", _STRATEGY_PARAMS)
+@given(
+    team=draft_team(),
+    remaining_budget=st.integers(min_value=1, max_value=500),
+)
+@settings(max_examples=50)
+def test_max_bid_bounded_above(module_path, class_name, kwargs, team, remaining_budget):
+    """calculate_max_bid(team, remaining_budget) <= remaining_budget always.
+
+    Invariant:
+        forall strategy, team, remaining_budget >= 1:
+            strategy.calculate_max_bid(team, remaining_budget) <= remaining_budget
+    """
+    strategy = _load_strategy(module_path, class_name, kwargs)
+    team.budget = remaining_budget
+    result = strategy.calculate_max_bid(team, remaining_budget)
+    assert result <= remaining_budget, (
+        f"{class_name}.calculate_max_bid returned {result} > budget {remaining_budget}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Base contract: max_bid_bounded_below
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("module_path,class_name,kwargs", _STRATEGY_PARAMS)
+@given(
+    team=draft_team(),
+    remaining_budget=st.integers(min_value=1, max_value=500),
+)
+@settings(max_examples=50)
+def test_max_bid_bounded_below(module_path, class_name, kwargs, team, remaining_budget):
+    """calculate_max_bid(team, remaining_budget) >= 1 when remaining_budget >= 1.
+
+    Invariant:
+        forall strategy, team, remaining_budget >= 1:
+            strategy.calculate_max_bid(team, remaining_budget) >= 1
+    """
+    strategy = _load_strategy(module_path, class_name, kwargs)
+    team.budget = remaining_budget
+    result = strategy.calculate_max_bid(team, remaining_budget)
+    assert result >= 1, (
+        f"{class_name}.calculate_max_bid returned {result} < 1 for budget {remaining_budget}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Base contract: max_bid_zero_budget
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("module_path,class_name,kwargs", _STRATEGY_PARAMS)
+@given(team=draft_team())
+@settings(max_examples=50)
+def test_max_bid_zero_budget(module_path, class_name, kwargs, team):
+    """calculate_max_bid with remaining_budget == 0 returns 0 or raises; never negative.
+
+    Invariant:
+        forall strategy, team:
+            calculate_max_bid(team, 0) >= 0 or raises ValueError/ZeroDivisionError
+    """
+    strategy = _load_strategy(module_path, class_name, kwargs)
+    team.budget = 0
+    try:
+        result = strategy.calculate_max_bid(team, 0)
+        assert result >= 0, f"{class_name}.calculate_max_bid returned {result} < 0 for budget 0"
+    except (ValueError, ZeroDivisionError, ArithmeticError):
+        pass  # acceptable for zero-budget edge case
+
+
+# ---------------------------------------------------------------------------
+# Base contract: max_bid_monotone_in_budget (BasicStrategy)
+# ---------------------------------------------------------------------------
+
+
+@given(
+    team=draft_team(),
+    low_budget=st.integers(min_value=5, max_value=100),
+    high_budget=st.integers(min_value=101, max_value=500),
+)
+@settings(max_examples=50)
+def test_max_bid_monotone_in_budget(team, low_budget, high_budget):
+    """With the same team structure, higher remaining_budget → non-decreasing max_bid.
+
+    BasicStrategy uses a simple linear calculation so strict monotonicity holds.
+
+    Invariant:
+        forall team, 5 <= low < high <= 500:
+            BasicStrategy.calculate_max_bid(team, low) <= BasicStrategy.calculate_max_bid(team, high)
+    """
+    from strategies.basic_strategy import BasicStrategy
+
+    strategy = BasicStrategy()
+
+    team.budget = low_budget
+    low_result = strategy.calculate_max_bid(team, low_budget)
+
+    team.budget = high_budget
+    high_result = strategy.calculate_max_bid(team, high_budget)
+
+    assert low_result <= high_result, (
+        f"BasicStrategy.calculate_max_bid not monotone: "
+        f"budget {low_budget}→{low_result} > budget {high_budget}→{high_result}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Strategy-specific: sigmoid output is bounded in (0, 1)
+# ---------------------------------------------------------------------------
+
+
+@given(
+    raw_score=st.floats(
+        min_value=-1e6, max_value=1e6, allow_nan=False, allow_infinity=False
+    )
+)
+@settings(max_examples=200)
+def test_sigmoid_output_bounded(raw_score):
+    """SigmoidStrategy's _sigmoid maps any finite float to strictly (0, 1).
+
+    Invariant:
+        forall x in [-1e6, 1e6]:  0 < sigmoid(x) < 1
+    """
+    from strategies.sigmoid_strategy import SigmoidStrategy
+
+    strategy = SigmoidStrategy()
+    result = strategy._sigmoid(raw_score)
+    assert 0.0 <= result <= 1.0, f"_sigmoid({raw_score}) = {result} not in [0, 1]"
+
+
+# ---------------------------------------------------------------------------
+# Strategy-specific: adaptive inflation guard
+# ---------------------------------------------------------------------------
+
+
+@given(
+    team=draft_team(),
+    remaining_budget=st.integers(min_value=1, max_value=500),
+)
+@settings(max_examples=50)
+def test_adaptive_inflation_guard(team, remaining_budget):
+    """AdaptiveStrategy: calculate_max_bid never exceeds remaining_budget regardless of inflation.
+
+    Invariant:
+        forall team, remaining_budget >= 1:
+            AdaptiveStrategy.calculate_max_bid(team, remaining_budget) <= remaining_budget
+    """
+    from strategies.adaptive_strategy import AdaptiveStrategy
+
+    strategy = AdaptiveStrategy()
+    team.budget = remaining_budget
+    result = strategy.calculate_max_bid(team, remaining_budget)
+    assert result <= remaining_budget
+
+
+# ---------------------------------------------------------------------------
+# Strategy-specific: conservative never bids more than auction_value (when > 0)
+# ---------------------------------------------------------------------------
+
+
+@given(
+    team=draft_team(),
+    player=draft_player(),
+    remaining_budget=st.integers(min_value=1, max_value=500),
+)
+@settings(max_examples=50)
+def test_conservative_always_below_value(team, player, remaining_budget):
+    """ConservativeStrategy.calculate_bid: bid <= player.auction_value when auction_value > 0.
+
+    Invariant:
+        forall team, player with auction_value > 0, remaining_budget >= 1:
+            ConservativeStrategy bid <= player.auction_value
+    """
+    from strategies.conservative_strategy import ConservativeStrategy
+    from classes.owner import Owner
+
+    assume(player.auction_value > 0)
+
+    strategy = ConservativeStrategy()
+    team.budget = remaining_budget
+    owner = Owner("o1", "Test Owner")
+
+    result = strategy.calculate_bid(
+        player=player,
+        team=team,
+        owner=owner,
+        current_bid=0,
+        remaining_budget=remaining_budget,
+        remaining_players=[player],
+    )
+    assert result <= player.auction_value, (
+        f"ConservativeStrategy bid {result} exceeded auction_value {player.auction_value}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Strategy-specific: aggressive bid capped at remaining budget
+# ---------------------------------------------------------------------------
+
+
+@given(
+    team=draft_team(),
+    remaining_budget=st.integers(min_value=1, max_value=500),
+)
+@settings(max_examples=50)
+def test_aggressive_capped_at_budget(team, remaining_budget):
+    """AggressiveStrategy: calculate_max_bid <= remaining_budget even with high aggression.
+
+    Invariant:
+        forall team, remaining_budget >= 1:
+            AggressiveStrategy.calculate_max_bid(team, remaining_budget) <= remaining_budget
+    """
+    from strategies.aggressive_strategy import AggressiveStrategy
+
+    strategy = AggressiveStrategy()
+    team.budget = remaining_budget
+    result = strategy.calculate_max_bid(team, remaining_budget)
+    assert result <= remaining_budget

--- a/tests/property/test_strategy_registry_properties.py
+++ b/tests/property/test_strategy_registry_properties.py
@@ -1,0 +1,141 @@
+"""Property tests for strategies/strategy_registry.py — security & config (#332).
+
+Tests:
+- create() with any valid key returns a Strategy instance
+- create() with any unknown key raises ValueError (fuzz arbitrary strings)
+- list_available() is sorted
+- list_available() is stable across repeated calls
+- from_dict() with any base_class not in the hardcoded allowlist raises ValueError
+- Arbitrary non-identifier strings as base_class are always rejected (security)
+- from_dict() with a valid allowlisted base_class returns the correct Strategy type
+"""
+from __future__ import annotations
+
+import pytest
+from hypothesis import given, settings
+from hypothesis import strategies as st
+
+from strategies import AVAILABLE_STRATEGIES
+from strategies.base_strategy import Strategy
+from strategies.strategy_registry import StrategyRegistry
+
+# ---------------------------------------------------------------------------
+# Known allowlisted base class names (kept in sync with StrategyRegistry source)
+# ---------------------------------------------------------------------------
+_ALLOWLISTED_BASE_CLASSES = frozenset({
+    "VorStrategy",
+    "SigmoidStrategy",
+    "AggressiveStrategy",
+    "ConservativeStrategy",
+    "ValueBasedStrategy",
+    "ImprovedValueStrategy",
+    "AdaptiveStrategy",
+    "RandomStrategy",
+    "SmartStrategy",
+    "BalancedStrategy",
+    "BasicStrategy",
+    "EliteHybridStrategy",
+    "InflationAwareVorStrategy",
+    "ValueRandomStrategy",
+    "ValueSmartStrategy",
+    "LeagueStrategy",
+    "RefinedValueRandomStrategy",
+})
+
+_VALID_KEYS = sorted(AVAILABLE_STRATEGIES.keys())
+
+_MINIMAL_CONFIG_BASE: dict = {
+    "name": "test",
+    "display_name": "Test Strategy",
+    "description": "A test strategy for property testing.",
+}
+
+
+# ---------------------------------------------------------------------------
+# Tests — create() by key
+# ---------------------------------------------------------------------------
+
+@given(key=st.sampled_from(_VALID_KEYS))
+@settings(max_examples=len(_VALID_KEYS))
+def test_create_valid_key_returns_strategy(key):
+    """StrategyRegistry.create() with any valid key returns a Strategy instance."""
+    result = StrategyRegistry.create(key)
+    assert isinstance(result, Strategy)
+
+
+@given(
+    key=st.text(min_size=1, max_size=50).filter(lambda k: k not in AVAILABLE_STRATEGIES)
+)
+@settings(max_examples=50)
+def test_create_unknown_key_raises_value_error(key):
+    """create() with any key not in AVAILABLE_STRATEGIES always raises ValueError."""
+    with pytest.raises(ValueError):
+        StrategyRegistry.create(key)
+
+
+# ---------------------------------------------------------------------------
+# Tests — list_available()
+# ---------------------------------------------------------------------------
+
+@given(st.just(None))
+@settings(max_examples=1)
+def test_list_available_is_sorted(_):
+    """list_available() returns keys in sorted (alphabetical) order."""
+    available = StrategyRegistry.list_available()
+    assert available == sorted(available)
+
+
+@given(st.just(None))
+@settings(max_examples=5)
+def test_list_available_is_stable_across_calls(_):
+    """Calling list_available() twice returns identical results."""
+    first = StrategyRegistry.list_available()
+    second = StrategyRegistry.list_available()
+    assert first == second
+
+
+# ---------------------------------------------------------------------------
+# Tests — from_dict() base_class allowlist security
+# ---------------------------------------------------------------------------
+
+@given(
+    base_class=st.text(min_size=1, max_size=100).filter(
+        lambda b: b not in _ALLOWLISTED_BASE_CLASSES
+    )
+)
+@settings(max_examples=50)
+def test_from_dict_unlisted_base_class_raises(base_class):
+    """Any base_class not in the hardcoded allowlist must raise ValueError."""
+    config = {**_MINIMAL_CONFIG_BASE, "base_class": base_class}
+    with pytest.raises(ValueError):
+        StrategyRegistry.from_dict(config)
+
+
+@given(
+    base_class=st.text(
+        alphabet=st.characters(
+            whitelist_categories=["P", "S", "Z", "C"],  # punctuation, symbols, spaces, control
+        ),
+        min_size=1,
+        max_size=50,
+    )
+)
+@settings(max_examples=50)
+def test_arbitrary_non_identifier_base_class_rejected(base_class):
+    """Non-identifier unicode strings as base_class are always rejected."""
+    config = {**_MINIMAL_CONFIG_BASE, "base_class": base_class}
+    with pytest.raises(Exception):  # ValueError from allowlist check or Pydantic validation
+        StrategyRegistry.from_dict(config)
+
+
+# ---------------------------------------------------------------------------
+# Tests — from_dict() valid path
+# ---------------------------------------------------------------------------
+
+@given(base_class=st.sampled_from(sorted(_ALLOWLISTED_BASE_CLASSES)))
+@settings(max_examples=len(_ALLOWLISTED_BASE_CLASSES))
+def test_from_dict_valid_base_class_returns_strategy(base_class):
+    """from_dict() with any allowlisted base_class returns a Strategy instance."""
+    config = {**_MINIMAL_CONFIG_BASE, "base_class": base_class}
+    result = StrategyRegistry.from_dict(config)
+    assert isinstance(result, Strategy)

--- a/tests/property/test_team_properties.py
+++ b/tests/property/test_team_properties.py
@@ -1,0 +1,137 @@
+"""Property-based tests: team roster and budget invariants.
+
+Track B — Issue #315
+
+Sprint 10 · sprint/10 branch
+"""
+
+from hypothesis import assume, given, settings
+from hypothesis import strategies as st
+
+from tests.property.conftest import draft_player, draft_team
+
+
+# ---------------------------------------------------------------------------
+# Property 1 — add then remove is a no-op
+# ---------------------------------------------------------------------------
+
+
+@given(team=draft_team(), player=draft_player(), price=st.integers(min_value=1, max_value=50))
+@settings(max_examples=50)
+def test_add_remove_is_noop(team, player, price):
+    """add_player(p, price) followed by remove_player(p) leaves team in original state."""
+    assume(price <= team.budget)
+    team.roster_config = {player.position: 2}
+    team.position_limits = {player.position: 2}
+
+    budget_before = team.budget
+    roster_len_before = len(team.roster)
+
+    added = team.add_player(player, price)
+    assume(added)
+
+    team.remove_player(player)
+
+    assert team.budget == budget_before
+    assert len(team.roster) == roster_len_before
+
+
+# ---------------------------------------------------------------------------
+# Property 2 — budget invariant after adding players
+# ---------------------------------------------------------------------------
+
+
+@given(
+    initial_budget=st.integers(min_value=10, max_value=500),
+    prices=st.lists(st.integers(min_value=1, max_value=10), min_size=1, max_size=6),
+)
+@settings(max_examples=50)
+def test_budget_invariant_after_add(initial_budget, prices):
+    """team.budget == initial_budget - sum(drafted prices) always."""
+    from classes.team import Team
+    from classes.player import Player
+
+    positions = ["QB", "RB", "WR", "TE", "K", "DST"]
+    team = Team("t", "o", "Test", initial_budget)
+
+    for i, price in enumerate(prices):
+        if price > team.budget:
+            break
+        p = Player(f"p{i}", f"Player {i}", positions[i % len(positions)], "NFL")
+        team.add_player(p, price)
+
+    total_in_roster = sum(
+        int(p.draft_price) for p in team.roster if p.draft_price is not None
+    )
+    assert team.budget == team.initial_budget - total_in_roster
+
+
+# ---------------------------------------------------------------------------
+# Property 3 — roster count is bounded by position limits
+# ---------------------------------------------------------------------------
+
+
+@given(
+    team=draft_team(),
+    players=st.lists(draft_player(), min_size=1, max_size=25),
+)
+@settings(max_examples=50)
+def test_roster_count_bounded(team, players):
+    """len(team.roster) never exceeds the sum of all position limits."""
+    max_slots = sum(team.position_limits.values())
+    for p in players:
+        if team.budget < 1:
+            break
+        team.add_player(p, 1)
+
+    assert len(team.roster) <= max_slots
+
+
+# ---------------------------------------------------------------------------
+# Property 4 — no duplicate players on roster
+# ---------------------------------------------------------------------------
+
+
+@given(
+    team=draft_team(),
+    player=draft_player(),
+)
+@settings(max_examples=50)
+def test_no_duplicate_players(team, player):
+    """Adding the same player twice results in at most one entry in team.roster."""
+    assume(team.budget >= 2)
+    team.roster_config = {player.position: 2}
+    team.position_limits = {player.position: 2}
+
+    team.add_player(player, 1)
+    team.add_player(player, 1)
+
+    occurrences = sum(1 for p in team.roster if p.player_id == player.player_id)
+    assert occurrences <= 1
+
+
+# ---------------------------------------------------------------------------
+# Property 5 — get_state round-trips key fields
+# ---------------------------------------------------------------------------
+
+
+@given(team=draft_team())
+@settings(max_examples=50)
+def test_to_dict_round_trips(team):
+    """get_state() captures all scalar fields and they can reconstruct the team."""
+    from classes.team import Team
+
+    state = team.get_state()
+    reconstructed = Team(
+        team_id=state.team_id,
+        owner_id=state.owner_id,
+        team_name=state.team_name,
+        budget=state.budget,
+    )
+    reconstructed.initial_budget = state.initial_budget
+
+    assert reconstructed.team_id == team.team_id
+    assert reconstructed.owner_id == team.owner_id
+    assert reconstructed.team_name == team.team_name
+    assert reconstructed.budget == team.budget
+    assert reconstructed.initial_budget == team.initial_budget

--- a/tests/property/test_tournament_properties.py
+++ b/tests/property/test_tournament_properties.py
@@ -1,0 +1,189 @@
+"""Property-based tests: tournament and simulation invariants.
+
+Track E — Issue #318
+
+Uses the draft_state composite strategy from conftest for full-draft simulations.
+Full-draft tests use max_examples=20, deadline=None to keep CI runtime reasonable.
+
+Sprint 10 · sprint/10 branch
+"""
+
+import json
+
+from hypothesis import assume, given, settings
+from hypothesis import strategies as st
+
+from tests.property.conftest import draft_player, draft_state, draft_team
+
+
+def _simulate_draft(teams, players):
+    """Round-robin auction draft simulation: each team bids $1 per player in turn."""
+    player_pool = list(players)
+    for i, player in enumerate(player_pool):
+        team = teams[i % len(teams)]
+        if team.budget >= 1 and not player.is_drafted:
+            team.add_player(player, 1)
+
+
+# ---------------------------------------------------------------------------
+# Property 1 — no team's total spend exceeds its initial budget
+# ---------------------------------------------------------------------------
+
+
+@given(state=draft_state())
+@settings(max_examples=20, deadline=None)
+def test_team_budget_never_exceeded(state):
+    """After a simulated draft, initial_budget - budget >= 0 for all teams.
+
+    Invariant:
+        forall (teams, players) from draft_state():
+            all(t.initial_budget - t.budget >= 0 for t in teams)
+    """
+    teams, players = state
+    _simulate_draft(teams, players)
+    for t in teams:
+        assert t.initial_budget - t.budget >= 0, (
+            f"Team {t.team_name}: initial_budget={t.initial_budget} budget={t.budget}"
+        )
+
+
+# ---------------------------------------------------------------------------
+# Property 2 — each player appears in at most one team's roster
+# ---------------------------------------------------------------------------
+
+
+@given(state=draft_state())
+@settings(max_examples=20, deadline=None)
+def test_no_player_drafted_twice(state):
+    """After a simulated draft, each player_id appears in at most one team's roster.
+
+    Invariant:
+        forall (teams, players) from draft_state():
+            len(all_player_ids) == len(set(all_player_ids))
+    """
+    teams, players = state
+    assume(len({p.player_id for p in players}) == len(players))
+    _simulate_draft(teams, players)
+    all_ids = [p.player_id for t in teams for p in t.roster]
+    assert len(all_ids) == len(set(all_ids)), (
+        f"Duplicate players found: {len(all_ids) - len(set(all_ids))} duplicates"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Property 3 — team projected score is always non-negative
+# ---------------------------------------------------------------------------
+
+
+@given(
+    team=draft_team(),
+    players=st.lists(draft_player(), min_size=1, max_size=15),
+)
+@settings(max_examples=50)
+def test_score_bounded(team, players):
+    """Team.get_projected_points() is always >= 0 regardless of player combination.
+
+    Invariant:
+        forall team, any subset of players on roster:
+            team.get_projected_points() >= 0.0
+    """
+    for p in players:
+        if team.budget >= 1 and not p.is_drafted:
+            team.add_player(p, 1)
+
+    score = team.get_projected_points()
+    assert score >= 0.0, f"Negative projected score: {score}"
+
+
+# ---------------------------------------------------------------------------
+# Property 4 — tournament results serialisation is lossless (JSON round-trip)
+# ---------------------------------------------------------------------------
+
+
+@given(state=draft_state(n_teams=2, n_rounds=1))
+@settings(max_examples=20, deadline=None)
+def test_results_serialization_lossless(state):
+    """A dict of tournament results survives json.dumps/json.loads losslessly.
+
+    TournamentResults is a plain Dict[str, Any] — serialisation is via json.
+
+    Invariant:
+        forall results dict:
+            json.loads(json.dumps(results)) == results
+    """
+    teams, players = state
+    _simulate_draft(teams, players)
+
+    results = {
+        "teams": [
+            {
+                "team_id": t.team_id,
+                "budget": t.budget,
+                "initial_budget": t.initial_budget,
+                "roster_size": len(t.roster),
+                "projected_points": t.get_projected_points(),
+            }
+            for t in teams
+        ]
+    }
+    serialised = json.dumps(results)
+    restored = json.loads(serialised)
+    assert restored == results
+
+
+# ---------------------------------------------------------------------------
+# Property 5 — strategy ranking is deterministic given the same inputs
+# ---------------------------------------------------------------------------
+
+
+@given(
+    n_teams=st.integers(min_value=2, max_value=6),
+    budget=st.integers(min_value=20, max_value=200),
+)
+@settings(max_examples=10, deadline=None)
+def test_strategy_ranking_deterministic(n_teams, budget):
+    """Building the same team roster twice produces identical projected score.
+
+    Invariant:
+        forall team, player_list:
+            build_roster(team, players) twice → identical get_projected_points()
+    """
+    from classes.team import Team
+    from classes.player import Player
+
+    positions = ["QB", "RB", "WR", "WR", "TE", "K"]
+
+    def build_team():
+        t = Team("t1", "o1", "Test", budget)
+        for i, pos in enumerate(positions):
+            p = Player(f"p{i}", f"Player {i}", pos, "NFL", projected_points=10.0 + i)
+            t.add_player(p, 1)
+        return t
+
+    t1 = build_team()
+    t2 = build_team()
+
+    assert t1.get_projected_points() == t2.get_projected_points()
+
+
+# ---------------------------------------------------------------------------
+# Property 6 — roster size bounded after full draft
+# ---------------------------------------------------------------------------
+
+
+@given(state=draft_state())
+@settings(max_examples=20, deadline=None)
+def test_roster_positions_filled(state):
+    """After a simulated draft, len(team.roster) <= sum(position_limits.values()).
+
+    Invariant:
+        forall (teams, players) from draft_state():
+            all(len(t.roster) <= sum(t.position_limits.values()) for t in teams)
+    """
+    teams, players = state
+    _simulate_draft(teams, players)
+    for t in teams:
+        max_slots = sum(t.position_limits.values())
+        assert len(t.roster) <= max_slots, (
+            f"Team {t.team_name}: roster {len(t.roster)} > max_slots {max_slots}"
+        )

--- a/tests/property/test_tournament_service_properties.py
+++ b/tests/property/test_tournament_service_properties.py
@@ -1,0 +1,85 @@
+"""Property tests for services/tournament_service.py (#337).
+
+Tests:
+- run_strategy_tournament with any invalid strategy key returns success=False
+- Error result always contains 'error' and 'available_strategies' keys
+- 'available_strategies' in error result matches AVAILABLE_STRATEGIES keys
+- Valid strategy keys don't trigger the validation error path
+"""
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+from hypothesis import given, settings
+from hypothesis import strategies as st
+
+from strategies import AVAILABLE_STRATEGIES
+from services.tournament_service import TournamentService
+
+_VALID_KEYS = sorted(AVAILABLE_STRATEGIES.keys())
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _service() -> TournamentService:
+    mock_manager = MagicMock()
+    mock_cfg = MagicMock()
+    mock_cfg.budget = 200
+    mock_cfg.roster_positions = {"QB": 1, "RB": 2, "WR": 2, "TE": 1, "K": 1, "DST": 1}
+    mock_manager.load_config.return_value = mock_cfg
+    return TournamentService(config_manager=mock_manager)
+
+
+# ---------------------------------------------------------------------------
+# Tests — invalid strategy validation
+# ---------------------------------------------------------------------------
+
+@given(
+    bad_key=st.text(min_size=1, max_size=40).filter(lambda k: k not in AVAILABLE_STRATEGIES)
+)
+@settings(max_examples=30)
+def test_invalid_strategy_returns_failure_dict(bad_key):
+    """Any unknown strategy key causes run_strategy_tournament to return success=False."""
+    svc = _service()
+    result = svc.run_strategy_tournament(
+        strategies_to_test=[bad_key],
+        num_simulations=1,
+        save_results=False,
+    )
+    assert isinstance(result, dict)
+    assert result.get("success") is False
+
+
+@given(
+    bad_key=st.text(min_size=1, max_size=40).filter(lambda k: k not in AVAILABLE_STRATEGIES)
+)
+@settings(max_examples=30)
+def test_invalid_strategy_result_has_error_key(bad_key):
+    """Error result dict always contains 'error' and 'available_strategies' keys."""
+    svc = _service()
+    result = svc.run_strategy_tournament(
+        strategies_to_test=[bad_key],
+        num_simulations=1,
+        save_results=False,
+    )
+    assert "error" in result
+    assert "available_strategies" in result
+
+
+@given(
+    bad_key=st.text(min_size=1, max_size=40).filter(lambda k: k not in AVAILABLE_STRATEGIES)
+)
+@settings(max_examples=20)
+def test_available_strategies_in_error_matches_registry(bad_key):
+    """The 'available_strategies' list in the error dict matches AVAILABLE_STRATEGIES."""
+    svc = _service()
+    result = svc.run_strategy_tournament(
+        strategies_to_test=[bad_key],
+        num_simulations=1,
+        save_results=False,
+    )
+    reported = set(result.get("available_strategies", []))
+    expected = set(AVAILABLE_STRATEGIES.keys())
+    assert reported == expected

--- a/tests/property/test_vor_strategy_properties.py
+++ b/tests/property/test_vor_strategy_properties.py
@@ -1,0 +1,156 @@
+"""Property tests for strategies/vor_strategy.py — VOR invariants (#333).
+
+Tests:
+- aggression and scarcity_weight are stored exactly as given
+- scarcity_factors values are all in [0.0, 1.0]
+- position_baselines values are all > 0
+- _vor_scaling_factor is positive
+- calculate_bid always returns a numeric (int/float) value
+- calculate_bid never exceeds remaining_budget
+- should_nominate always returns a bool
+"""
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+from hypothesis import given, settings
+from hypothesis import strategies as st
+
+from tests.property.conftest import draft_player
+from strategies.vor_strategy import VorStrategy
+
+
+# ---------------------------------------------------------------------------
+# Shared mock helpers
+# ---------------------------------------------------------------------------
+
+def _make_team(remaining_slots: int = 5, remaining_budget: float = 100.0) -> MagicMock:
+    """Minimal team mock with delegation methods VorStrategy relies on."""
+    team = MagicMock()
+    team.get_remaining_roster_slots.return_value = remaining_slots
+    team.calculate_position_priority.return_value = 0.8
+    # Clamp bid to remaining_budget, matching real enforce_budget_constraint semantics
+    team.enforce_budget_constraint.side_effect = lambda bid, budget: min(bid, budget)
+    team.calculate_minimum_budget_needed.return_value = 0.0
+    team.budget = int(remaining_budget)
+    team.initial_budget = int(remaining_budget)
+    team.roster = []
+    return team
+
+
+def _make_owner() -> MagicMock:
+    owner = MagicMock()
+    owner.get_risk_tolerance.return_value = 0.7
+    owner.is_target_player.return_value = False
+    return owner
+
+
+# ---------------------------------------------------------------------------
+# Tests — constructor parameter storage
+# ---------------------------------------------------------------------------
+
+@given(
+    aggression=st.floats(min_value=0.1, max_value=1.5, allow_nan=False, allow_infinity=False),
+    scarcity_weight=st.floats(min_value=0.0, max_value=1.0, allow_nan=False, allow_infinity=False),
+)
+@settings(max_examples=20, deadline=None)
+def test_params_stored_correctly(aggression, scarcity_weight):
+    """aggression and scarcity_weight are stored exactly as provided."""
+    s = VorStrategy(aggression=aggression, scarcity_weight=scarcity_weight)
+    assert s.aggression == aggression
+    assert s.scarcity_weight == scarcity_weight
+
+
+# ---------------------------------------------------------------------------
+# Tests — internal table invariants
+# ---------------------------------------------------------------------------
+
+@given(st.just(None))
+@settings(max_examples=5, deadline=None)
+def test_scarcity_factors_all_in_range(_):
+    """All static scarcity_factors values are in [0.0, 1.0]."""
+    s = VorStrategy()
+    for pos, factor in s.scarcity_factors.items():
+        assert 0.0 <= factor <= 1.0, f"scarcity_factors[{pos!r}] = {factor} out of [0,1]"
+
+
+@given(st.just(None))
+@settings(max_examples=5, deadline=None)
+def test_position_baselines_all_positive(_):
+    """All position_baselines replacement-level values are strictly positive."""
+    s = VorStrategy()
+    for pos, baseline in s.position_baselines.items():
+        assert baseline > 0, f"position_baselines[{pos!r}] = {baseline} not positive"
+
+
+@given(st.just(None))
+@settings(max_examples=5, deadline=None)
+def test_vor_scaling_factor_is_positive(_):
+    """_vor_scaling_factor must be positive for meaningful VOR bids."""
+    s = VorStrategy()
+    assert s._vor_scaling_factor > 0
+
+
+# ---------------------------------------------------------------------------
+# Tests — calculate_bid
+# ---------------------------------------------------------------------------
+
+@given(
+    player=draft_player(),
+    remaining_budget=st.floats(min_value=10.0, max_value=500.0, allow_nan=False, allow_infinity=False),
+    current_bid=st.floats(min_value=0.0, max_value=50.0, allow_nan=False, allow_infinity=False),
+)
+@settings(max_examples=50, deadline=None)
+def test_calculate_bid_returns_numeric(player, remaining_budget, current_bid):
+    """calculate_bid always returns an int or float (never raises, never NaN)."""
+    s = VorStrategy()
+    team = _make_team(remaining_budget=remaining_budget)
+    result = s.calculate_bid(
+        player=player,
+        team=team,
+        owner=_make_owner(),
+        current_bid=current_bid,
+        remaining_budget=remaining_budget,
+        remaining_players=[],
+    )
+    assert isinstance(result, (int, float))
+    assert result == result  # NaN check
+
+
+@given(
+    player=draft_player(),
+    remaining_budget=st.floats(min_value=10.0, max_value=500.0, allow_nan=False, allow_infinity=False),
+)
+@settings(max_examples=50, deadline=None)
+def test_calculate_bid_never_exceeds_remaining_budget(player, remaining_budget):
+    """calculate_bid never returns more than remaining_budget."""
+    s = VorStrategy()
+    team = _make_team(remaining_budget=remaining_budget)
+    result = s.calculate_bid(
+        player=player,
+        team=team,
+        owner=_make_owner(),
+        current_bid=0.0,
+        remaining_budget=remaining_budget,
+        remaining_players=[],
+    )
+    assert result <= remaining_budget
+
+
+# ---------------------------------------------------------------------------
+# Tests — should_nominate
+# ---------------------------------------------------------------------------
+
+@given(player=draft_player())
+@settings(max_examples=50, deadline=None)
+def test_should_nominate_returns_bool(player):
+    """should_nominate always returns a bool (True or False, never raises)."""
+    s = VorStrategy()
+    team = _make_team()
+    result = s.should_nominate(
+        player=player,
+        team=team,
+        owner=_make_owner(),
+        remaining_budget=100.0,
+    )
+    assert isinstance(result, bool)

--- a/tests/unit/classes/test_team.py
+++ b/tests/unit/classes/test_team.py
@@ -135,17 +135,19 @@ class TestPlayerManagement:
         assert len(team.roster) == 2
     
     def test_add_already_drafted_player(self, team, sample_qb):
-        """Test adding a player that's already been drafted."""
+        """Test adding a player that's already been drafted is rejected.
+
+        fix(sprint10): Hypothesis property testing (Track B, #315) identified
+        that allowing duplicate drafted players violated the no-duplicate-players
+        invariant. The is_drafted guard was added to add_player to fix this.
+        """
         sample_qb.mark_as_drafted(30.0, "other_owner")
-        
+
         result = team.add_player(sample_qb, 25.0)
-        
-        # Note: Current implementation allows adding already drafted players
-        # This might be a bug or intentional behavior to test
-        # For now, we test the actual behavior
-        assert result is True  # Current behavior allows this
-        assert len(team.roster) == 1
-        assert team.budget == 175.0
+
+        assert result is False  # Correctly rejected — player is already drafted
+        assert len(team.roster) == 0
+        assert team.budget == 200  # Budget unchanged
     
     def test_get_position_count(self, team):
         """Test position counting functionality."""

--- a/uv.lock
+++ b/uv.lock
@@ -541,6 +541,18 @@ wheels = [
 ]
 
 [[package]]
+name = "hypothesis"
+version = "6.152.6"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "sortedcontainers" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/f0/09/f5219c8fd75ff1f270a6f691df651c206e9316b9d0ce2cbd8b6f82844e1e/hypothesis-6.152.6.tar.gz", hash = "sha256:4a3f21e9a7349a17616626e9010f04360b02e6bf8ff15fdc7c53e76d5517c1e8", size = 467945, upload-time = "2026-05-11T13:12:59.888Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/5f/1c/ed568eca3a963dc3e447b01961ae653e0d6f107c2cfd77b3f2b1a5cfc520/hypothesis-6.152.6-py3-none-any.whl", hash = "sha256:b20ffc532e5f2901229348d10ed7cb37fd9723ebf4799df663d2dce1cdce4e32", size = 533724, upload-time = "2026-05-11T13:12:56.182Z" },
+]
+
+[[package]]
 name = "idna"
 version = "3.13"
 source = { registry = "https://pypi.org/simple" }
@@ -995,6 +1007,7 @@ dev = [
     { name = "bandit" },
     { name = "black" },
     { name = "flake8" },
+    { name = "hypothesis" },
     { name = "isort" },
     { name = "mypy" },
     { name = "pytest" },
@@ -1027,6 +1040,7 @@ dev = [
     { name = "bandit", specifier = ">=1.7.0" },
     { name = "black", specifier = ">=23.0.0" },
     { name = "flake8", specifier = ">=6.0.0" },
+    { name = "hypothesis", specifier = ">=6.100" },
     { name = "isort", specifier = ">=5.12.0" },
     { name = "mypy", specifier = ">=1.0.0" },
     { name = "pytest", specifier = ">=7.0.0" },
@@ -1466,6 +1480,15 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/94/e7/b2c673351809dca68a0e064b6af791aa332cf192da575fd474ed7d6f16a2/six-1.17.0.tar.gz", hash = "sha256:ff70335d468e7eb6ec65b95b99d3a2836546063f63acc5171de367e834932a81", size = 34031, upload-time = "2024-12-04T17:35:28.174Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/b7/ce/149a00dd41f10bc29e5921b496af8b574d8413afcd5e30dfa0ed46c2cc5e/six-1.17.0-py2.py3-none-any.whl", hash = "sha256:4721f391ed90541fddacab5acf947aa0d3dc7d27b2e1e8eda2be8970586c3274", size = 11050, upload-time = "2024-12-04T17:35:26.475Z" },
+]
+
+[[package]]
+name = "sortedcontainers"
+version = "2.4.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/e8/c4/ba2f8066cceb6f23394729afe52f3bf7adec04bf9ed2c820b39e19299111/sortedcontainers-2.4.0.tar.gz", hash = "sha256:25caa5a06cc30b6b83d11423433f65d1f9d76c4c6a0c90e3379eaa43b9bfdb88", size = 30594, upload-time = "2021-05-16T22:03:42.897Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/32/46/9cb0e58b2deb7f82b84065f37f3bffeb12413f947f9388e4cac22c4621ce/sortedcontainers-2.4.0-py2.py3-none-any.whl", hash = "sha256:a163dcaede0f1c021485e957a39245190e74249897e2ae4b2aa38595db237ee0", size = 29575, upload-time = "2021-05-16T22:03:41.177Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

Integrates `develop` into `main` for the v1.0.0 milestone: all work from Sprints 1–8, covering foundational infrastructure, Pydantic v2 models, FastAPI layer, 15 auction strategies, lab scaffolding, security hardening, and comprehensive unit-test coverage (≥ 85% gate). 241 files changed, 35 805 insertions, 2 434 deletions across 156 commits.

Closes #1, #2, #3, #4, #5, #9, #10, #11, #14, #20, #21, #22, #23, #24, #25, #35, #36, #37, #38, #39, #40, #41, #42, #43, #44, #47, #48, #49, #50, #51, #52, #53, #55, #57, #59, #67, #70, #77, #79, #83, #84, #85, #86, #87, #88, #89, #90, #91, #92, #94, #95, #97, #110, #111, #112, #113, #114, #116, #126, #127, #128, #129, #130, #131, #132, #143, #144, #145, #146, #147, #156, #157, #158, #159, #160, #161, #179, #185, #186, #192, #193, #194, #198, #199, #210, #211, #212, #233, #234, #235, #241, #242, #243, #244, #245, #246, #247, #248, #252, #255, #256, #257, #259, #266, #267, #278, #279, #280, #288, #289, #290, #291, #294, #296.

## Type of Change

- [x] Bug fix (`fix/`)
- [x] New feature (`feat/`)
- [ ] Refactor (`refactor/`)
- [x] Tests only (`test/`)
- [x] Docs / chore (`docs/` / `chore/`)
- [ ] Performance (`perf/`)

## Changes

### Sprint 1 — Foundation & Green Baseline
- Remove `sys.path` manipulation from all source and test files (#1, #2, #3)
- Convert all strategy files to absolute imports (#4)
- Delete orphaned test files; add `pythonpath = .` to `pytest.ini` (#3, #21)
- Add `utils/cheatsheet_parser` module stub (#25)
- Add `.env.example`; verify no secrets in repo (#20)
- Restore clean test baseline: 411/420 passing

### Sprint 2 — Code Review Bug Clearance
- Resolve 14 CR bugs (#35–#51): type mismatches, bare exceptions, unused imports, f-string issues, duplicate methods
- Fix `get_remaining_roster_slots()` `int/dict` type mismatch in `gridiron_sage_strategy.py` (#84)
- Add `pytest.ini` marks for `slow`, `integration`, `unit`; add verification test (#24)

### Sprint 3
- Resolve all Sprint 3 open issues; fix 9 failing tests
- Add GitHub Actions workflows to main branch

### Sprint 4 — Tech Debt & Pydantic v2 Models
- Tech debt cleanup: logging, sys.path, nits, conftest, AlphaZero cleanup (#23, #50, #52, #53, #55, #57, #59, #70)
- Replace `shell=True` subprocess with `shlex.split` list-form args (#67, OWASP A08)
- `classes/player.py`: Pydantic `BaseModel` with field validation (#6)
- `classes/team.py` + `DraftState`: Pydantic validation (#7)
- `data/fantasypros_loader.py`: returns typed `Player` models (#8)

### Sprint 5 — FastAPI Scaffold & Config
- Scaffold `FastAPI` app + DTO schemas (`api/main.py`, `api/routers/`, `api/schemas/`) (#11, #77)
- Add `pydantic-settings` `Settings` class and `config_manager` shim (`config/settings.py`, `config/config_manager.py`)
- Lint cleanup; CI gate integration; flake8 / isort config (`.flake8`)

### Sprint 6 — Security & Lab Scaffold
- **#97** SSRF fix: validate Sleeper API URLs against allowlist before request (OWASP A10)
- **#160** Path traversal fix in `utils/path_utils.py`: resolve + confine all file-load paths (OWASP A01)
- **#91** Exponential backoff with jitter on HTTP 429 in `api/sleeper_api.py`
- **#185** `asyncio.Lock` audit across all async Sleeper calls
- **#186** Lab scaffold: `lab/` directory structure, `__init__.py` files, `lab/pyproject.toml`
- **#192–#199** Sleeper projection research, ADR-005, compliance memo, projection audit
- **#241** Replace vacuous tests with real invariant assertions
- Fix `lab/simulation/runner.py` and `lab/data/` scaffolding

### Sprint 7 — Test Coverage Push (≥ 85%)
- **#242–#248** Coverage boosts across all subsystems:
  - `api/` layer: 58% → 99% (#244)
  - `classes/auction.py`: 55% → 100% (#247)
  - `services/`: `BidRecommendationService`, `SleeperDraftService` unit tests (#245, #246)
  - `strategies/`: `spending_analyzer`, `strategy_analyzer`, `enhanced_vor` (#243)
  - `cli/commands.py`: 76% → full coverage (#252, #255, #256)
  - `utils/`: `print_module`, `sleeper_cache`, `market_tracker` (#248)
- New test modules: `tests/unit/classes/`, `tests/unit/cli/`, `tests/unit/config/`, `tests/unit/data/`, `tests/unit/services/`, `tests/unit/strategies/`, `tests/unit/utils/`
- **#257** `lab/simulation/runner.py` — `SimulationRunner` multi-strategy benchmark
- **#259** `StrategyConfig` Pydantic model + `StrategyRegistry` (#259)
- **#266/#267** Register `InflationAwareVorStrategy`; remove `HybridImprovedValueStrategy` duplicate

### Sprint 8 — P1 Bug Clearance & CI Hardening
- P1 bug clearance across 15 issues: auction mechanics, draft state, tournament key bugs, roster edge cases (#110–#116, #126–#132, #143–#147, #156–#161)
- `api/sleeper_api.py`: full async `httpx` client rewrite (#14)
- **#179** `POST /recommend/bid` endpoint (`api/routers/recommend.py`)
- **#211/#212** `X-API-Key` auth dependency + full test coverage (`api/deps.py`)
- **#233–#235** `lab/data/sleeper_auction_scraper.py` + `sleeper_client.py`: Sleeper auction data scraper
- **#194** `lab/results_db/` Alembic migrations: baseline schema + real auction tables
- **#278–#280** CI governance: commit-msg hook, sprint-branch guard, pre-commit + pre-push hooks (`.githooks/`)
- **#288/#289** AI code smell checklist + 750-line file-size gate (`.agents/`)
- **#290/#291/#294/#296** ADR-008 (GitHub Actions), ADR-009 (contributions workflow), ADR-010 (CLI standardisation) (`docs/adr/`)
- CI: notify-ci-failure workflow; automated project board status sync
- `Makefile`: expanded targets for install, lint, test, lab

## Testing

- [x] New or updated tests exist for this change
- [x] `pytest tests/ -x -q` passes locally
- [x] For bug fixes: regression test added that would have caught the bug before the fix
- [x] For features: happy path and at least one edge case covered

```bash
# Test command run and output:
pytest tests/ -x -q
# All tests pass — coverage gate (≥ 85%) satisfied
```

## Code Review Checklist

### Correctness
- [x] Logic is correct for auction mechanics / VOR / budget constraints
- [x] Edge cases handled (empty rosters, zero budgets, position scarcity)
- [x] No off-by-one errors in nomination cycles or draft rounds

### Code Standards
- [x] PEP 8 compliant, 120-char line limit
- [x] Type hints on all new function signatures
- [x] No magic numbers — constants in `config/` or named constants
- [x] Absolute imports only (no relative imports)

### Architecture
- [x] Strategies inherit from `base_strategy.py` and implement `calculate_bid()`
- [x] Budget logic uses `BudgetConstraintManager`, not inline math
- [x] No circular imports introduced

### Security
- [x] No hardcoded secrets or API tokens
- [x] External API inputs (Sleeper) validated before use
- [x] No path traversal in file loading

### Performance
- [x] VOR calculations cached where applicable
- [x] MCTS iterations bounded appropriately

## Notes for Reviewers

- This is the first `develop → main` integration, accumulating all sprint work since the repo was initialized. The large diff (241 files) is expected.
- Security fixes (#67, #97, #160, #211/#212) are the highest-risk items to review carefully.
- `lab/` is intentionally experimental — it is excluded from the app-CI coverage gate via `.coveragerc` and `app-ci.yml`.
- ADR-008 through ADR-010 (`docs/adr/`) document architectural decisions made during Sprints 7–8.
- The `api/deps.py` auth dependency and `api/sleeper_api.py` async rewrite are the two largest API-layer changes; the OpenAPI schema now includes 401/403 responses on all authenticated routes.
