### PR TITLE
feat(cicd): make openapi target, promotion script dry-run — closes #182, #191

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 # Makefile for Pigskin Auction Draft Tool
 
-.PHONY: setup install dev-install lock test clean help run-tests format lint typecheck coverage security audit ci standup lab-bench lab-gate install-hooks hooks
+.PHONY: setup install dev-install lock test clean help run-tests format lint typecheck coverage security audit ci standup lab-bench lab-gate openapi install-hooks hooks
 
 # Default target
 help:
@@ -29,6 +29,9 @@ help:
 	@echo "  standup     - Print daily standup summary (git log + project board)"
 	@echo "  clean       - Clean up cache and temporary files"
 	@echo "  install-hooks - Install shared git hooks from .githooks/ (aliases: hooks)"
+	@echo ""
+	@echo "API:"
+	@echo "  openapi     - Generate docs/api/openapi.yaml from the FastAPI app"
 	@echo ""
 	@echo "Lab (pigskin-lab — ADR-001/Sprint 5 migration required):"
 	@echo "  lab-bench   - Run simulation benchmark batch (STRATEGY=all or STRATEGY=<name>)"
@@ -187,6 +190,16 @@ lab-gate:
 		echo "The lab/ structure requires the ADR-001 Sprint 5 migration to be complete."; \
 		exit 1; \
 	fi
+
+# Generate OpenAPI schema from FastAPI app
+openapi:
+	@echo "Generating OpenAPI schema..."
+	@python -c "\
+import json, yaml; \
+from api.main import app; \
+schema = app.openapi(); \
+open('docs/api/openapi.yaml', 'w').write(yaml.dump(schema, default_flow_style=False)); \
+print('Written to docs/api/openapi.yaml')"
 
 standup:
 	@echo "=== Daily Standup — $$(date +%Y-%m-%d) ==="

--- a/docs/api/openapi.yaml
+++ b/docs/api/openapi.yaml
@@ -1,94 +1,234 @@
-openapi: "3.1.0"
-info:
-  title: Pigskin Draft Assistant API
-  version: "0.1.0"
-  description: |
-    Fantasy football auction draft assistant.
-    All endpoints are versioned under /api/v1/ (planned).
-    Current scaffold uses root paths.
-  contact:
-    name: Pigskin Dev Team
-
-servers:
-  - url: http://localhost:8000
-    description: Local development
-
-paths:
-  /health:
-    get:
-      summary: Health check
-      tags: [meta]
-      responses:
-        "200":
-          description: Service is healthy
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/HealthResponse"
-
-  /strategies/:
-    get:
-      summary: List available bidding strategies
-      tags: [strategies]
-      responses:
-        "200":
-          description: List of strategy names
-          content:
-            application/json:
-              schema:
-                type: array
-                items:
-                  type: string
-
-  /players/:
-    get:
-      summary: List players (not yet implemented)
-      tags: [players]
-      responses:
-        "200":
-          description: Placeholder
-          content:
-            application/json:
-              schema:
-                type: object
-
-  /draft/:
-    get:
-      summary: Draft status (not yet implemented)
-      tags: [draft]
-      responses:
-        "200":
-          description: Placeholder
-          content:
-            application/json:
-              schema:
-                type: object
-
-  /auction/:
-    get:
-      summary: Auction operations (not yet implemented)
-      tags: [auction]
-      responses:
-        "200":
-          description: Placeholder
-          content:
-            application/json:
-              schema:
-                type: object
-
 components:
   schemas:
-    HealthResponse:
-      type: object
+    BidRecommendationRequest:
+      description: Request body for POST /recommend/bid.
       properties:
-        status:
+        current_bid:
+          description: Current highest bid (0 if no bids yet)
+          minimum: 0.0
+          title: Current Bid
+          type: number
+        player_id:
+          anyOf:
+          - type: string
+          - type: 'null'
+          description: Sleeper player ID (optional)
+          title: Player Id
+        player_name:
+          description: Name of the player to bid on
+          minLength: 1
+          title: Player Name
           type: string
