### PR TITLE
feat(lab): implement SimulationRunner and ExperimentConfig — closes #187, closes #188

### DIFF
--- a/lab/experiments/config.py
+++ b/lab/experiments/config.py
@@ -1,25 +1,30 @@
 """Experiment configuration loader for named lab experiments.
 
 Provides :class:`ExperimentConfig`, which loads experiment parameters from
-a YAML or JSON config file. Implementation tracked by issue #226.
+a YAML or JSON config file. Closes #188.
 """
 
 from __future__ import annotations
 
+import json
+from pathlib import Path
+from typing import Any, Dict, List
+
 
 class ExperimentConfig:
-    """Configuration for a named lab experiment.
+    """Configuration for a named lab experiment loaded from a YAML or JSON file."""
 
-    Attributes will be populated from a config file by :meth:`load_from_file`.
-    """
+    REQUIRED_FIELDS = ("name", "strategies", "num_simulations")
 
-    def __init__(self) -> None:
-        self.name: str = ""
-        self.params: dict = {}
+    def __init__(self, name: str, strategies: List[str], num_simulations: int, **extra: Any) -> None:
+        self.name = name
+        self.strategies = strategies
+        self.num_simulations = num_simulations
+        self._extra = extra
 
     @classmethod
     def load_from_file(cls, path: str) -> "ExperimentConfig":
-        """Load experiment configuration from a YAML or JSON file.
+        """Load experiment config from a YAML (.yaml/.yml) or JSON (.json) file.
 
         Args:
             path: Filesystem path to the config file.
@@ -28,6 +33,47 @@ class ExperimentConfig:
             A populated :class:`ExperimentConfig` instance.
 
         Raises:
-            NotImplementedError: Until issue #226 is implemented.
+            FileNotFoundError: If the file does not exist.
+            ValueError: If required fields are missing or invalid.
+            ImportError: If PyYAML is not installed for YAML files.
         """
-        raise NotImplementedError("ExperimentConfig.load_from_file — tracked by #226")
+        file_path = Path(path)
+        if not file_path.exists():
+            raise FileNotFoundError(f"Config file not found: {path}")
+
+        raw: Dict[str, Any]
+        suffix = file_path.suffix.lower()
+        if suffix in (".yaml", ".yml"):
+            try:
+                import yaml  # type: ignore[import]
+            except ImportError as exc:
+                raise ImportError(
+                    "PyYAML is required for YAML config files: pip install pyyaml"
+                ) from exc
+            with open(file_path) as f:
+                raw = yaml.safe_load(f) or {}
+        elif suffix == ".json":
+            with open(file_path) as f:
+                raw = json.load(f)
+        else:
+            raise ValueError(f"Unsupported config format: {suffix!r}. Use .yaml or .json")
+
+        return cls._validate_and_build(raw)
+
+    @classmethod
+    def _validate_and_build(cls, raw: Dict[str, Any]) -> "ExperimentConfig":
+        """Validate raw config dict and return an :class:`ExperimentConfig`."""
+        for field_name in cls.REQUIRED_FIELDS:
+            if field_name not in raw:
+                raise ValueError(f"Missing required field: {field_name!r}")
+
+        num_sim = raw["num_simulations"]
+        if not isinstance(num_sim, int) or num_sim <= 0:
+            raise ValueError(f"num_simulations must be a positive integer, got {num_sim!r}")
+
+        strategies = raw["strategies"]
+        if not isinstance(strategies, list) or not strategies:
+            raise ValueError("strategies must be a non-empty list")
+
+        extra = {k: v for k, v in raw.items() if k not in cls.REQUIRED_FIELDS}
+        return cls(name=raw["name"], strategies=strategies, num_simulations=num_sim, **extra)

--- a/lab/simulation/runner.py
+++ b/lab/simulation/runner.py
@@ -23,7 +23,7 @@ import uuid
 from concurrent.futures import ThreadPoolExecutor, as_completed
 from dataclasses import dataclass, field
 from datetime import datetime
-from typing import Dict, List, Optional
+from typing import Dict, List, Optional, Union, overload
 
 from classes.tournament import Tournament  # type: ignore
 
@@ -194,7 +194,11 @@ class SimulationRunner:
     # Public API
     # ------------------------------------------------------------------
 
-    def run(self, n_simulations: int = None) -> "List[SimulationResult] | Dict[str, Dict]":
+    @overload
+    def run(self, n_simulations: int) -> List[SimulationResult]: ...
+    @overload
+    def run(self, n_simulations: None = None) -> Dict[str, Dict]: ...
+    def run(self, n_simulations: Optional[int] = None) -> Union[List[SimulationResult], Dict[str, Dict]]:
         """Run simulations and return results.
 
         When *n_simulations* is provided, runs that many individual simulations

