### PR TITLE
feat(lab): scaffold lab module stubs — closes #226, #227, #228

### DIFF
--- a/lab/README.md
+++ b/lab/README.md
@@ -12,13 +12,13 @@ promoted to the core `pigskin` package via the gate process in `lab/promotion/`.
 | `strategies/` | Experimental strategy implementations | #82 |
 | `gridiron_sage/` | GridironSage MCTS training | #83 |
 | `simulation/` | Tournament runner | #187 |
-| `benchmarks/` | Strategy comparison harness | — |
-| `promotion/` | Gate evaluation for production promotion | #80 |
-| `results_db/` | SQLite results store + Alembic migrations | #79 |
-| `experiments/` | Named experiment configuration files | — |
-| `data/` | Auction data scraper, projection snapshots | #192 |
-| `backtest/` | Value-efficiency replay harness | — |
-| `eval/` | Projection accuracy evaluator | — |
+| `benchmarks/` | Strategy comparison harness | #227 |
+| `promotion/` | Gate evaluation for production promotion | #80, #227 |
+| `results_db/` | SQLite results store + Alembic migrations | #79, #228 |
+| `experiments/` | Named experiment configuration files | #226 |
+| `data/` | Auction data scraper, projection snapshots | #192, #228 |
+| `backtest/` | Value-efficiency replay harness | #228 |
+| `eval/` | Projection accuracy evaluator | #228 |
 
 ## Usage
 

--- a/lab/backtest/__init__.py
+++ b/lab/backtest/__init__.py
@@ -1,0 +1,1 @@
+"""Auction replay backtest harness for strategy value-efficiency evaluation."""

--- a/lab/backtest/auction_replay.py
+++ b/lab/backtest/auction_replay.py
@@ -1,0 +1,34 @@
+"""Auction replay backtest harness for strategy value-efficiency evaluation.
+
+Replays historical auction pick data against a given strategy and measures
+how efficiently the strategy would have allocated budget. Implementation
+tracked by issue #228.
+"""
+
+from __future__ import annotations
+
+from typing import Any, List
+
+
+class AuctionBacktester:
+    """Replays historical auction data against a strategy to measure value efficiency.
+
+    Args:
+        strategy: An instantiated strategy object with a ``pick()`` interface.
+        player_data: List of player records from the auction corpus.
+    """
+
+    def __init__(self, strategy: Any, player_data: List[dict]) -> None:
+        self.strategy = strategy
+        self.player_data = player_data
+
+    def run(self) -> dict:
+        """Execute the backtest replay.
+
+        Returns:
+            A dict of evaluation metrics (e.g. roster value, budget efficiency).
+
+        Raises:
+            NotImplementedError: Until issue #228 is implemented.
+        """
+        raise NotImplementedError("AuctionBacktester.run — tracked by #228")

--- a/lab/benchmarks/__init__.py
+++ b/lab/benchmarks/__init__.py
@@ -1,0 +1,1 @@
+"""Strategy benchmarking and comparison harness."""