-          example: ok
-
+        roster_spots_remaining:
+          default: 1
+          description: Number of roster spots still to fill
+          minimum: 1.0
+          title: Roster Spots Remaining
+          type: integer
+        sleeper_draft_id:
+          anyOf:
+          - type: string
+          - type: 'null'
+          description: Sleeper draft ID for live draft context
+          title: Sleeper Draft Id
+        strategy_override:
+          anyOf:
+          - type: string
+          - type: 'null'
+          description: Override the configured strategy
+          title: Strategy Override
+        team_budget:
+          description: Remaining team budget in dollars
+          minimum: 0.0
+          title: Team Budget
+          type: number
+      required:
+      - player_name
+      - current_bid
+      - team_budget
+      title: BidRecommendationRequest
+      type: object
+    BidRecommendationResponse:
+      description: Response body for POST /recommend/bid.
+      properties:
+        confidence:
+          description: Confidence score [0, 1]
+          maximum: 1.0
+          minimum: 0.0
+          title: Confidence
+          type: number
+        rationale:
+          description: Human-readable explanation for the recommendation
+          title: Rationale
+          type: string
+        recommended_bid:
+          description: Recommended bid amount in dollars
+          title: Recommended Bid
+          type: number
+      required:
+      - recommended_bid
+      - confidence
+      - rationale
+      title: BidRecommendationResponse
+      type: object
+    HTTPValidationError:
+      properties:
+        detail:
+          items:
+            $ref: '#/components/schemas/ValidationError'
+          title: Detail
+          type: array
+      title: HTTPValidationError
+      type: object
+    ValidationError:
+      properties:
+        ctx:
+          title: Context
+          type: object
+        input:
+          title: Input
+        loc:
+          items:
+            anyOf:
+            - type: string
+            - type: integer
+          title: Location
+          type: array
+        msg:
+          title: Message
+          type: string
+        type:
+          title: Error Type
+          type: string
+      required:
+      - loc
+      - msg
+      - type
+      title: ValidationError
+      type: object
   securitySchemes:
-    ApiKeyAuth:
-      type: apiKey
+    APIKeyHeader:
       in: header
       name: X-API-Key
-
-security: []
+      type: apiKey
+info:
+  description: Fantasy football auction draft assistant API
+  title: Pigskin Draft Assistant
+  version: 0.1.0
+openapi: 3.1.0
+paths:
+  /auction/:
+    get:
+      operationId: auction_index_auction__get
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                additionalProperties: true
+                title: Response Auction Index Auction  Get
+                type: object
+          description: Successful Response
+      security:
+      - APIKeyHeader: []
+      summary: Auction operations (not yet implemented)
+      tags:
+      - auction
+  /draft/:
+    get:
+      operationId: draft_index_draft__get
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                additionalProperties: true
+                title: Response Draft Index Draft  Get
+                type: object
+          description: Successful Response
+      security:
+      - APIKeyHeader: []
+      summary: Draft operations (not yet implemented)
+      tags:
+      - draft
+  /health:
+    get:
+      operationId: health_health_get
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                additionalProperties: true
+                title: Response Health Health Get
+                type: object
+          description: Successful Response
+      summary: Health
+      tags:
+      - meta
+  /players/:
+    get:
+      operationId: list_players_players__get
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                additionalProperties: true
+                title: Response List Players Players  Get
+                type: object
+          description: Successful Response
+      security:
+      - APIKeyHeader: []
+      summary: List players (not yet implemented)
+      tags:
+      - players
+  /recommend/bid:
+    post:
+      description: Returns a recommended bid amount, confidence score, and rationale
+        for the requested player based on the configured bidding strategy. Returns
+        HTTP 503 if no draft context is available.
+      operationId: recommend_bid_recommend_bid_post
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/BidRecommendationRequest'
+        required: true
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/BidRecommendationResponse'
+          description: Successful Response
+        '422':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
+          description: Validation Error
+      security:
+      - APIKeyHeader: []
+      summary: Get a bid recommendation for a player
+      tags:
+      - recommend
+  /strategies/:
+    get:
+      description: Return the names of all available bidding strategies.
+      operationId: list_strategies_strategies__get
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                items:
+                  type: string
+                title: Response List Strategies Strategies  Get
+                type: array
+          description: Successful Response
+      security:
+      - APIKeyHeader: []
+      summary: List available strategies
+      tags:
+      - strategies

--- a/lab/promotion/promote.py
+++ b/lab/promotion/promote.py
@@ -1,23 +1,83 @@
-"""Promotion executor for graduating lab strategies to production.
+#!/usr/bin/env python3
+"""Lab strategy promotion script.
 