--- a/lab/simulation/runner.py
+++ b/lab/simulation/runner.py
@@ -20,12 +20,23 @@ import json
 import logging
 import subprocess
 import uuid
+from concurrent.futures import ThreadPoolExecutor, as_completed
+from dataclasses import dataclass, field
 from datetime import datetime
 from typing import Dict, List, Optional
 
 from classes.tournament import Tournament  # type: ignore
 
 logger = logging.getLogger(__name__)
+
+
+@dataclass
+class SimulationResult:
+    """Result of a single simulation run."""
+
+    strategy_name: str
+    score: float
+    rank: int = field(default=0)
 
 
 def _git_sha() -> str:
@@ -168,6 +179,7 @@ class SimulationRunner:
         num_opponents: int = 11,
         db_url: str = "sqlite+aiosqlite:///lab/results_db/pigskin_lab.db",
         experiment_id: Optional[str] = None,
+        max_workers: int = 4,
     ) -> None:
         self.strategies = strategies or ["all"]
         self.runs = runs
@@ -176,14 +188,71 @@ class SimulationRunner:
         self.num_opponents = num_opponents
         self.db_url = db_url
         self.experiment_id = experiment_id or str(uuid.uuid4())[:8]
+        self.max_workers = max_workers
 
     # ------------------------------------------------------------------
     # Public API
     # ------------------------------------------------------------------
 
-    def run(self) -> Dict[str, Dict]:
-        """Execute the benchmark synchronously. Returns per-strategy summaries."""
+    def run(self, n_simulations: int = None) -> "List[SimulationResult] | Dict[str, Dict]":
+        """Run simulations and return results.
+
+        When *n_simulations* is provided, runs that many individual simulations
+        in parallel via :class:`ThreadPoolExecutor` and returns a ranked
+        ``List[SimulationResult]`` (rank 1 = highest score).
+
+        When called with no arguments (legacy mode), executes the full benchmark
+        pipeline via ``asyncio`` and returns per-strategy summary dicts.
+        """
+        if n_simulations is not None:
+            return self._run_parallel(n_simulations)
         return asyncio.run(self._run_async())
+
+    def _run_parallel(self, n_simulations: int) -> List[SimulationResult]:
+        """Run *n_simulations* individual simulations via ThreadPoolExecutor."""
+        results: List[SimulationResult] = []
+        workers = min(self.max_workers, n_simulations)
+        with ThreadPoolExecutor(max_workers=workers) as executor:
+            futures = {
+                executor.submit(self._run_single, i): i
+                for i in range(n_simulations)
+            }
+            for future in as_completed(futures):
+                sim_id = futures[future]
+                try:
+                    results.append(future.result())
+                except Exception as exc:  # noqa: BLE001
+                    logger.warning("Simulation %d failed: %s", sim_id, exc)
+                    results.append(SimulationResult(strategy_name="error", score=0.0))
+
+        results.sort(key=lambda r: r.score, reverse=True)
+        for rank, result in enumerate(results, start=1):
+            result.rank = rank
+        return results
+
+    def _run_single(self, sim_id: int) -> SimulationResult:
+        """Run one simulation and return a :class:`SimulationResult`.
+
+        The strategy is cycled from :attr:`strategies` by *sim_id* index.
+        Exceptions are propagated so the caller can record an error result.
+        """
+        keys = [
+            k for k in (self.strategies or [])
+            if k != "all"
+        ] or ["balanced"]
+        strategy_key = keys[sim_id % len(keys)]
+        players = _load_players()
+        all_results = _run_tournament_for_strategy(
+            strategy_key=strategy_key,
+            players=players,
+            budget=self.budget,
+            roster_size=self.roster_size,
+            num_opponents=self.num_opponents,
+            runs=1,
+        )
+        focal = all_results.get(strategy_key, {})
+        score = float(focal.get("win_rate", 0.0))
+        return SimulationResult(strategy_name=strategy_key, score=score)
 
     # ------------------------------------------------------------------
     # Internals

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,6 +24,7 @@ dependencies = [
     "pydantic-settings>=2.0.0",
     "fastapi>=0.110.0",
     "uvicorn[standard]>=0.29.0",
+    "pyyaml>=6.0",
 ]
 
 [project.scripts]

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,3 +8,4 @@ colorama>=0.4.6
 pydantic-settings>=2.0.0
 fastapi>=0.110.0
 uvicorn[standard]>=0.29.0
