### PR TITLE
docs: strategy catalog, how-to-create guide, and wiki plan — closes #263, closes #297

### DIFF
--- a/docs/strategies/catalog.md
+++ b/docs/strategies/catalog.md
@@ -1,0 +1,72 @@
+# Strategy Catalog
+
+All strategies registered in `AVAILABLE_STRATEGIES` (see `strategies/__init__.py`).  
+To instantiate any strategy: `from strategies import create_strategy; s = create_strategy("key")`.
+
+---
+
+| Key | Class | Description | Key Parameters (defaults) | Best For |
+|-----|-------|-------------|---------------------------|----------|
+| `value` | `ValueBasedStrategy` | Bids based on player auction value with position premiums and budget reservation logic | `value_multiplier=1.4`, `max_overbid=1.3`, `position_premiums` (RB: 1.3, WR: 1.2) | General-purpose; balanced 10–12 team leagues |
+| `aggressive` | `AggressiveStrategy` | Goes all-in on elite players early; throttles back when budget falls below threshold | `elite_threshold=25`, `elite_multiplier=1.3`, `budget_threshold=0.7` | Deep leagues; managers willing to punt thin positions for 2–3 studs |
+| `conservative` | `ConservativeStrategy` | Caps bids at 85% of value; mildly overbids on sleepers under $15; never spends >20% of budget on one player | `max_value_ratio=0.85`, `sleeper_threshold=15`, `sleeper_multiplier=1.1` | Risk-averse managers; high-variance leagues where overpaying is punished |
+| `sigmoid` | `SigmoidStrategy` | Uses sigmoid curves to blend aggression with draft progress, budget pressure, and positional need | `base_multiplier=1.05`, `steepness=8.0`, `midpoint=0.5`, `need_boost=1.35`, `budget_pressure_factor=2.2` | Experienced managers who want math-driven, context-sensitive bidding |
+| `improved_value` | `ImprovedValueStrategy` | Value-based bidding with a configurable scarcity adjustment per position | `aggression=1.0`, `scarcity_weight=0.3`, `randomness=0.0` | Leagues where positional scarcity (RB, TE) drives inflation |
+| `adaptive` | `AdaptiveStrategy` | Tracks bid history and per-position market trends to adjust aggression in real time | `base_aggression=1.0`, `adapt_factor=0.5` | Variable markets; experienced managers who want the bot to "learn" the room |
+| `vor` | `VorStrategy` | Bids using Value Over Replacement relative to positional baselines, weighted by scarcity | `aggression=1.0`, `scarcity_weight=0.7` | Analytics-driven leagues; managers targeting the best positional upside |
+| `random` | `RandomStrategy` | Bids with randomized aggression and configurable noise; primarily for simulation variety | `aggression=random(0.5–1.5)`, `randomness=0.5` | Stress testing, simulation baseline, unpredictable opponent modeling |
+| `smart` | `SmartStrategy` | Placeholder — delegates to `ValueBasedStrategy`; reserved for future sprint work (#63) | (inherits `value` params) | Testing harness; do not use in production tournaments |
+| `balanced` | `BalancedStrategy` | VOR-variance-adjusted bidding with position scarcity; slightly more aggressive defaults | `aggression=1.25`, `vor_variance=1.1` | All-around leagues; recommended starting point for new users |
+| `basic` | `BasicStrategy` | Straightforward bid = `player_value × aggression × position_priority × urgency` | `aggression=1.0` | Baseline benchmarking; learning how the bid pipeline works |
+| `elite_hybrid` | `EliteHybridStrategy` | Pays up sharply for players above per-position elite thresholds; conserves on the rest | `aggression=1.2`, `vor_variance=0.8`, `elite_thresholds` (RB: 35, WR: 30, QB: 25) | Leagues where elite RB/WR scarcity is extreme and studs win championships |
+| `inflation_aware_vor` | `InflationAwareVorStrategy` | VOR strategy that measures league-wide budget consumption to compute a real-time inflation factor | `aggression=1.0`, `scarcity_weight=0.7`, `inflation_sensitivity=0.5`, `budget=200`, `roster_size=15` | Large (14+) leagues; inflationary markets where $1 bids drain the pool |
+| `value_random` | `ValueRandomStrategy` | Value-based core with a configurable random perturbation on each bid | `aggression=1.0`, `randomness=0.3`, `scarcity_weight=0.5` | Simulation variety; modeling human unpredictability in tournament fields |
+| `value_smart` | `ValueSmartStrategy` | Hybrid of value-based bidding and adaptive trend tracking | `aggression=1.0`, `adapt_factor=0.5`, `scarcity_weight=0.5` | Mid-skill managers who want value discipline with situational flexibility |
+| `league` | `LeagueStrategy` | Applies per-position trend factors (e.g., league overvalues top RBs, undervalues K/DST) to adjust bids | `aggression=1.0`, `trend_adjustment=0.8` | Experienced managers who know their specific league's bidding tendencies |
+| `refined_value_random` | `RefinedValueRandomStrategy` | Enhanced value-random hybrid with higher RB/TE scarcity weights and explicit position targets | `aggression=1.1`, `randomness=0.35`, `scarcity_weight=0.5` | Semi-random simulation runs; tournament fields that need realistic variance |
+
+---
+
+## Strategy Family Overview
+
+```
+BaseStrategy (strategies/base_strategy.py)
+├── Simple / Baseline
+│   ├── basic            — configurable aggression only
+│   ├── random           — randomized bids for simulation
+│   └── smart            — placeholder (ValueBased delegate)
+├── Value-Based
+│   ├── value            — position-premium value bidding
+│   ├── conservative     — capped value, sleeper-friendly
+│   ├── improved_value   — value + scarcity adjustment
+│   └── value_random     — value + random noise
+├── VOR-Based
+│   ├── vor              — Value Over Replacement
+│   └── inflation_aware_vor  — VOR + market inflation factor
+├── Hybrid
+│   ├── balanced         — VOR variance + scarcity
+│   ├── elite_hybrid     — elite-threshold spikes + VOR
+│   ├── value_smart      — value + adaptive trending
+│   └── refined_value_random — value + scarcity + random
+├── Adaptive / Trend
+│   ├── adaptive         — real-time aggression adjustment
+│   ├── sigmoid          — sigmoid-curve context model
+│   └── league           — per-position league-trend factors
+└── Aggressive
+    └── aggressive       — elite-first, throttled budget
+```
+
+---
+
+## Parameter Quick Reference
+
+| Parameter | Type | Typical Range | Meaning |
+|-----------|------|---------------|---------|
+| `aggression` | float | 0.5 – 1.5 | Scales final bid up/down from base value |
+| `scarcity_weight` | float | 0.0 – 1.0 | How much positional scarcity inflates bids |
+| `randomness` | float | 0.0 – 1.0 | Probability / magnitude of random bid noise |
+| `adapt_factor` | float | 0.0 – 1.0 | Speed at which aggression adapts to observed trends |
+| `vor_variance` | float | 0.1 – 1.5 | Multiplier on VOR-derived bid variance |
+| `inflation_sensitivity` | float | 0.0 – 1.0 | Responsiveness to league-wide budget inflation |
+| `elite_threshold` | int/dict | per position | Auction value above which a player is "elite" |
+| `trend_adjustment` | float | 0.5 – 1.0 | Weight of per-position league-trend factors |

--- a/docs/strategies/how-to-create.md
+++ b/docs/strategies/how-to-create.md
@@ -1,0 +1,321 @@
+# How to Create a New Strategy
+
+This guide walks through adding a strategy from scratch so it works end-to-end: lab experiments, simulations, and the CLI.
+
+---
+
+## Prerequisites
+
+- Python ≥ 3.10, project venv activated (`source venv/bin/activate`)
+- Familiarity with `strategies/base_strategy.py` — read it before writing your own
+- A clear idea of the bidding logic you want to implement
+
+---
+
+## Step 1 — Create `strategies/my_strategy.py`
+
+All strategies inherit from `Strategy` (alias for `BaseStrategy`).
+
+```python
+# strategies/my_strategy.py
+"""One-line summary of the strategy."""
+
+from typing import List, TYPE_CHECKING
+from .base_strategy import Strategy
+
+if TYPE_CHECKING:
+    from classes.player import Player
+    from classes.team import Team
+    from classes.owner import Owner
+
+
+class MyStrategy(Strategy):
+    """Short description used in catalog and CLI output."""
+
+    def __init__(self, aggression: float = 1.0):
+        """
+        Args:
+            aggression: Scales bid relative to base value (0.5 – 1.5).
+        """
+        super().__init__(
+            "My Strategy",          # Human-readable name
+            f"Description with aggression={aggression:.1f}"
+        )
+        self.aggression = aggression
+
+    def calculate_bid(
+        self,
+        player: "Player",
+        team: "Team",
+        owner: "Owner",
+        current_bid: float,
+        remaining_budget: float,
+        remaining_players: List["Player"],
+    ) -> float:
+        """Return the bid amount, or 0.0 to pass."""
+        # Guard: always reserve $1 per unfilled roster slot
+        slots_left = self._get_remaining_roster_slots(team)
+        if remaining_budget <= slots_left + 3:
+            return max(current_bid + 1, 1.0)
+
+        position_priority = self._calculate_position_priority(player, team)
+        if position_priority <= 0.1:
+            return 0.0
+
+        player_value = self._get_player_value(player, default=10.0)
+        max_bid = self.calculate_max_bid(team, remaining_budget)
+
+        bid = min(player_value * self.aggression * position_priority, max_bid)
+        if bid <= current_bid:
+            return 0.0
+
+        return self._enforce_budget_constraint(bid, team, remaining_budget)
+```
+
+### Key helpers available from `BaseStrategy`
+
+| Helper | What it does |
+|--------|--------------|
+| `self._get_player_value(player, default)` | Returns `auction_value` (falls back to `projected_points`) |
+| `self._calculate_position_priority(player, team)` | 0.0 – 1.0 based on roster needs |
+| `self._calculate_position_urgency(player, team)` | Urgency multiplier as roster fills |
+| `self._get_remaining_roster_slots(team)` | Count of unfilled mandatory slots |
+| `self.calculate_max_bid(team, remaining_budget)` | Safe max spend respecting roster completion |
+| `self._enforce_budget_constraint(bid, team, budget)` | Clamps bid so team can still complete roster |
+| `self._calculate_budget_reservation(team, budget)` | Minimum $$ to hold for remaining slots |
+
+---
+
+## Step 2 — Register in `strategies/__init__.py`
+
+Open `strategies/__init__.py` and add in two places:
+
+```python
+# 1. Import at the top (keep alphabetical within the section)
+from .my_strategy import MyStrategy
+
+# 2. Add to AVAILABLE_STRATEGIES dict
+AVAILABLE_STRATEGIES = {
+    ...
+    'my_strategy': MyStrategy,   # ← new entry
+}
+
+# 3. Add to __all__
+__all__ = [
+    ...
+    'MyStrategy',
+]
+```
+
+Verify it's visible:
+
+```bash
+python -c "from strategies import AVAILABLE_STRATEGIES; print('my_strategy' in AVAILABLE_STRATEGIES)"
+# True
+```
+
+---
+
+## Step 3 — Add unit tests in `tests/unit/strategies/`
+
+Create `tests/unit/strategies/test_my_strategy.py`:
+
+```python
+"""Unit tests for MyStrategy."""
+
+import pytest
+from strategies.my_strategy import MyStrategy
+from unittest.mock import MagicMock
+
+
+def _make_player(auction_value: float = 20.0, position: str = "RB"):
+    p = MagicMock()
+    p.auction_value = auction_value
+    p.position = position
+    return p
+
+
+def _make_team(needs=("RB",), roster_len=0, initial_budget=200.0):
+    t = MagicMock()
+    t.get_needs.return_value = list(needs)
+    t.roster = [MagicMock()] * roster_len
+    t.roster_requirements = {"QB": 1, "RB": 2, "WR": 2, "TE": 1, "K": 1, "DST": 1}
+    t.initial_budget = initial_budget
+    return t
+
+
+class TestMyStrategy:
+    def test_passes_when_budget_is_low(self):
+        s = MyStrategy()
+        player = _make_player(20.0)
+        team = _make_team()
+        bid = s.calculate_bid(player, team, MagicMock(), 0.0, 5.0, [])
+        # With almost no budget left, strategy should not overbid
+        assert bid <= 5.0
+
+    def test_bids_above_current_for_needed_position(self):
+        s = MyStrategy(aggression=1.0)
+        player = _make_player(20.0, "RB")
+        team = _make_team(needs=["RB"])
+        bid = s.calculate_bid(player, team, MagicMock(), 5.0, 150.0, [])
+        assert bid > 5.0
+
+    def test_passes_for_unwanted_position(self):
+        s = MyStrategy()
+        player = _make_player(20.0, "QB")
+        team = _make_team(needs=[])  # team needs nothing
+        bid = s.calculate_bid(player, team, MagicMock(), 0.0, 150.0, [])
+        assert bid == 0.0
+
+    def test_never_exceeds_remaining_budget(self):
+        s = MyStrategy(aggression=2.0)  # deliberately over-aggressive
+        player = _make_player(100.0, "RB")
+        team = _make_team(needs=["RB"])
+        remaining = 50.0
+        bid = s.calculate_bid(player, team, MagicMock(), 0.0, remaining, [])
+        assert bid <= remaining
+```
+
+Run just your new tests:
+
+```bash
+pytest tests/unit/strategies/test_my_strategy.py -v
+```
+
+---
+
+## Step 4 — Add property tests in `tests/property/`
+
+Property tests catch edge cases your unit tests won't imagine.  
+Add `tests/property/test_my_strategy_properties.py`:
+
+```python
+"""Property-based tests for MyStrategy (Hypothesis)."""
+
+from hypothesis import given, settings, HealthCheck
+from hypothesis import strategies as st
+from unittest.mock import MagicMock
+
+from strategies.my_strategy import MyStrategy
+
+
+def _make_team(needs, roster_len, initial_budget):
+    t = MagicMock()
+    t.get_needs.return_value = needs
+    t.roster = [MagicMock()] * roster_len
+    t.roster_requirements = {"QB": 1, "RB": 2, "WR": 2, "TE": 1, "K": 1, "DST": 1}
+    t.initial_budget = max(initial_budget, 1.0)
+    return t
+
+
+@given(
+    auction_value=st.floats(min_value=1.0, max_value=200.0, allow_nan=False),
+    current_bid=st.floats(min_value=0.0, max_value=100.0, allow_nan=False),
+    remaining_budget=st.floats(min_value=1.0, max_value=400.0, allow_nan=False),
+    aggression=st.floats(min_value=0.1, max_value=3.0, allow_nan=False),
+)
+@settings(suppress_health_check=[HealthCheck.too_slow], max_examples=200)
+def test_bid_never_exceeds_remaining_budget(auction_value, current_bid, remaining_budget, aggression):
+    """Invariant: bid must never exceed remaining_budget."""
+    s = MyStrategy(aggression=aggression)
+    player = MagicMock()
+    player.auction_value = auction_value
+    player.position = "RB"
+    team = _make_team(["RB"], roster_len=0, initial_budget=200.0)
+
+    bid = s.calculate_bid(player, team, MagicMock(), current_bid, remaining_budget, [])
+    assert bid <= remaining_budget, f"bid {bid} > budget {remaining_budget}"
+
+
+@given(
+    auction_value=st.floats(min_value=1.0, max_value=200.0, allow_nan=False),
+    remaining_budget=st.floats(min_value=1.0, max_value=400.0, allow_nan=False),
+)
+@settings(max_examples=100)
+def test_bid_is_non_negative(auction_value, remaining_budget):
+    """Invariant: bid must be ≥ 0."""
+    s = MyStrategy()
+    player = MagicMock()
+    player.auction_value = auction_value
+    player.position = "WR"
+    team = _make_team(["WR"], roster_len=1, initial_budget=200.0)
+
+    bid = s.calculate_bid(player, team, MagicMock(), 0.0, remaining_budget, [])
+    assert bid >= 0.0
+```
+
+Run property tests:
+
+```bash
+pytest tests/property/test_my_strategy_properties.py -v
+```
+
+---
+
+## Step 5 — Test in the lab
+
+Create an experiment config at `lab/experiments/my_experiment.yaml`:
+
+```yaml
+name: my_strategy_baseline
+description: First run of MyStrategy against existing strategies
+
+strategies:
+  - my_strategy
+  - balanced
+  - vor
+  - aggressive
+
+num_simulations: 500
+num_teams: 10
+budget: 200
+
+metrics:
+  - win_rate
+  - avg_score
+  - budget_efficiency
+```
+
+Run it:
+
+```bash
+python -m lab.simulation.runner --experiment lab/experiments/my_experiment.yaml
+```
+
+Results land in `lab/results_db/`. Compare with:
+
+```bash
+python -m lab.eval.compare_strategies --experiment my_strategy_baseline
+```
+
+---
+
+## Step 6 — Update the strategy catalog
+
+Add your strategy to [docs/strategies/catalog.md](catalog.md) following the existing table format.  
+Include: key, class name, description, key parameters with defaults, and best-use guidance.
+
+---
+
+## Checklist
+
+- [ ] `strategies/my_strategy.py` created, inherits `Strategy`
+- [ ] `calculate_bid()` always returns `0.0 ≤ bid ≤ remaining_budget`
+- [ ] Registered in `AVAILABLE_STRATEGIES` and `__all__`
+- [ ] `create_strategy("my_strategy")` works without errors
+- [ ] Unit tests in `tests/unit/strategies/test_my_strategy.py` — all pass
+- [ ] Property tests in `tests/property/test_my_strategy_properties.py` — all pass
+- [ ] Lab experiment YAML created and at least one simulation run completed
+- [ ] `docs/strategies/catalog.md` updated
+
+---
+
+## Common Pitfalls
+
+| Problem | Fix |
+|---------|-----|
+| `bid > remaining_budget` | Always call `_enforce_budget_constraint()` before returning |
+| `ZeroDivisionError` on `initial_budget` | Guard: `initial_budget = getattr(team, 'initial_budget', None) or remaining_budget or 1` |
+| Strategy never bids | Check `_calculate_position_priority()` — returns 0.0 when position slot is full |
+| Strategy overbids on K/DST | These positions need special handling; see `AggressiveStrategy.calculate_bid()` for the pattern |
+| Import error in `__init__.py` | Ensure class name in import matches exactly what's defined in the module |

--- a/docs/wiki-plan.md
+++ b/docs/wiki-plan.md
@@ -1,0 +1,145 @@
+# GitHub Wiki Plan
+
+**Status:** Draft — Sprint 11, Track G  
+**Issues:** #297  
+**Last updated:** 2026-05-13
+
+This document defines the structure, ownership, writing standard, and rollout priority for the Pigskin Fantasy Football GitHub Wiki.
+
+---
+
+## 1. Page Structure
+
+The wiki uses a flat namespace (GitHub wikis do not support subdirectories), so pages are prefixed with a category slug.
+
+```
+Home
+│
+├── Getting Started
+│   ├── GettingStarted-Installation
+│   ├── GettingStarted-QuickStart
+│   └── GettingStarted-Configuration
+│
+├── Strategies
+│   ├── Strategies-Catalog          ← mirrors docs/strategies/catalog.md
+│   ├── Strategies-HowToCreate      ← mirrors docs/strategies/how-to-create.md
+│   └── Strategies-LabExperiments
+│
+├── API
+│   ├── API-Overview
+│   └── API-Endpoints               ← generated from docs/api/openapi.yaml
+│
+├── Architecture
+│   ├── Architecture-Overview
+│   ├── Architecture-ADRs           ← index of docs/adr/
+│   └── Architecture-LabPipeline
+│
+├── Development
+│   ├── Development-ContributingGuide
+│   ├── Development-BranchingStrategy
+│   ├── Development-TestingGuide
+│   └── Development-CIWorkflows
+│
+└── Operations
+    ├── Operations-Runbook
+    └── Operations-PromotionPipeline
+```
+
+---
+
+## 2. Ownership Matrix
+
+Each page has a **primary owner** (the agent/team responsible for keeping it current) and a **reviewer** (signs off on major changes).
+
+| Page | Primary Owner | Reviewer | Update Cadence |
+|------|---------------|----------|----------------|
+| Home | Docs Agent | Lead Dev | Each sprint |
+| GettingStarted-Installation | Docs Agent | DevOps | On dependency change |
+| GettingStarted-QuickStart | Docs Agent | Lead Dev | Quarterly |
+| GettingStarted-Configuration | Docs Agent | Backend Agent | On config schema change |
+| Strategies-Catalog | Docs Agent | Strategy Agent | When strategy added/removed |
+| Strategies-HowToCreate | Docs Agent | Strategy Agent | On `BaseStrategy` API change |
+| Strategies-LabExperiments | Lab Agent | Strategy Agent | Each sprint |
+| API-Overview | Docs Agent | Backend Agent | Each sprint |
+| API-Endpoints | Backend Agent (auto-gen) | Docs Agent | Each PR to `api/` |
+| Architecture-Overview | Docs Agent | Lead Dev | Quarterly |
+| Architecture-ADRs | Docs Agent | Lead Dev | When ADR is merged |
+| Architecture-LabPipeline | Lab Agent | Lead Dev | On pipeline change |
+| Development-ContributingGuide | Docs Agent | Lead Dev | On workflow change |
+| Development-BranchingStrategy | Docs Agent | Lead Dev | On branching policy change |
+| Development-TestingGuide | Docs Agent | QA Agent | On test infra change |
+| Development-CIWorkflows | DevOps Agent | Lead Dev | On workflow change |
+| Operations-Runbook | DevOps Agent | Lead Dev | On infra change |
+| Operations-PromotionPipeline | Lab Agent | Lead Dev | Sprint 12+ |
+
+> **Agent key:**  
+> - **Docs Agent** — GitHub Copilot chat, Track G work  
+> - **Backend Agent** — Copilot, API / FastAPI work  
+> - **Strategy Agent** — Copilot, strategies module work  
+> - **Lab Agent** — Copilot, `lab/` work  
+> - **DevOps Agent** — Copilot, CI/CD / Make target work  
+> - **Lead Dev** — human maintainer (final approval)
+
+---
+
+## 3. Writing Standard
+
+### 3.1 Tone and Voice
+
+- **Direct and technical.** Write for Python developers; avoid over-explaining basic concepts.
+- **Present tense.** "The strategy bids…" not "The strategy will bid…"
+- **Second person for instructions.** "Run `pytest`…" not "The user should run…"
+- **No marketing language.** Avoid "powerful", "seamless", "best-in-class".
+
+### 3.2 Format
+
+| Element | Guidance |
+|---------|----------|
+| Headings | `##` for sections, `###` for subsections; no `#` (GitHub renders page title) |
+| Code blocks | Always fenced with language tag (` ```python `, ` ```bash `, ` ```yaml `) |
+| Tables | Use for comparisons, parameter references, and matrices |
+| Links | Use wiki-relative links: `[[Strategies-Catalog]]`; repo links use full path |
+| File references | Backtick the path: `` `strategies/__init__.py` `` |
+| Commands | Single-line commands inline (`` `pytest` ``); multi-step in fenced bash block |
+
+### 3.3 Required Sections per Page
+
+Every wiki page must include:
+
+1. **One-line summary** at the top (plain text, no heading)
+2. **Last updated** line: `_Last updated: YYYY-MM-DD (Sprint N)_`
+3. **Body content** (varies by page type)
+4. **Related pages** section at the bottom (2–4 wiki links)
+
+### 3.4 Update Cadence
+
+- **Sprint-end review:** Primary owner checks whether the page is still accurate before closing the sprint.
+- **Triggered updates:** Any PR that changes a documented behavior must update the relevant wiki page in the same PR (or file a follow-up issue tagged `docs`).
+- **Quarterly audit:** Lead Dev + Docs Agent review all pages for staleness each quarter.
+
+---
+
+## 4. Priority Pages (Sprint 12+)
+
+Pages to create first, in order of user impact:
+
+| Priority | Page | Rationale |
+|----------|------|-----------|
+| P0 | Home | Entry point; every visitor lands here |
+| P0 | GettingStarted-Installation | Needed to onboard new contributors |
+| P0 | Strategies-Catalog | Core reference; mirrors `catalog.md` (already written) |
+| P1 | GettingStarted-QuickStart | Reduces time-to-first-draft for new users |
+| P1 | Development-ContributingGuide | Needed before external contributions |
+| P1 | Strategies-HowToCreate | Mirrors `how-to-create.md` (already written) |
+| P2 | API-Endpoints | Auto-generated from `openapi.yaml` via `make openapi` |
+| P2 | Architecture-ADRs | Index pointing to `docs/adr/` for decision history |
+| P3 | Development-TestingGuide | Property test infra is non-obvious; guide reduces friction |
+| P3 | Architecture-LabPipeline | Important once lab promotion (Sprint 12) is live |
+
+---
+
+## 5. Tooling Notes
+
+- **Source of truth:** The `docs/` directory in the repo is canonical for ADRs, the strategy catalog, and the API spec. Wiki pages that mirror repo docs should note this and link to the source file.
+- **Auto-generation:** `API-Endpoints` can be generated from `docs/api/openapi.yaml` using a script in `Makefile` (target TBD in Sprint 12).
+- **Sync script:** Consider a `make wiki-sync` target (Sprint 13+) that pushes `docs/strategies/catalog.md` and `docs/strategies/how-to-create.md` to the wiki automatically on merge to `main`.


### PR DESCRIPTION
## Track G — Documentation

### Changes
- `docs/strategies/catalog.md` — table of all 17 strategies with description, parameters, when-to-use; strategy family tree; parameter quick reference
- `docs/strategies/how-to-create.md` — step-by-step guide to creating a new strategy (file scaffold, registration, unit tests, property tests, lab experiment, checklist, common pitfalls)
- `docs/wiki-plan.md` — wiki page structure, ownership matrix, writing standard, P0–P3 priority rollout plan

Closes #263
Closes #297
