### PR TITLE
test(qa): Phase 1 failing tests — Sprint 11 Tracks B & D (#195, #196, #151, #153, #171, #172)

### DIFF
--- a/tests/unit/cli/test_cli_season_default.py
+++ b/tests/unit/cli/test_cli_season_default.py
@@ -1,0 +1,171 @@
+"""Failing tests for CLI season default and dependency deduplication.
+
+Issue #171: cli/main.py hard-codes the season string '2024' in
+            handle_sleeper_status() and handle_sleeper_leagues().  The default
+            must be datetime.now().year (as a string).
+
+Issue #172: ConfigManager and SleeperAPI are each instantiated twice per CLI
+            run — once in AuctionDraftCLI.__init__() and again in
+            CommandProcessor.__init__().  They must be instantiated exactly once
+            and the single instance must be shared between both objects.
+"""
+
+import pytest
+from datetime import datetime
+from unittest.mock import patch, MagicMock
+
+
+# ---------------------------------------------------------------------------
+# Issue #171 — Season default must be the current year
+# ---------------------------------------------------------------------------
+
+class TestCliSeasonDefault:
+    """The CLI must default to the current calendar year, not the hardcoded '2024'."""
+
+    CURRENT_YEAR = str(datetime.now().year)
+
+    def test_handle_sleeper_status_uses_current_year_as_default(self):
+        """handle_sleeper_status() with no season arg must use the current year.
+
+        The command currently defaults to '2024'; this test fails until #171 is
+        fixed.
+        """
+        from cli.main import AuctionDraftCLI
+
+        cli = AuctionDraftCLI()
+
+        # Provide a username but NO season argument — the default must kick in.
+        captured_season = []
+
+        def _fake_get_status(username, season):
+            captured_season.append(season)
+            return {"success": True}
+
+        cli.command_processor.get_sleeper_draft_status = _fake_get_status
+        # Patch load_config to return an object without sleeper_username so our
+        # explicit arg is used.
+        mock_config = MagicMock()
+        mock_config.sleeper_username = None
+        cli.config_manager.load_config = MagicMock(return_value=mock_config)
+
+        cli.handle_sleeper_status(["testuser"])  # no season arg
+
+        assert len(captured_season) == 1, "get_sleeper_draft_status was not called"
+        assert captured_season[0] == self.CURRENT_YEAR, (
+            f"Expected default season '{self.CURRENT_YEAR}', "
+            f"got '{captured_season[0]}' — hardcoded '2024' not yet removed (#171)"
+        )
+
+    def test_handle_sleeper_leagues_uses_current_year_as_default(self):
+        """handle_sleeper_leagues() with no season arg must use the current year."""
+        from cli.main import AuctionDraftCLI
+
+        cli = AuctionDraftCLI()
+
+        captured_season = []
+
+        def _fake_list_leagues(username, season):
+            captured_season.append(season)
+            return {"success": True}
+
+        cli.command_processor.list_sleeper_leagues = _fake_list_leagues
+        mock_config = MagicMock()
+        mock_config.sleeper_username = None
+        cli.config_manager.load_config = MagicMock(return_value=mock_config)
+
+        cli.handle_sleeper_leagues(["testuser"])  # no season arg
+
+        assert len(captured_season) == 1, "list_sleeper_leagues was not called"
+        assert captured_season[0] == self.CURRENT_YEAR, (
+            f"Expected default season '{self.CURRENT_YEAR}', "
+            f"got '{captured_season[0]}' — hardcoded '2024' not yet removed (#171)"
+        )
+
+    def test_season_default_matches_current_year_not_literal_2024(self):
+        """The CLI default season must not be the literal string '2024'."""
+        assert self.CURRENT_YEAR != "2024" or pytest.skip(
+            "This test is only meaningful when the calendar year is not 2024"
+        )
+        # If CURRENT_YEAR != '2024' then any test above that captured '2024'
+        # will already fail.  This test documents the intent explicitly.
+        assert self.CURRENT_YEAR == str(datetime.now().year)
+
+
+# ---------------------------------------------------------------------------
+# Issue #172 — ConfigManager and SleeperAPI instantiated exactly once
+# ---------------------------------------------------------------------------
+
+class TestCliSingletonDependencies:
+    """ConfigManager and SleeperAPI must be created exactly once per CLI run.
+
+    Currently AuctionDraftCLI and CommandProcessor each create their own
+    instances.  After #172 is fixed they must share a single instance.
+    """
+
+    def test_config_manager_instantiated_once(self):
+        """ConfigManager() is constructed exactly once when AuctionDraftCLI is created.
+
+        Currently it is constructed twice (once in AuctionDraftCLI.__init__ and
+        again in CommandProcessor.__init__), so this test fails until #172 is fixed.
+        """
+        from config.config_manager import ConfigManager
+        from cli.main import AuctionDraftCLI
+
+        instance_ids: list = []
+        original_init = ConfigManager.__init__
+
+        def _tracking_init(self_inner, *args, **kwargs):
+            instance_ids.append(id(self_inner))
+            original_init(self_inner, *args, **kwargs)
+
+        with patch.object(ConfigManager, "__init__", _tracking_init):
+            AuctionDraftCLI()
+
+        assert len(instance_ids) == 1, (
+            f"ConfigManager.__init__ was called {len(instance_ids)} time(s); "
+            "expected exactly 1.  Duplicate instantiation not yet removed (#172)."
+        )
+
+    def test_sleeper_api_instantiated_once(self):
+        """SleeperAPI() is constructed exactly once when AuctionDraftCLI is created.
+
+        Currently it is constructed twice (once in AuctionDraftCLI.__init__ and
+        again in CommandProcessor.__init__), so this test fails until #172 is fixed.
+        """
+        from api.sleeper_api import SleeperAPI
+        from cli.main import AuctionDraftCLI
+
+        instance_ids: list = []
+        original_init = SleeperAPI.__init__
+
+        def _tracking_init(self_inner, *args, **kwargs):
+            instance_ids.append(id(self_inner))
+            original_init(self_inner, *args, **kwargs)
+
+        with patch.object(SleeperAPI, "__init__", _tracking_init):
+            AuctionDraftCLI()
+
+        assert len(instance_ids) == 1, (
+            f"SleeperAPI.__init__ was called {len(instance_ids)} time(s); "
+            "expected exactly 1.  Duplicate instantiation not yet removed (#172)."
+        )
+
+    def test_command_processor_receives_shared_config_manager(self):
+        """CommandProcessor must use the same ConfigManager instance as AuctionDraftCLI."""
+        from cli.main import AuctionDraftCLI
+
+        cli = AuctionDraftCLI()
+        assert cli.config_manager is cli.command_processor.config_manager, (
+            "AuctionDraftCLI.config_manager and CommandProcessor.config_manager are "
+            "different objects — the instance is not shared (#172)."
+        )
+
+    def test_command_processor_receives_shared_sleeper_api(self):
+        """CommandProcessor must use the same SleeperAPI instance as AuctionDraftCLI."""
+        from cli.main import AuctionDraftCLI
+
+        cli = AuctionDraftCLI()
+        assert cli.sleeper_api is cli.command_processor.sleeper_api, (
+            "AuctionDraftCLI.sleeper_api and CommandProcessor.sleeper_api are "
+            "different objects — the instance is not shared (#172)."
+        )

--- a/tests/unit/cli/test_cli_season_default.py
+++ b/tests/unit/cli/test_cli_season_default.py
@@ -24,6 +24,10 @@ class TestCliSeasonDefault:
 
     CURRENT_YEAR = str(datetime.now().year)
 
+    @pytest.mark.xfail(
+        strict=True,
+        reason="handle_sleeper_status() still uses hardcoded '2024' (issue #171)",
+    )
     def test_handle_sleeper_status_uses_current_year_as_default(self):
         """handle_sleeper_status() with no season arg must use the current year.
 
@@ -56,6 +60,10 @@ class TestCliSeasonDefault:
             f"got '{captured_season[0]}' — hardcoded '2024' not yet removed (#171)"
         )
 
+    @pytest.mark.xfail(
+        strict=True,
+        reason="handle_sleeper_leagues() still uses hardcoded '2024' (issue #171)",
+    )
     def test_handle_sleeper_leagues_uses_current_year_as_default(self):
         """handle_sleeper_leagues() with no season arg must use the current year."""
         from cli.main import AuctionDraftCLI
@@ -102,6 +110,10 @@ class TestCliSingletonDependencies:
     instances.  After #172 is fixed they must share a single instance.
     """
 
+    @pytest.mark.xfail(
+        strict=True,
+        reason="ConfigManager is instantiated twice per CLI run (issue #172)",
+    )
     def test_config_manager_instantiated_once(self):
         """ConfigManager() is constructed exactly once when AuctionDraftCLI is created.
 
@@ -126,6 +138,10 @@ class TestCliSingletonDependencies:
             "expected exactly 1.  Duplicate instantiation not yet removed (#172)."
         )
 
+    @pytest.mark.xfail(
+        strict=True,
+        reason="SleeperAPI is instantiated twice per CLI run (issue #172)",
+    )
     def test_sleeper_api_instantiated_once(self):
         """SleeperAPI() is constructed exactly once when AuctionDraftCLI is created.
 
@@ -150,6 +166,10 @@ class TestCliSingletonDependencies:
             "expected exactly 1.  Duplicate instantiation not yet removed (#172)."
         )
 
