### PR TITLE
refactor: cleanup — dynamic season defaults, BidRequest validation, CLI stderr, ConfigManager audit — closes #107, #108, #295

### DIFF
--- a/api/schemas/auction.py
+++ b/api/schemas/auction.py
@@ -3,9 +3,9 @@ from pydantic import BaseModel, Field
 
 
 class BidRequest(BaseModel):
-    player_id: str
+    player_id: str = Field(min_length=1)
     bid_amount: int = Field(ge=1)
-    team_name: str
+    team_name: str = Field(min_length=1)
 
 
 class BidResponse(BaseModel):

--- a/api/sleeper_api.py
+++ b/api/sleeper_api.py
@@ -3,6 +3,7 @@
 import asyncio
 import random
 import httpx
+from datetime import datetime
 from typing import Dict, List, Optional, Any
 import time
 from urllib.parse import quote
@@ -105,7 +106,7 @@ class SleeperAPI:
             return None
 
     # League methods
-    async def get_user_leagues(self, user_id: str, season: str = "2024") -> List[Dict]:
+    async def get_user_leagues(self, user_id: str, season: str = str(datetime.now().year)) -> List[Dict]:
         """Get leagues for a user in a specific season."""
         try:
             return await self._make_request(
@@ -222,7 +223,7 @@ class SleeperAPI:
             
     # Stats methods
     async def get_player_stats(
-        self, season: str = "2024", week: Optional[int] = None
+        self, season: str = str(datetime.now().year), week: Optional[int] = None
     ) -> Dict[str, Dict]:
         """Get player stats for season or specific week."""
         try:
@@ -238,7 +239,7 @@ class SleeperAPI:
             return {}
             
     async def get_player_projections(
-        self, season: str = "2024", week: Optional[int] = None
+        self, season: str = str(datetime.now().year), week: Optional[int] = None
     ) -> Dict[str, Dict]:
         """Get player projections for season or specific week."""
         try:

--- a/cli/main.py
+++ b/cli/main.py
@@ -66,7 +66,7 @@ class AuctionDraftCLI:
     def _handle_command_result(self, result: Dict, error_message: str = "Command failed") -> int:
         """Helper to handle standard command result patterns."""
         if not result.get('success', False):
-            print(f"ERROR: {result.get('error', error_message)}")
+            print(f"ERROR: {result.get('error', error_message)}", file=sys.stderr)
             return 1
         return 0
 
@@ -93,7 +93,7 @@ class AuctionDraftCLI:
                 self.show_help()
                 return 0
             else:
-                print(f"ERROR: Unknown command: {command}")
+                print(f"ERROR: Unknown command: {command}", file=sys.stderr)
                 print("Use 'help' to see available commands")
                 return 1
                 
@@ -101,13 +101,13 @@ class AuctionDraftCLI:
             print("\nOperation cancelled by user")
             return 130
         except Exception as e:
-            print(f"ERROR: {e}")
+            print(f"ERROR: {e}", file=sys.stderr)
             return 1
     
     def handle_bid_command(self, args: List[str]) -> int:
         """Handle bid recommendation command."""
         if not args:
-            print("ERROR: Player name required")
+            print("ERROR: Player name required", file=sys.stderr)
             print("Usage: bid <player_name> [current_bid] [sleeper_draft_id]")
             print("Note: Use quotes for multi-word names: bid 'Josh Allen' 25")
             return 1
@@ -128,7 +128,7 @@ class AuctionDraftCLI:
             self._display_bid_recommendation(result)
             return 0
         else:
-            print(f"ERROR: {result.get('error', 'Failed to get bid recommendation')}")
+            print(f"ERROR: {result.get('error', 'Failed to get bid recommendation')}", file=sys.stderr)
             return 1
     
     def handle_mock_command(self, args: List[str]) -> int:
@@ -168,14 +168,14 @@ class AuctionDraftCLI:
             strategies = [s.strip() for s in strategy_arg.split(',')]
             invalid_strategies = [s for s in strategies if s not in AVAILABLE_STRATEGIES]
             if invalid_strategies:
-                print(f"ERROR: Invalid strategies: {', '.join(invalid_strategies)}")
+                print(f"ERROR: Invalid strategies: {', '.join(invalid_strategies)}", file=sys.stderr)
                 print(f"Available strategies: {', '.join(AVAILABLE_STRATEGIES)}")
                 return 1
             strategy_display = f"{len(strategies)} strategies: {', '.join(strategies)}"
         else:
             strategies = strategy_arg
             if strategy_arg not in AVAILABLE_STRATEGIES:
-                print(f"ERROR: Invalid strategy: {strategy_arg}")
+                print(f"ERROR: Invalid strategy: {strategy_arg}", file=sys.stderr)
                 print(f"Available strategies: {', '.join(AVAILABLE_STRATEGIES)}")
                 return 1
             strategy_display = strategy_arg
@@ -191,7 +191,7 @@ class AuctionDraftCLI:
             self._display_mock_results(result)
             return 0
         else:
-            print(f"ERROR: {result.get('error', 'Mock draft failed')}")
+            print(f"ERROR: {result.get('error', 'Mock draft failed')}", file=sys.stderr)
             return 1
     
     def handle_tournament_command(self, args: List[str]) -> int:
@@ -212,13 +212,13 @@ class AuctionDraftCLI:
             try:
                 rounds = int(filtered_args[0])
             except ValueError:
-                print(f"ERROR: Invalid rounds value '{filtered_args[0]}' — must be an integer")
+                print(f"ERROR: Invalid rounds value '{filtered_args[0]}' — must be an integer", file=sys.stderr)
                 return 1
         if len(filtered_args) > 1:
             try:
                 teams_per_draft = int(filtered_args[1])
             except ValueError:
-                print(f"ERROR: Invalid teams_per_draft value '{filtered_args[1]}' — must be an integer")
+                print(f"ERROR: Invalid teams_per_draft value '{filtered_args[1]}' — must be an integer", file=sys.stderr)
                 return 1
         
         print("Starting elimination tournament...")
@@ -234,7 +234,7 @@ class AuctionDraftCLI:
             self._display_tournament_results(result)
             return 0
         else:
-            print(f"ERROR: Tournament failed: {result.get('error', 'Unknown error')}")
+            print(f"ERROR: Tournament failed: {result.get('error', 'Unknown error')}", file=sys.stderr)
             return 1
     
     def handle_ping_command(self, args: List[str]) -> int:
@@ -252,7 +252,7 @@ class AuctionDraftCLI:
     def handle_sleeper_command(self, args: List[str]) -> int:
         """Handle Sleeper draft commands."""
         if not args:
-            print("ERROR: Sleeper command requires subcommand")
+            print("ERROR: Sleeper command requires subcommand", file=sys.stderr)
             print("Usage: sleeper <subcommand> [options]")
             print("Subcommands: status, draft, league, leagues")
             return 1
@@ -270,7 +270,7 @@ class AuctionDraftCLI:
         elif subcommand == "cache":
             return self.handle_sleeper_cache(args[1:])
         else:
-            print(f"ERROR: Unknown Sleeper subcommand: {subcommand}")
+            print(f"ERROR: Unknown Sleeper subcommand: {subcommand}", file=sys.stderr)
             print("Available subcommands: status, draft, league, leagues, cache")
             return 1
     
@@ -280,7 +280,7 @@ class AuctionDraftCLI:
         default_username = self._get_config_default('sleeper_username')
         
         if not args and not default_username:
-            print("ERROR: Username required (not provided and not set in config)")
+            print("ERROR: Username required (not provided and not set in config)", file=sys.stderr)
             print("Usage: sleeper status <username> [season]")
             print("Or set 'sleeper_username' in config/config.json")
             return 1
@@ -299,7 +299,7 @@ class AuctionDraftCLI:
         default_draft_id = getattr(config, 'sleeper_draft_id', None)
         
         if not args and not default_draft_id:
-            print("ERROR: Draft ID required (not provided and not set in config)")
+            print("ERROR: Draft ID required (not provided and not set in config)", file=sys.stderr)
             print("Usage: sleeper draft <draft_id>")
             print("Or set 'sleeper_draft_id' in config/config.json")
             return 1
@@ -315,7 +315,7 @@ class AuctionDraftCLI:
         # For league command, we could potentially derive league_id from user's current leagues
         # but for now, require explicit league_id as there's no direct config default
         if not args:
-            print("ERROR: League ID required")
+            print("ERROR: League ID required", file=sys.stderr)
             print("Usage: sleeper league <league_id>")
             print("Tip: Use 'sleeper leagues <username>' to find league IDs")
             return 1
@@ -331,7 +331,7 @@ class AuctionDraftCLI:
         default_username = self._get_config_default('sleeper_username')
         
         if not args and not default_username:
-            print("ERROR: Username required (not provided and not set in config)")
+            print("ERROR: Username required (not provided and not set in config)", file=sys.stderr)
             print("Usage: sleeper leagues <username> [season]")
             print("Or set 'sleeper_username' in config/config.json")
             return 1
@@ -391,7 +391,7 @@ class AuctionDraftCLI:
                 print("Failed to clear player cache")
                 return 1
         else:
-            print(f"ERROR: Unknown cache action: {action}")
+            print(f"ERROR: Unknown cache action: {action}", file=sys.stderr)
             print("Available actions: info, refresh, clear")
             return 1
     
@@ -618,7 +618,7 @@ class AuctionDraftCLI:
                 print("  No undervalued players found.")
             return 0
         else:
-            print(f"ERROR: {result.get('error', 'Analysis failed')}")
+            print(f"ERROR: {result.get('error', 'Analysis failed')}", file=sys.stderr)
             return 1
 
 

--- a/tests/unit/api/test_sleeper_api.py
+++ b/tests/unit/api/test_sleeper_api.py
@@ -187,7 +187,10 @@ class TestSleeperAPIUserMethods:
         
         assert len(result) == 2
         assert result[0]['league_id'] == 'league1'
-        self.api._make_request.assert_called_once_with('/user/user123/leagues/nfl/2024')
+        from datetime import datetime
+        self.api._make_request.assert_called_once_with(
+            f'/user/user123/leagues/nfl/{datetime.now().year}'
+        )
     
     async def test_get_user_leagues_custom_season(self):
         """Test getting user leagues for custom season."""
@@ -335,7 +338,10 @@ class TestSleeperAPIPlayerMethods:
         
         assert 'player1' in result
         assert result['player1']['pts'] == 300.5
-        self.api._make_request.assert_called_once_with('/projections/nfl/regular/2024')
+        from datetime import datetime
+        self.api._make_request.assert_called_once_with(
+            f'/projections/nfl/regular/{datetime.now().year}'
+        )
     
     async def test_get_player_projections_with_week(self):
         """Test getting player projections for specific week."""

--- a/tests/unit/cli/test_main.py
+++ b/tests/unit/cli/test_main.py
@@ -65,7 +65,8 @@ class TestAuctionDraftCLI:
         result = {'success': False, 'error': 'Test error'}
         exit_code = cli._handle_command_result(result)
         assert exit_code == 1
-        mock_print.assert_called_with("ERROR: Test error")
+        import sys
+        mock_print.assert_called_with("ERROR: Test error", file=sys.stderr)
 
 
 class TestCommandRouting:


### PR DESCRIPTION
## Track E — Cleanup Batch

Batches four P3 improvements into one PR to reduce review overhead.

### Changes

#### #93 — ConfigManager → get_settings() migration
**Deferred — out of scope.** `ConfigManager` is not a thin shim: it owns a full `DraftConfig` dataclass, reads/writes `config.json`, performs migration/validation, and layers env-var settings on top. It has 11 non-test callers (CLI, services, integrations). Replacing it wholesale with the Pydantic-settings-backed `get_settings()` would require schema consolidation across `config.json` and `.env`. Recommend a dedicated refactor sprint with new integration tests before touching callers.

#### #107 — api/sleeper_api.py hardcoded season
Replaced hardcoded `'2024'` default with `str(datetime.now().year)` in three methods:
- `get_user_leagues()`
- `get_player_stats()`
- `get_player_projections()`

Added `from datetime import datetime` import. Updated two unit tests that were asserting the old default URL segment.

#### #108 — api/schemas/auction.py BidRequest validation
Added `min_length=1` to `player_id` and `team_name` string fields in `BidRequest` to reject empty strings at the schema boundary. Over-budget cross-field validation deliberately left to the service layer per ADR-002. PR #375 (P0 security hotfix) does not touch `api/schemas/auction.py` — no merge conflict risk.

#### #295 — CLI standardization per ADR-010
ADR-010 exists (`docs/adr/ADR-010-cli-standardization.md`). The full Click migration and positional-arg deprecation are out of scope (structural changes tracked via #19). Small violation fixed: 19 `print("ERROR: ...")` calls in `cli/main.py` now route to `sys.stderr` (ADR-010 §5 exit-code contract requires errors on stderr). Updated the one unit test asserting the `print` call signature.

### Test Results
```
1483 passed, 16 xfailed, 20 warnings in 3.94s
```