--- a/lab/benchmarks/reporter.py
+++ b/lab/benchmarks/reporter.py
@@ -1,0 +1,35 @@
+"""Benchmark report generator for strategy comparison results.
+
+Formats aggregate benchmark results into human-readable or machine-readable
+reports. Implementation tracked by issue #227.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Dict
+
+
+class BenchmarkReporter:
+    """Generates reports from benchmark run results.
+
+    Args:
+        results: Mapping of strategy name → aggregate metrics, as returned by
+            :class:`~lab.benchmarks.runner.BenchmarkRunner`.
+    """
+
+    def __init__(self, results: Dict[str, Any]) -> None:
+        self.results = results
+
+    def generate_report(self, output_format: str = "text") -> str:
+        """Render benchmark results as a formatted report.
+
+        Args:
+            output_format: One of ``"text"``, ``"markdown"``, or ``"json"``.
+
+        Returns:
+            The formatted report as a string.
+
+        Raises:
+            NotImplementedError: Until issue #227 is implemented.
+        """
+        raise NotImplementedError("BenchmarkReporter.generate_report — tracked by #227")

--- a/lab/benchmarks/runner.py
+++ b/lab/benchmarks/runner.py
@@ -1,0 +1,33 @@
+"""Benchmark runner for multi-strategy auction draft comparisons.
+
+Runs a configurable number of simulated drafts for each registered strategy
+and records aggregate metrics. Implementation tracked by issue #227.
+"""
+
+from __future__ import annotations
+
+from typing import List
+
+
+class BenchmarkRunner:
+    """Orchestrates benchmark runs across multiple strategies.
+
+    Args:
+        strategies: List of strategy names to benchmark.
+        runs: Number of simulation runs per strategy.
+    """
+
+    def __init__(self, strategies: List[str], runs: int = 100) -> None:
+        self.strategies = strategies
+        self.runs = runs
+
+    def run(self) -> dict:
+        """Execute benchmark runs for all configured strategies.
+
+        Returns:
+            A mapping of strategy name → aggregate result metrics.
+
+        Raises:
+            NotImplementedError: Until issue #227 is implemented.
+        """
+        raise NotImplementedError("BenchmarkRunner.run — tracked by #227")

--- a/lab/data/__init__.py
+++ b/lab/data/__init__.py
@@ -1,0 +1,1 @@
+"""Lab data acquisition: auction scrapers and projection snapshots."""

--- a/lab/eval/__init__.py
+++ b/lab/eval/__init__.py
@@ -1,0 +1,1 @@
+"""Projection accuracy evaluation module."""

--- a/lab/experiments/__init__.py
+++ b/lab/experiments/__init__.py
@@ -1,0 +1,1 @@
+"""Named experiment configuration and management module."""

--- a/lab/experiments/config.py
+++ b/lab/experiments/config.py
@@ -1,0 +1,33 @@
+"""Experiment configuration loader for named lab experiments.
+
+Provides :class:`ExperimentConfig`, which loads experiment parameters from
+a YAML or JSON config file. Implementation tracked by issue #226.
+"""
+
+from __future__ import annotations
+
+
+class ExperimentConfig:
+    """Configuration for a named lab experiment.
+
+    Attributes will be populated from a config file by :meth:`load_from_file`.
+    """
+
+    def __init__(self) -> None:
+        self.name: str = ""
+        self.params: dict = {}
+
+    @classmethod
+    def load_from_file(cls, path: str) -> "ExperimentConfig":
+        """Load experiment configuration from a YAML or JSON file.
+
+        Args:
+            path: Filesystem path to the config file.
+
+        Returns:
+            A populated :class:`ExperimentConfig` instance.
+
+        Raises:
+            NotImplementedError: Until issue #226 is implemented.
+        """
+        raise NotImplementedError("ExperimentConfig.load_from_file — tracked by #226")

--- a/lab/promotion/__init__.py
+++ b/lab/promotion/__init__.py
@@ -1,0 +1,1 @@
+"""Promotion gate for evaluating lab strategies for production promotion."""

--- a/lab/promotion/gate.py
+++ b/lab/promotion/gate.py
@@ -1,1 +1,25 @@
-# stub — implementation tracked by #80
+"""Promotion gate criteria checker for lab strategy graduation.
+
+Evaluates whether a lab strategy meets the performance thresholds required
+for promotion to the core production package. Implementation tracked by #80.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Dict
+
+
+def check_promotion_criteria(strategy_name: str, metrics: Dict[str, Any]) -> bool:
+    """Evaluate whether a strategy meets promotion thresholds.
+
+    Args:
+        strategy_name: The registered name of the strategy to evaluate.
+        metrics: Aggregate benchmark metrics for the strategy.
+
+    Returns:
+        ``True`` if all promotion criteria are met, ``False`` otherwise.
+
+    Raises:
+        NotImplementedError: Until issue #80 is implemented.
+    """
+    raise NotImplementedError("check_promotion_criteria — tracked by #80")

--- a/lab/promotion/promote.py
+++ b/lab/promotion/promote.py
@@ -1,0 +1,23 @@
+"""Promotion executor for graduating lab strategies to production.
+
+Applies the promotion gate result to copy a validated strategy from the lab
+package into the core ``strategies/`` package. Implementation tracked by #227.
+"""
+
+from __future__ import annotations
+
+
+def promote_strategy(strategy_name: str, dry_run: bool = False) -> None:
+    """Promote a lab strategy to the core production package.
+
+    Copies strategy source, updates ``strategies/__init__.py`` registration,
+    and records promotion metadata.
+
+    Args:
+        strategy_name: The registered name of the strategy to promote.
+        dry_run: If ``True``, validate without making filesystem changes.
+
+    Raises:
+        NotImplementedError: Until issue #227 is implemented.
+    """
+    raise NotImplementedError("promote_strategy — tracked by #227")

--- a/lab/results_db/__init__.py
+++ b/lab/results_db/__init__.py
@@ -1,0 +1,1 @@
+"""SQLite results store and Alembic migration management (ADR-004)."""

--- a/lab/simulation/__init__.py
+++ b/lab/simulation/__init__.py
@@ -1,0 +1,1 @@
+"""Simulation runner module for multi-strategy auction draft benchmarking."""


### PR DESCRIPTION
## Track A — Lab Scaffolding

Creates stub/scaffold files for the lab module, unblocking Tracks B and C implementation.

### Issues
- Closes #226 — `lab/simulation/` and `lab/experiments/` stubs
- Closes #227 — `lab/benchmarks/` and `lab/promotion/` stubs
- Closes #228 — `lab/data/`, `lab/backtest/`, `lab/eval/`, `lab/results_db/` stubs + README

### Changes
| File | Status |
|------|--------|
| `lab/experiments/config.py` | New — `ExperimentConfig` stub |
| `lab/benchmarks/runner.py` | New — `BenchmarkRunner` stub |
| `lab/benchmarks/reporter.py` | New — `BenchmarkReporter` stub |
| `lab/promotion/promote.py` | New — `promote_strategy()` stub |
| `lab/backtest/auction_replay.py` | New — `AuctionBacktester` stub |
| `lab/promotion/gate.py` | Updated — added `check_promotion_criteria()` function |
| `lab/*/__init__.py` (8 files) | Updated — added module docstrings |
| `lab/README.md` | Updated — tracking column with sprint 11 issue numbers |

### Notes
- All classes/functions raise `NotImplementedError` to be implemented in subsequent tracks
- All modules are importable without error (verified)
- Existing tests: **1464 passed**, 0 failures
- No QA gate required for stub files (no behavior to test)