+    @pytest.mark.xfail(
+        strict=True,
+        reason="ConfigManager instance not shared between AuctionDraftCLI and CommandProcessor (issue #172)",
+    )
     def test_command_processor_receives_shared_config_manager(self):
         """CommandProcessor must use the same ConfigManager instance as AuctionDraftCLI."""
         from cli.main import AuctionDraftCLI
@@ -160,6 +180,10 @@ class TestCliSingletonDependencies:
             "different objects — the instance is not shared (#172)."
         )
 
+    @pytest.mark.xfail(
+        strict=True,
+        reason="SleeperAPI instance not shared between AuctionDraftCLI and CommandProcessor (issue #172)",
+    )
     def test_command_processor_receives_shared_sleeper_api(self):
         """CommandProcessor must use the same SleeperAPI instance as AuctionDraftCLI."""
         from cli.main import AuctionDraftCLI

--- a/tests/unit/lab/test_auction_replay.py
+++ b/tests/unit/lab/test_auction_replay.py
@@ -1,0 +1,146 @@
+"""Failing tests for AuctionBacktester — acceptance criteria for issue #196.
+
+`lab/backtest/auction_replay.py` does not exist yet.  Importing it will raise
+`ModuleNotFoundError`, which makes every test in this file fail at collection
+time — exactly the right signal for QA Phase 1.
+"""
+
+# This import will raise ModuleNotFoundError until #196 is implemented.
+from lab.backtest.auction_replay import AuctionBacktester  # noqa: F401
+
+
+# ---------------------------------------------------------------------------
+# Sample data helpers
+# ---------------------------------------------------------------------------
+
+def _sample_player_data():
+    """Minimal player data list for test fixtures."""
+    return [
+        {"player_name": "Josh Allen", "position": "QB", "auction_value": 45, "actual_price": 52},
+        {"player_name": "Christian McCaffrey", "position": "RB", "auction_value": 70, "actual_price": 68},
+        {"player_name": "Tyreek Hill", "position": "WR", "auction_value": 55, "actual_price": 50},
+    ]
+
+
+def _sample_strategy():
+    """Return a minimal duck-typed strategy object."""
+    class _MinimalStrategy:
+        name = "test_strategy"
+
+        def bid(self, player, budget):
+            return min(player.get("auction_value", 1), budget)
+
+    return _MinimalStrategy()
+
+
+# ---------------------------------------------------------------------------
+# 1. Instantiation
+# ---------------------------------------------------------------------------
+
+class TestAuctionBacktesterInstantiation:
+    """AuctionBacktester(strategy, player_data) must be constructible."""
+
+    def test_instantiation_succeeds(self):
+        """AuctionBacktester can be constructed with a strategy and player_data."""
+        bt = AuctionBacktester(strategy=_sample_strategy(), player_data=_sample_player_data())
+        assert bt is not None
+
+    def test_instantiation_stores_strategy(self):
+        """Constructed instance exposes the strategy it was given."""
+        strategy = _sample_strategy()
+        bt = AuctionBacktester(strategy=strategy, player_data=_sample_player_data())
+        assert bt.strategy is strategy
+
+    def test_instantiation_stores_player_data(self):
+        """Constructed instance exposes the player_data it was given."""
+        data = _sample_player_data()
+        bt = AuctionBacktester(strategy=_sample_strategy(), player_data=data)
+        assert bt.player_data == data
+
+
+# ---------------------------------------------------------------------------
+# 2. run() return shape
+# ---------------------------------------------------------------------------
+
+class TestAuctionBacktesterRun:
+    """run() must return a dict with the three required keys."""
+
+    REQUIRED_KEYS = {"efficiency_score", "total_spend", "total_value"}
+
+    def _make_backtester(self):
+        return AuctionBacktester(strategy=_sample_strategy(), player_data=_sample_player_data())
+
+    def test_run_returns_dict(self):
+        """run() returns a dict."""
+        bt = self._make_backtester()
+        result = bt.run()
+        assert isinstance(result, dict)
+
+    def test_run_result_has_required_keys(self):
+        """run() result contains 'efficiency_score', 'total_spend', 'total_value'."""
+        bt = self._make_backtester()
+        result = bt.run()
+        missing = self.REQUIRED_KEYS - result.keys()
+        assert not missing, f"run() result is missing keys: {missing}"
+
+    def test_efficiency_score_is_between_0_and_1(self):
+        """efficiency_score is a float in [0.0, 1.0]."""
+        bt = self._make_backtester()
+        result = bt.run()
+        score = result["efficiency_score"]
+        assert isinstance(score, float), f"efficiency_score must be float, got {type(score)}"
+        assert 0.0 <= score <= 1.0, f"efficiency_score out of range: {score}"
+
+    def test_total_spend_is_non_negative(self):
+        """total_spend must be >= 0."""
+        bt = self._make_backtester()
+        result = bt.run()
+        assert result["total_spend"] >= 0
+
+    def test_total_value_is_non_negative(self):
+        """total_value must be >= 0."""
+        bt = self._make_backtester()
+        result = bt.run()
+        assert result["total_value"] >= 0
+
+
+# ---------------------------------------------------------------------------
+# 3. Empty player_data edge case
+# ---------------------------------------------------------------------------
+
+class TestAuctionBacktesterEmptyData:
+    """run() with empty player_data must return efficiency_score=0.0 or raise ValueError."""
+
+    def test_empty_player_data_handled(self):
+        """run() with empty player_data returns efficiency_score=0.0 or raises ValueError."""
+        bt = AuctionBacktester(strategy=_sample_strategy(), player_data=[])
+        try:
+            result = bt.run()
+            assert result["efficiency_score"] == 0.0, (
+                f"Expected efficiency_score=0.0 for empty data, got {result['efficiency_score']}"
+            )
+        except ValueError:
+            pass  # also acceptable
+
+
+# ---------------------------------------------------------------------------
+# 4. Determinism — same input → same output
+# ---------------------------------------------------------------------------
+
+class TestAuctionBacktesterDeterminism:
+    """run() must be deterministic for the same input."""
+
+    def test_run_is_deterministic(self):
+        """Two successive run() calls with the same data return identical results."""
+        data = _sample_player_data()
+        strategy = _sample_strategy()
+
+        bt1 = AuctionBacktester(strategy=strategy, player_data=data)
+        bt2 = AuctionBacktester(strategy=strategy, player_data=data)
+
+        result1 = bt1.run()
+        result2 = bt2.run()
+
+        assert result1 == result2, (
+            f"run() is not deterministic:\n  first:  {result1}\n  second: {result2}"
+        )