-Applies the promotion gate result to copy a validated strategy from the lab
-package into the core ``strategies/`` package. Implementation tracked by #227.
+Evaluates a lab strategy against a benchmark threshold and optionally copies
+it from ``lab/strategies/`` into the production ``strategies/`` package.
+Real benchmark score integration is deferred to Sprint 12 (issue #227).
+
+Usage:
+    python lab/promotion/promote.py --dry-run
+    python lab/promotion/promote.py --dry-run --strategy my_strategy
+    python lab/promotion/promote.py --strategy my_strategy --threshold 0.75
 """
 
 from __future__ import annotations
 
+import argparse
+import sys
+from pathlib import Path
 
-def promote_strategy(strategy_name: str, dry_run: bool = False) -> None:
-    """Promote a lab strategy to the core production package.
 
-    Copies strategy source, updates ``strategies/__init__.py`` registration,
-    and records promotion metadata.
+def promote_strategy(strategy_name: str, threshold: float, dry_run: bool = False) -> bool:
+    """Evaluate and optionally promote a lab strategy to main strategies/.
 
     Args:
         strategy_name: The registered name of the strategy to promote.
-        dry_run: If ``True``, validate without making filesystem changes.
+        threshold: Minimum efficiency score required for promotion.
+        dry_run: If ``True``, print what would happen without modifying files.
 
-    Raises:
-        NotImplementedError: Until issue #227 is implemented.
+    Returns:
+        ``True`` if promotion criteria are met (or dry-run succeeds), ``False`` otherwise.
     """
-    raise NotImplementedError("promote_strategy — tracked by #227")
+    lab_path = Path("lab/strategies") / f"{strategy_name}.py"
+    prod_path = Path("strategies") / f"{strategy_name}.py"
+
+    if not lab_path.exists():
+        print(f"ERROR: Lab strategy not found: {lab_path}", file=sys.stderr)
+        return False
+
+    if dry_run:
+        print(f"[DRY RUN] Would evaluate {strategy_name} against threshold {threshold}")
+        print(f"[DRY RUN] Source: {lab_path}")
+        print(f"[DRY RUN] Target: {prod_path}")
+        print("[DRY RUN] No files modified.")
+        return True
+
+    # Placeholder: fetch benchmark score from results_db (Sprint 12 / #227)
+    print("ERROR: Live promotion not yet implemented — use --dry-run (tracked by #227)", file=sys.stderr)
+    return False
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Lab strategy promotion tool")
+    parser.add_argument("--strategy", default=None, help="Strategy name to promote")
+    parser.add_argument(
+        "--threshold",
+        type=float,
+        default=0.70,
+        help="Minimum efficiency threshold (default: 0.70)",
+    )
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Print what would be done without making changes",
+    )
+    args = parser.parse_args()
+
+    if args.dry_run:
+        if args.strategy:
+            promote_strategy(args.strategy, args.threshold, dry_run=True)
+        else:
+            print("[DRY RUN] No strategy specified. Pass --strategy <name> to evaluate.")
+        sys.exit(0)
+
+    if not args.strategy:
+        print("ERROR: --strategy is required in non-dry-run mode", file=sys.stderr)
+        sys.exit(1)
+
+    success = promote_strategy(args.strategy, args.threshold, dry_run=False)
+    sys.exit(0 if success else 1)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Track F — CI/CD & Make Targets

### Changes

#### #182 — `make openapi` target
Added `openapi` target to `Makefile` that generates `docs/api/openapi.yaml` from the live FastAPI `app` object using `pyyaml`. Runs without any env-var scaffolding since `create_app()` has no required args. Also refreshed the YAML output with the latest schema.

#### #190 — Lab CI nightly workflow
`.github/workflows/lab-ci.yml` was already fully implemented (nightly at 1 AM UTC, PR trigger on `lab/**` paths, 60-min hard cap per ADR-003, simulation batch + gate report jobs). No changes needed.

#### #191 — Promotion script dry-run
Replaced the `raise NotImplementedError` stub in `lab/promotion/promote.py` with a working CLI:
- `--dry-run` prints what would happen without touching files
- `--dry-run --strategy <name>` validates the lab strategy path and prints source/target
- Live promotion is intentionally deferred to Sprint 12 / #227 (benchmark score integration not yet available)

### Testing
- `make openapi` → writes `docs/api/openapi.yaml` (6.4 KB)
- `python lab/promotion/promote.py --dry-run` → `[DRY RUN] No strategy specified`
- `python lab/promotion/promote.py --dry-run --strategy <name>` → prints dry-run plan
- 1483 unit tests pass, 16 xfailed

Closes #182
Closes #191
