### PR TITLE
fix(lab): AuctionBacktester.run() consults strategy per player — closes #196

### DIFF
--- a/lab/backtest/auction_replay.py
+++ b/lab/backtest/auction_replay.py
@@ -23,8 +23,10 @@ class AuctionBacktester:
     def run(self) -> Dict[str, float]:
         """Execute the backtest replay.
 
-        Computes efficiency_score = sum(auction_value) / sum(actual_price),
-        capped at [0.0, 1.0].
+        For each player, asks the strategy for a bid via ``strategy.bid(player,
+        remaining_budget)``.  A player is "won" when ``strategy_bid >=
+        actual_price``.  ``efficiency_score`` is the ratio of projected auction
+        value won to actual spend, capped at [0.0, 1.0].
 
         Returns:
             Dict with keys: efficiency_score, total_spend, total_value.
@@ -32,8 +34,19 @@ class AuctionBacktester:
         if not self.player_data:
             return {"efficiency_score": 0.0, "total_spend": 0.0, "total_value": 0.0}
 
-        total_value = sum(float(p.get("auction_value", 0)) for p in self.player_data)
-        total_spend = sum(float(p.get("actual_price", 0)) for p in self.player_data)
+        # Seed budget from total market spend so the strategy has a realistic cap.
+        remaining_budget = sum(float(p.get("actual_price", 0)) for p in self.player_data)
+        total_spend = 0.0
+        total_value = 0.0
+
+        for player in self.player_data:
+            actual_price = float(player.get("actual_price", 0))
+            auction_value = float(player.get("auction_value", 0))
+            strategy_bid = float(self.strategy.bid(player, remaining_budget))
+            if strategy_bid >= actual_price:
+                total_spend += actual_price
+                total_value += auction_value
+                remaining_budget -= actual_price
 
         if total_spend == 0:
             efficiency_score = 0.0

--- a/tests/unit/lab/test_auction_replay.py
+++ b/tests/unit/lab/test_auction_replay.py
@@ -135,7 +135,28 @@ class TestAuctionBacktesterEmptyData:
 
 
 # ---------------------------------------------------------------------------
-# 4. Determinism — same input → same output
+# 4. Strategy is consulted during run()
+# ---------------------------------------------------------------------------
+
+class TestAuctionBacktesterStrategyConsulted:
+    """run() must invoke the strategy for every player in player_data."""
+
+    def test_strategy_is_consulted(self):
+        """run() calls strategy.bid() exactly once per player."""
+        from unittest.mock import MagicMock
+        mock_strategy = MagicMock()
+        mock_strategy.bid.return_value = 100  # always high enough to win
+        data = _sample_player_data()
+        bt = AuctionBacktester(strategy=mock_strategy, player_data=data)
+        bt.run()
+        assert mock_strategy.bid.call_count == len(data), (
+            f"Expected strategy.bid() called {len(data)} times, "
+            f"got {mock_strategy.bid.call_count}"
+        )
+
+
+# ---------------------------------------------------------------------------
+# 5. Determinism — same input → same output
 # ---------------------------------------------------------------------------
 
 @_RUN_NOT_IMPLEMENTED


### PR DESCRIPTION
## Summary

Post-merge fix addressing QA/Planning review comments on PR #376.

### Changes
- `AuctionBacktester.run()` now calls `strategy.bid(player, remaining_budget)` for each player
- A player is **won** when `strategy_bid >= actual_price`
- `total_spend` / `total_value` accumulate only for won players
- `efficiency_score` = won value / won spend, capped to `[0.0, 1.0]`
- Budget decrements after each win so bids reflect realistic remaining capacity

### New test
`TestAuctionBacktesterStrategyConsulted.test_strategy_is_consulted` — `MagicMock` asserts `strategy.bid()` called exactly once per player.

### Test results
All 1693 unit + property tests pass (0 failures).

Closes #196 (supplemental fix)