--- a/tests/unit/lab/test_auction_replay.py
+++ b/tests/unit/lab/test_auction_replay.py
@@ -1,12 +1,26 @@
 """Failing tests for AuctionBacktester — acceptance criteria for issue #196.
 
-`lab/backtest/auction_replay.py` does not exist yet.  Importing it will raise
-`ModuleNotFoundError`, which makes every test in this file fail at collection
-time — exactly the right signal for QA Phase 1.
+`lab/backtest/auction_replay.py` does not exist yet.  All tests are marked
+xfail(strict=True): they are expected to fail until #196 is implemented.
+Remove the pytestmark (and verify green) once AuctionBacktester is available.
 """
 
-# This import will raise ModuleNotFoundError until #196 is implemented.
-from lab.backtest.auction_replay import AuctionBacktester  # noqa: F401
+import pytest
+
+# Graceful import — module does not exist yet; tests fail at runtime, not at
+# collection time, which keeps the full suite collectable.
+try:
+    from lab.backtest.auction_replay import AuctionBacktester
+    _AUCTION_REPLAY_AVAILABLE = True
+except ModuleNotFoundError:
+    AuctionBacktester = None  # type: ignore[assignment,misc]
+    _AUCTION_REPLAY_AVAILABLE = False
+
+# All tests are expected to fail until issue #196 is implemented.
+pytestmark = pytest.mark.xfail(
+    strict=True,
+    reason="lab/backtest/auction_replay.AuctionBacktester not yet implemented (issue #196)",
+)
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/lab/test_sleeper_auction_scraper.py
+++ b/tests/unit/lab/test_sleeper_auction_scraper.py
@@ -5,7 +5,16 @@ intentionally written to fail against the current stub so that a red/green
 cycle can be used to drive the implementation.
 """
 
+import pytest
 from unittest.mock import patch
+
+# All tests in this module are expected to fail until issue #195 is implemented.
+# Remove this mark (and verify green) once SleeperAuctionScraper has the
+# (league_id, season) constructor API and fetch() method.
+pytestmark = pytest.mark.xfail(
+    strict=True,
+    reason="SleeperAuctionScraper(league_id, season) + fetch() not yet implemented (issue #195)",
+)
 
 # This import will succeed (stub exists) but the *interface* tested below
 # does not match the stub, so individual tests will fail.

--- a/tests/unit/lab/test_sleeper_auction_scraper.py
+++ b/tests/unit/lab/test_sleeper_auction_scraper.py
@@ -1,0 +1,149 @@
+"""Failing tests for SleeperAuctionScraper — acceptance criteria for issue #195.
+
+These tests define the required public API after implementation.  They are
+intentionally written to fail against the current stub so that a red/green
+cycle can be used to drive the implementation.
+"""
+
+from unittest.mock import patch
+
+# This import will succeed (stub exists) but the *interface* tested below
+# does not match the stub, so individual tests will fail.
+from lab.data.sleeper_auction_scraper import SleeperAuctionScraper
+
+
+REQUIRED_KEYS = {"player_name", "position", "auction_value", "actual_price"}
+
+
+# ---------------------------------------------------------------------------
+# 1. Instantiation with (league_id, season)
+# ---------------------------------------------------------------------------
+
+class TestSleeperAuctionScraperInstantiation:
+    """SleeperAuctionScraper must accept (league_id, season) as its primary
+    constructor signature (issue #195).  The current stub takes (db_url, client)
+    which is a different shape — these tests will fail until the API is updated.
+    """
+
+    def test_instantiation_with_league_id_and_season(self):
+        """SleeperAuctionScraper(league_id, season) can be constructed."""
+        scraper = SleeperAuctionScraper(league_id="123456789", season="2024")
+        assert scraper is not None
+
+    def test_instantiation_stores_league_id(self):
+        """Constructed instance exposes the league_id it was given."""
+        scraper = SleeperAuctionScraper(league_id="999", season="2023")
+        assert scraper.league_id == "999"
+
+    def test_instantiation_stores_season(self):
+        """Constructed instance exposes the season it was given."""
+        scraper = SleeperAuctionScraper(league_id="999", season="2023")
+        assert scraper.season == "2023"
+
+
+# ---------------------------------------------------------------------------
+# 2. fetch() returns a list of dicts
+# ---------------------------------------------------------------------------
+
+class TestSleeperAuctionScraperFetch:
+    """fetch() must return a list of dicts with the required schema."""
+
+    def _make_scraper(self):
+        return SleeperAuctionScraper(league_id="123456789", season="2024")
+
+    def test_fetch_returns_list(self):
+        """`fetch()` must return a list."""
+        scraper = self._make_scraper()
+        with patch.object(scraper, "_fetch_from_api", return_value=_sample_picks()):
+            result = scraper.fetch()
+        assert isinstance(result, list)
+
+    def test_fetch_returns_list_of_dicts(self):
+        """`fetch()` must return a list of dicts."""
+        scraper = self._make_scraper()
+        with patch.object(scraper, "_fetch_from_api", return_value=_sample_picks()):
+            result = scraper.fetch()
+        assert all(isinstance(row, dict) for row in result)
+
+    def test_fetch_dicts_have_required_keys(self):
+        """Every dict returned by `fetch()` must contain the required keys."""
+        scraper = self._make_scraper()
+        with patch.object(scraper, "_fetch_from_api", return_value=_sample_picks()):
+            result = scraper.fetch()
+        assert len(result) > 0, "fetch() returned an empty list — cannot validate keys"
+        for row in result:
+            missing = REQUIRED_KEYS - row.keys()
+            assert not missing, f"Missing keys in fetch() result: {missing}"
+
+
+# ---------------------------------------------------------------------------
+# 3. Invalid league_id raises ValueError or returns []
+# ---------------------------------------------------------------------------
+
+class TestSleeperAuctionScraperInvalidLeague:
+    """fetch() with a bad league_id must either raise ValueError or return []."""
+
+    def test_invalid_league_id_raises_or_returns_empty(self):
+        """fetch() with an invalid league_id raises ValueError or returns []."""
+        scraper = SleeperAuctionScraper(league_id="INVALID_LEAGUE_XYZ", season="2024")
+        with patch.object(scraper, "_fetch_from_api", return_value=[]):
+            try:
+                result = scraper.fetch()
+                assert result == [], (
+                    "Expected fetch() to raise ValueError or return [] for an "
+                    f"invalid league, but got: {result!r}"
+                )
+            except ValueError:
+                pass  # acceptable
+
+
+# ---------------------------------------------------------------------------
+# 4. Caching — second call must not re-fetch from the API
+# ---------------------------------------------------------------------------
+
+class TestSleeperAuctionScraperCaching:
+    """Results must be cached; a second call to fetch() must not hit the API."""
+
+    def test_second_fetch_uses_cache(self):
+        """fetch() called twice hits the underlying API only once."""
+        scraper = SleeperAuctionScraper(league_id="123456789", season="2024")
+
+        with patch.object(
+            scraper, "_fetch_from_api", return_value=_sample_picks()
+        ) as mock_api:
+            scraper.fetch()
+            scraper.fetch()
+
+        mock_api.assert_called_once()
+
+    def test_cache_returns_same_data(self):
+        """Cached fetch() returns identical data on both calls."""
+        scraper = SleeperAuctionScraper(league_id="123456789", season="2024")
+
+        with patch.object(scraper, "_fetch_from_api", return_value=_sample_picks()):
+            first = scraper.fetch()
+            second = scraper.fetch()
+
+        assert first == second
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _sample_picks():
+    """Return a minimal set of valid auction pick dicts."""
+    return [
+        {
+            "player_name": "Josh Allen",
+            "position": "QB",
+            "auction_value": 45,
+            "actual_price": 52,
+        },
+        {
+            "player_name": "Christian McCaffrey",
+            "position": "RB",
+            "auction_value": 70,
+            "actual_price": 68,
+        },
+    ]

--- a/tests/unit/strategies/test_strategy_registration.py
+++ b/tests/unit/strategies/test_strategy_registration.py
@@ -9,10 +9,20 @@ Issue #153: InflationAwareVorStrategy._calculate_inflation_factor() hard-codes
             use them in the inflation calculation.
 """
 
+import pytest
 from unittest.mock import MagicMock
 
 from strategies import AVAILABLE_STRATEGIES, create_strategy
 from strategies.enhanced_vor_strategy import InflationAwareVorStrategy
+
+# All tests in this module are expected to fail until issues #151 and #153 are
+# implemented.  Remove pytestmark (and verify green) once:
+#   #151 — 'inflation_aware_vor' is registered in AVAILABLE_STRATEGIES
+#   #153 — InflationAwareVorStrategy accepts budget / roster_size kwargs
+pytestmark = pytest.mark.xfail(
+    strict=True,
+    reason="InflationAwareVorStrategy registration (#151) and custom budget/roster_size (#153) not yet implemented",
+)
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/strategies/test_strategy_registration.py
+++ b/tests/unit/strategies/test_strategy_registration.py
@@ -1,0 +1,115 @@
+"""Failing tests for strategy registration — acceptance criteria for issues #151 and #153.
+
+Issue #151: InflationAwareVorStrategy must be registered under the canonical key
+            'inflation_aware_vor' in AVAILABLE_STRATEGIES (currently 'inflation_vor').
+
+Issue #153: InflationAwareVorStrategy._calculate_inflation_factor() hard-codes
+            standard_budget_per_slot = 200 / 15, which breaks non-standard leagues.
+            The constructor must accept `budget` and `roster_size` parameters and
+            use them in the inflation calculation.
+"""
+
+from unittest.mock import MagicMock
+
+from strategies import AVAILABLE_STRATEGIES, create_strategy
+from strategies.enhanced_vor_strategy import InflationAwareVorStrategy
+
+
+# ---------------------------------------------------------------------------
+# Issue #151 — Registration key
+# ---------------------------------------------------------------------------
+
+class TestInflationAwareVorStrategyRegistration:
+    """InflationAwareVorStrategy must be accessible as 'inflation_aware_vor'."""
+
+    def test_inflation_aware_vor_key_in_available_strategies(self):
+        """'inflation_aware_vor' must be a key in AVAILABLE_STRATEGIES (issue #151).
+
+        Currently the key is 'inflation_vor', so this test fails.
+        """
+        assert "inflation_aware_vor" in AVAILABLE_STRATEGIES, (
+            "'inflation_aware_vor' is not registered in AVAILABLE_STRATEGIES.  "
+            f"Current keys: {list(AVAILABLE_STRATEGIES.keys())}"
+        )
+
+    def test_create_strategy_returns_inflation_aware_vor_instance(self):
+        """create_strategy('inflation_aware_vor') must return an InflationAwareVorStrategy."""
+        strategy = create_strategy("inflation_aware_vor")
+        assert isinstance(strategy, InflationAwareVorStrategy), (
+            f"Expected InflationAwareVorStrategy, got {type(strategy)}"
+        )
+
+    def test_inflation_aware_vor_name_attribute(self):
+        """The registered strategy instance must have name == 'inflation_aware_vor'."""
+        strategy = create_strategy("inflation_aware_vor")
+        assert strategy.name == "inflation_aware_vor", (
+            f"Expected strategy.name='inflation_aware_vor', got '{strategy.name}'"
+        )
+
+
+# ---------------------------------------------------------------------------
+# Issue #153 — Custom budget and roster_size
+# ---------------------------------------------------------------------------
+
+class TestInflationAwareVorStrategyCustomBudget:
+    """InflationAwareVorStrategy must accept and use custom budget / roster_size.
+
+    The hard-coded `standard_budget_per_slot = 200 / 15` inside
+    _calculate_inflation_factor() must be replaced by values derived from the
+    constructor arguments `budget` and `roster_size`.
+    """
+
+    def test_constructor_accepts_budget_kwarg(self):
+        """InflationAwareVorStrategy(budget=100) must not raise TypeError (issue #153)."""
+        strategy = InflationAwareVorStrategy(budget=100)
+        assert strategy is not None
+
+    def test_constructor_accepts_roster_size_kwarg(self):
+        """InflationAwareVorStrategy(roster_size=20) must not raise TypeError (issue #153)."""
+        strategy = InflationAwareVorStrategy(roster_size=20)
+        assert strategy is not None
+
+    def test_constructor_stores_budget(self):
+        """Constructed instance must expose the custom budget."""
+        strategy = InflationAwareVorStrategy(budget=100, roster_size=20)
+        assert strategy.budget == 100
+
+    def test_constructor_stores_roster_size(self):
+        """Constructed instance must expose the custom roster_size."""
+        strategy = InflationAwareVorStrategy(budget=100, roster_size=20)
+        assert strategy.roster_size == 20
+
+    def test_inflation_factor_uses_custom_budget_and_roster_size(self):
+        """_calculate_inflation_factor() must use instance budget/roster_size, not 200/15.
+
+        With budget=100 and roster_size=10 the standard_budget_per_slot is 10.0.
+        With budget=200 and roster_size=15 the standard_budget_per_slot is ~13.33.
+        The two instances must produce different inflation factors when given the
+        same team situation, proving the calculation is parameterised.
+        """
+        # Two teams, each with $50 remaining and 5 roster slots left.
+        def _make_team(remaining_budget: float, roster_size: int):
+            team = MagicMock()
+            team.budget = remaining_budget
+            team.roster = [MagicMock()] * (roster_size - 5)  # 5 slots still open
+            return team
+
+        strategy_small = InflationAwareVorStrategy(budget=100, roster_size=10)
+        strategy_standard = InflationAwareVorStrategy(budget=200, roster_size=15)
+
+        teams = [_make_team(50, 10), _make_team(50, 10)]
+        remaining = []  # not used in the inflation calc itself
+
+        factor_small = strategy_small._calculate_inflation_factor(teams, remaining)
+        factor_standard = strategy_standard._calculate_inflation_factor(teams, remaining)
+
+        assert factor_small != factor_standard, (
+            "Inflation factors are identical despite different budget/roster_size "
+            "configurations — the hardcoded 200/15 constant has not been removed."
+        )
+
+    def test_default_budget_and_roster_size_match_standard_league(self):
+        """Default InflationAwareVorStrategy() must default to budget=200, roster_size=15."""
+        strategy = InflationAwareVorStrategy()
+        assert strategy.budget == 200
+        assert strategy.roster_size == 15


### PR DESCRIPTION
## QA Phase 1 — Sprint 11

Writes failing/xfail unit tests that define acceptance criteria for Sprint 11 Track B (Lab Data & Backtest) and Track D (Strategy Correctness). These tests must be failing before implementation begins, per the QA-First lifecycle.

### Issues covered
- #195 — SleeperAuctionScraper: tests in `tests/unit/lab/test_sleeper_auction_scraper.py`
- #196 — AuctionBacktester: tests in `tests/unit/lab/test_auction_replay.py`
- #151 — InflationAwareVorStrategy registration: tests in `tests/unit/strategies/test_strategy_registration.py`
- #153 — EnhancedVorStrategy hardcoded budget: tests in `tests/unit/strategies/test_strategy_registration.py`
- #171 — CLI season default: tests in `tests/unit/cli/test_cli_season_default.py`
- #172 — CLI duplicate instantiation: tests in `tests/unit/cli/test_cli_season_default.py`

### QA Gate Status
All 6 issues labeled `qa:tests-defined`. Backend Agent may begin implementation for each issue only after this PR is merged.

### Notes
- Tests use `@pytest.mark.xfail(strict=True)` for CI compatibility — they will be updated to pass as implementation PRs land
- `tests/unit/lab/__init__.py` added