+pyyaml>=6.0

--- a/tests/unit/lab/test_experiment_config.py
+++ b/tests/unit/lab/test_experiment_config.py
@@ -1,0 +1,82 @@
+"""Unit tests for ExperimentConfig — QA Phase 1 — closes #188."""
+from __future__ import annotations
+
+import json
+import os
+import tempfile
+import unittest
+
+
+class TestExperimentConfigLoad(unittest.TestCase):
+    """ExperimentConfig.load_from_file() supports YAML and JSON."""
+
+    def _write_temp(self, content: str, suffix: str) -> str:
+        f = tempfile.NamedTemporaryFile(mode="w", suffix=suffix, delete=False)
+        f.write(content)
+        f.flush()
+        f.close()
+        return f.name
+
+    def test_load_from_yaml_returns_experiment_config(self):
+        from lab.experiments.config import ExperimentConfig
+
+        yaml_content = (
+            "name: test_experiment\n"
+            "strategies:\n"
+            "  - balanced\n"
+            "  - basic\n"
+            "num_simulations: 10\n"
+        )
+        path = self._write_temp(yaml_content, ".yaml")
+        try:
+            config = ExperimentConfig.load_from_file(path)
+            self.assertIsInstance(config, ExperimentConfig)
+            self.assertEqual(config.name, "test_experiment")
+            self.assertEqual(config.num_simulations, 10)
+            self.assertIn("balanced", config.strategies)
+        finally:
+            os.unlink(path)
+
+    def test_load_from_json_returns_experiment_config(self):
+        from lab.experiments.config import ExperimentConfig
+
+        data = {"name": "json_exp", "strategies": ["balanced"], "num_simulations": 5}
+        path = self._write_temp(json.dumps(data), ".json")
+        try:
+            config = ExperimentConfig.load_from_file(path)
+            self.assertIsInstance(config, ExperimentConfig)
+            self.assertEqual(config.name, "json_exp")
+        finally:
+            os.unlink(path)
+
+
+class TestExperimentConfigValidation(unittest.TestCase):
+    """Missing or invalid fields raise ValueError."""
+
+    def test_missing_name_raises_value_error(self):
+        from lab.experiments.config import ExperimentConfig
+
+        raw = {"strategies": ["balanced"], "num_simulations": 5}
+        with self.assertRaises(ValueError):
+            ExperimentConfig._validate_and_build(raw)
+
+    def test_missing_strategies_raises_value_error(self):
+        from lab.experiments.config import ExperimentConfig
+
+        raw = {"name": "test", "num_simulations": 5}
+        with self.assertRaises(ValueError):
+            ExperimentConfig._validate_and_build(raw)
+
+    def test_num_simulations_zero_raises_value_error(self):
+        from lab.experiments.config import ExperimentConfig
+
+        raw = {"name": "test", "strategies": ["balanced"], "num_simulations": 0}
+        with self.assertRaises(ValueError):
+            ExperimentConfig._validate_and_build(raw)
+
+    def test_num_simulations_negative_raises_value_error(self):
+        from lab.experiments.config import ExperimentConfig
+
+        raw = {"name": "test", "strategies": ["balanced"], "num_simulations": -1}
+        with self.assertRaises(ValueError):
+            ExperimentConfig._validate_and_build(raw)

--- a/tests/unit/lab/test_simulation_runner.py
+++ b/tests/unit/lab/test_simulation_runner.py
@@ -1,0 +1,93 @@
+"""Unit tests for SimulationRunner — QA Phase 1 — closes #187."""
+from __future__ import annotations
+
+import unittest
+from unittest.mock import patch
+
+
+class TestSimulationRunnerInstantiation(unittest.TestCase):
+    """SimulationRunner can be instantiated with no args."""
+
+    def test_instantiation(self):
+        from lab.simulation.runner import SimulationRunner
+
+        runner = SimulationRunner()
+        self.assertIsNotNone(runner)
+
+
+class TestSimulationRunnerRun(unittest.TestCase):
+    """run(n_simulations=N) returns a list of N SimulationResult objects."""
+
+    def _make_result(self, name: str = "balanced", score: float = 0.5):
+        from lab.simulation.runner import SimulationResult
+
+        return SimulationResult(strategy_name=name, score=score)
+
+    def test_run_returns_list_of_n_results(self):
+        from lab.simulation.runner import SimulationRunner
+
+        runner = SimulationRunner(strategies=["balanced"])
+        with patch.object(runner, "_run_single", side_effect=[
+            self._make_result(score=0.9),
+            self._make_result(score=0.5),
+            self._make_result(score=0.3),
+        ]):
+            results = runner.run(n_simulations=3)
+
+        self.assertIsInstance(results, list)
+        self.assertEqual(len(results), 3)
+
+    def test_each_result_has_required_fields(self):
+        from lab.simulation.runner import SimulationRunner
+
+        runner = SimulationRunner(strategies=["balanced"])
+        with patch.object(runner, "_run_single", side_effect=[
+            self._make_result("balanced", 0.9),
+            self._make_result("balanced", 0.5),
+            self._make_result("balanced", 0.3),
+        ]):
+            results = runner.run(n_simulations=3)
+
+        for r in results:
+            self.assertIsInstance(r.strategy_name, str)
+            self.assertIsInstance(r.score, float)
+            self.assertIsInstance(r.rank, int)
+
+    def test_strategy_error_doesnt_crash(self):
+        """A simulation that raises should not propagate — it produces an error result."""
+        from lab.simulation.runner import SimulationRunner
+
+        runner = SimulationRunner(strategies=["balanced"])
+        call_count = 0
+
+        def flaky_side_effect(sim_id: int):
+            nonlocal call_count
+            call_count += 1
+            if call_count == 2:
+                raise RuntimeError("strategy exploded")
+            return self._make_result(score=0.5)
+
+        with patch.object(runner, "_run_single", side_effect=flaky_side_effect):
+            results = runner.run(n_simulations=3)
+
+        # All 3 results returned despite one failure
+        self.assertEqual(len(results), 3)
+
+    def test_results_sorted_by_rank(self):
+        """Rank 1 corresponds to highest score; results are in ascending rank order."""
+        from lab.simulation.runner import SimulationRunner
+
+        runner = SimulationRunner(strategies=["balanced"])
+        with patch.object(runner, "_run_single", side_effect=[
+            self._make_result(score=0.3),
+            self._make_result(score=0.9),
+            self._make_result(score=0.5),
+        ]):
+            results = runner.run(n_simulations=3)
+
+        ranks = [r.rank for r in results]
+        self.assertEqual(ranks, sorted(ranks))
+        # Rank 1 has the highest score
+        self.assertEqual(results[0].rank, 1)
+        self.assertGreaterEqual(results[0].score, results[1].score)
+        self.assertGreaterEqual(results[1].score, results[2].score)


### PR DESCRIPTION
## Track C — Lab Simulation & Experiments

### Implementation
- `lab/simulation/runner.py`: Added `SimulationResult` dataclass and `_run_parallel` / `_run_single` methods. `run(n_simulations: int)` now executes N simulations in parallel via `ThreadPoolExecutor`, returns a ranked `List[SimulationResult]` (rank 1 = highest score). Legacy `run()` benchmark path preserved via `@overload`.
- `lab/experiments/config.py`: Full `ExperimentConfig` implementation with `load_from_file()` supporting `.yaml`/`.yml` and `.json`, field validation raising `ValueError` on missing or invalid fields.
- `requirements.txt` / `pyproject.toml`: Added `pyyaml>=6.0` (was installed but undeclared).

### QA Gate
QA Phase 1 tests written **before** implementation. Labels `qa:tests-defined` applied to #187, #188.

### Test Results
```
11 passed in 0.11s   (new unit tests)
1788 passed, 16 xfailed, 95.21% coverage  (full suite CI gate)
```

Closes #187
Closes #188
