### PR TITLE
Develop

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 # Makefile for Pigskin Auction Draft Tool
 
-.PHONY: setup install dev-install lock test clean help run-tests format lint typecheck coverage security audit ci standup lab-bench lab-gate install-hooks hooks
+.PHONY: setup install dev-install lock test clean help run-tests format lint typecheck coverage security audit ci standup lab-bench lab-gate openapi install-hooks hooks
 
 # Default target
 help:
@@ -29,6 +29,9 @@ help:
 	@echo "  standup     - Print daily standup summary (git log + project board)"
 	@echo "  clean       - Clean up cache and temporary files"
 	@echo "  install-hooks - Install shared git hooks from .githooks/ (aliases: hooks)"
+	@echo ""
+	@echo "API:"
+	@echo "  openapi     - Generate docs/api/openapi.yaml from the FastAPI app"
 	@echo ""
 	@echo "Lab (pigskin-lab — ADR-001/Sprint 5 migration required):"
 	@echo "  lab-bench   - Run simulation benchmark batch (STRATEGY=all or STRATEGY=<name>)"
@@ -187,6 +190,16 @@ lab-gate:
 		echo "The lab/ structure requires the ADR-001 Sprint 5 migration to be complete."; \
 		exit 1; \
 	fi
+
+# Generate OpenAPI schema from FastAPI app
+openapi:
+	@echo "Generating OpenAPI schema..."
+	@python -c "\
+import json, yaml; \
+from api.main import app; \
+schema = app.openapi(); \
+open('docs/api/openapi.yaml', 'w').write(yaml.dump(schema, default_flow_style=False)); \
+print('Written to docs/api/openapi.yaml')"
 
 standup:
 	@echo "=== Daily Standup — $$(date +%Y-%m-%d) ==="

--- a/api/main.py
+++ b/api/main.py
@@ -1,4 +1,5 @@
 """FastAPI application factory for Pigskin Draft Assistant."""
+import os
 from contextlib import asynccontextmanager
 from typing import AsyncGenerator
 
@@ -16,13 +17,49 @@ async def lifespan(app: FastAPI) -> AsyncGenerator[None, None]:
     # Future: clean up resources
 
 
-def create_app() -> FastAPI:
-    """Create and configure the FastAPI application."""
+def create_app(
+    *,
+    api_key: str | None = None,
+    docs_enabled: bool | None = None,
+) -> FastAPI:
+    """Create and configure the FastAPI application.
+
+    Parameters
+    ----------
+    api_key:
+        Override the API key (used in tests).  When *None* the value is read
+        from ``settings.api_key`` / ``PIGSKIN_API_KEY`` env var.
+    docs_enabled:
+        Override whether /docs is exposed (used in tests).  When *None* the
+        value is read from ``settings.docs_enabled`` / ``PIGSKIN_DOCS_ENABLED``.
+    """
+    from config.settings import get_settings
+
+    settings = get_settings()
+
+    resolved_api_key = api_key if api_key is not None else settings.api_key
+    resolved_docs_enabled = docs_enabled if docs_enabled is not None else settings.docs_enabled
+
+    # Security guard: refuse to start with an empty API key outside of tests.
+    if not resolved_api_key and os.getenv("TESTING") != "true":
+        raise RuntimeError(
+            "PIGSKIN_API_KEY must be set. "
+            "An empty API key is not allowed in non-test environments."
+        )
+
+    # Gate /docs, /openapi.json and /redoc behind PIGSKIN_DOCS_ENABLED.
+    _docs_url = "/docs" if resolved_docs_enabled else None
+    _openapi_url = "/openapi.json" if resolved_docs_enabled else None
+    _redoc_url = "/redoc" if resolved_docs_enabled else None
+
     app = FastAPI(
         title="Pigskin Draft Assistant",
         description="Fantasy football auction draft assistant API",
         version="0.1.0",
         lifespan=lifespan,
+        docs_url=_docs_url,
+        openapi_url=_openapi_url,
+        redoc_url=_redoc_url,
     )
 
     # Health check (no auth required)

--- a/api/schemas/auction.py
+++ b/api/schemas/auction.py
@@ -3,9 +3,9 @@ from pydantic import BaseModel, Field
 
 
 class BidRequest(BaseModel):
-    player_id: str
+    player_id: str = Field(min_length=1)
     bid_amount: int = Field(ge=1)
-    team_name: str
+    team_name: str = Field(min_length=1)
 
 
 class BidResponse(BaseModel):

--- a/api/sleeper_api.py
+++ b/api/sleeper_api.py
@@ -3,6 +3,7 @@
 import asyncio
 import random
 import httpx
+from datetime import datetime
 from typing import Dict, List, Optional, Any
 import time
 from urllib.parse import quote
@@ -105,7 +106,7 @@ class SleeperAPI:
             return None
 
     # League methods
-    async def get_user_leagues(self, user_id: str, season: str = "2024") -> List[Dict]:
+    async def get_user_leagues(self, user_id: str, season: str = str(datetime.now().year)) -> List[Dict]:
         """Get leagues for a user in a specific season."""
         try:
             return await self._make_request(
@@ -222,7 +223,7 @@ class SleeperAPI:
             
     # Stats methods
     async def get_player_stats(
-        self, season: str = "2024", week: Optional[int] = None
+        self, season: str = str(datetime.now().year), week: Optional[int] = None
     ) -> Dict[str, Dict]:
         """Get player stats for season or specific week."""
         try:
@@ -238,7 +239,7 @@ class SleeperAPI:
             return {}
             
     async def get_player_projections(
-        self, season: str = "2024", week: Optional[int] = None
+        self, season: str = str(datetime.now().year), week: Optional[int] = None
     ) -> Dict[str, Dict]:
         """Get player projections for season or specific week."""
         try:

--- a/cli/commands.py
+++ b/cli/commands.py
@@ -17,7 +17,7 @@ from services.sleeper_draft_service import SleeperDraftService
 class CommandProcessor:
     """Processes individual CLI commands with enhanced functionality."""
     
-    def __init__(self, config_manager: ConfigManager = None, sleeper_api: SleeperAPI = None):
+    def __init__(self, config_manager: Optional[ConfigManager] = None, sleeper_api: Optional[SleeperAPI] = None):
         self.config_manager = config_manager if config_manager is not None else ConfigManager()
         self.sleeper_api = sleeper_api if sleeper_api is not None else SleeperAPI()
         self.sleeper_draft_service = SleeperDraftService(sleeper_api=self.sleeper_api)

--- a/cli/commands.py
+++ b/cli/commands.py
@@ -17,10 +17,10 @@ from services.sleeper_draft_service import SleeperDraftService
 class CommandProcessor:
     """Processes individual CLI commands with enhanced functionality."""
     
-    def __init__(self):
-        self.config_manager = ConfigManager()
-        self.sleeper_api = SleeperAPI()
-        self.sleeper_draft_service = SleeperDraftService()
+    def __init__(self, config_manager: ConfigManager = None, sleeper_api: SleeperAPI = None):
+        self.config_manager = config_manager if config_manager is not None else ConfigManager()
+        self.sleeper_api = sleeper_api if sleeper_api is not None else SleeperAPI()
+        self.sleeper_draft_service = SleeperDraftService(sleeper_api=self.sleeper_api)
     
     def get_bid_recommendation_detailed(self, player_name: str, current_bid: float = 1.0, sleeper_draft_id: Optional[str] = None) -> Dict:
         """Get detailed bid recommendation with enhanced display."""

--- a/cli/main.py
+++ b/cli/main.py
@@ -33,6 +33,7 @@ Examples:
 """
 
 import sys
+from datetime import datetime
 from typing import List, Dict
 
 # Add parent directory to path for imports
@@ -52,7 +53,7 @@ class AuctionDraftCLI:
     def __init__(self):
         self.config_manager = ConfigManager()
         self.sleeper_api = SleeperAPI()
-        self.command_processor = CommandProcessor()
+        self.command_processor = CommandProcessor(config_manager=self.config_manager, sleeper_api=self.sleeper_api)
         
     def _get_config_default(self, key: str, default=None):
         """Helper to get config values with error handling."""
@@ -285,7 +286,7 @@ class AuctionDraftCLI:
             return 1
         
         username = args[0] if args else default_username
-        season = args[1] if len(args) > 1 else "2024"
+        season = args[1] if len(args) > 1 else str(datetime.now().year)
         
         result = self.command_processor.get_sleeper_draft_status(username, season)
         
@@ -336,7 +337,7 @@ class AuctionDraftCLI:
             return 1
         
         username = args[0] if args else default_username
-        season = args[1] if len(args) > 1 else "2024"
+        season = args[1] if len(args) > 1 else str(datetime.now().year)
         
         result = self.command_processor.list_sleeper_leagues(username, season)
         return self._handle_command_result(result, "Failed to list leagues")

--- a/cli/main.py
+++ b/cli/main.py
@@ -66,7 +66,7 @@ class AuctionDraftCLI:
     def _handle_command_result(self, result: Dict, error_message: str = "Command failed") -> int:
         """Helper to handle standard command result patterns."""
         if not result.get('success', False):
-            print(f"ERROR: {result.get('error', error_message)}")
+            print(f"ERROR: {result.get('error', error_message)}", file=sys.stderr)
             return 1
         return 0
 
@@ -93,7 +93,7 @@ class AuctionDraftCLI:
                 self.show_help()
                 return 0
             else:
-                print(f"ERROR: Unknown command: {command}")
+                print(f"ERROR: Unknown command: {command}", file=sys.stderr)
                 print("Use 'help' to see available commands")
                 return 1
                 
@@ -101,13 +101,13 @@ class AuctionDraftCLI:
             print("\nOperation cancelled by user")
             return 130
         except Exception as e:
-            print(f"ERROR: {e}")
+            print(f"ERROR: {e}", file=sys.stderr)
             return 1
     
     def handle_bid_command(self, args: List[str]) -> int:
         """Handle bid recommendation command."""
         if not args:
-            print("ERROR: Player name required")
+            print("ERROR: Player name required", file=sys.stderr)
             print("Usage: bid <player_name> [current_bid] [sleeper_draft_id]")
             print("Note: Use quotes for multi-word names: bid 'Josh Allen' 25")
             return 1
@@ -128,7 +128,7 @@ class AuctionDraftCLI:
             self._display_bid_recommendation(result)
             return 0
         else:
-            print(f"ERROR: {result.get('error', 'Failed to get bid recommendation')}")
+            print(f"ERROR: {result.get('error', 'Failed to get bid recommendation')}", file=sys.stderr)
             return 1
     
     def handle_mock_command(self, args: List[str]) -> int:
@@ -168,14 +168,14 @@ class AuctionDraftCLI:
             strategies = [s.strip() for s in strategy_arg.split(',')]
             invalid_strategies = [s for s in strategies if s not in AVAILABLE_STRATEGIES]
             if invalid_strategies:
-                print(f"ERROR: Invalid strategies: {', '.join(invalid_strategies)}")
+                print(f"ERROR: Invalid strategies: {', '.join(invalid_strategies)}", file=sys.stderr)
                 print(f"Available strategies: {', '.join(AVAILABLE_STRATEGIES)}")
                 return 1
             strategy_display = f"{len(strategies)} strategies: {', '.join(strategies)}"
         else:
             strategies = strategy_arg
             if strategy_arg not in AVAILABLE_STRATEGIES:
-                print(f"ERROR: Invalid strategy: {strategy_arg}")
+                print(f"ERROR: Invalid strategy: {strategy_arg}", file=sys.stderr)
                 print(f"Available strategies: {', '.join(AVAILABLE_STRATEGIES)}")
                 return 1
             strategy_display = strategy_arg
@@ -191,7 +191,7 @@ class AuctionDraftCLI:
             self._display_mock_results(result)
             return 0
         else:
-            print(f"ERROR: {result.get('error', 'Mock draft failed')}")
+            print(f"ERROR: {result.get('error', 'Mock draft failed')}", file=sys.stderr)
             return 1
     
     def handle_tournament_command(self, args: List[str]) -> int:
@@ -212,13 +212,13 @@ class AuctionDraftCLI:
             try:
                 rounds = int(filtered_args[0])
             except ValueError:
-                print(f"ERROR: Invalid rounds value '{filtered_args[0]}' — must be an integer")
+                print(f"ERROR: Invalid rounds value '{filtered_args[0]}' — must be an integer", file=sys.stderr)
                 return 1
         if len(filtered_args) > 1:
             try:
                 teams_per_draft = int(filtered_args[1])
             except ValueError:
-                print(f"ERROR: Invalid teams_per_draft value '{filtered_args[1]}' — must be an integer")
+                print(f"ERROR: Invalid teams_per_draft value '{filtered_args[1]}' — must be an integer", file=sys.stderr)
                 return 1
         
         print("Starting elimination tournament...")
@@ -234,7 +234,7 @@ class AuctionDraftCLI:
             self._display_tournament_results(result)
             return 0
         else:
-            print(f"ERROR: Tournament failed: {result.get('error', 'Unknown error')}")
+            print(f"ERROR: Tournament failed: {result.get('error', 'Unknown error')}", file=sys.stderr)
             return 1
     
     def handle_ping_command(self, args: List[str]) -> int:
@@ -252,7 +252,7 @@ class AuctionDraftCLI:
     def handle_sleeper_command(self, args: List[str]) -> int:
         """Handle Sleeper draft commands."""
         if not args:
-            print("ERROR: Sleeper command requires subcommand")
+            print("ERROR: Sleeper command requires subcommand", file=sys.stderr)
             print("Usage: sleeper <subcommand> [options]")
             print("Subcommands: status, draft, league, leagues")
             return 1
@@ -270,7 +270,7 @@ class AuctionDraftCLI:
         elif subcommand == "cache":
             return self.handle_sleeper_cache(args[1:])
         else:
-            print(f"ERROR: Unknown Sleeper subcommand: {subcommand}")
+            print(f"ERROR: Unknown Sleeper subcommand: {subcommand}", file=sys.stderr)
             print("Available subcommands: status, draft, league, leagues, cache")
             return 1
     
@@ -280,7 +280,7 @@ class AuctionDraftCLI:
         default_username = self._get_config_default('sleeper_username')
         
         if not args and not default_username:
-            print("ERROR: Username required (not provided and not set in config)")
+            print("ERROR: Username required (not provided and not set in config)", file=sys.stderr)
             print("Usage: sleeper status <username> [season]")
             print("Or set 'sleeper_username' in config/config.json")
             return 1
@@ -299,7 +299,7 @@ class AuctionDraftCLI:
         default_draft_id = getattr(config, 'sleeper_draft_id', None)
         
         if not args and not default_draft_id:
-            print("ERROR: Draft ID required (not provided and not set in config)")
+            print("ERROR: Draft ID required (not provided and not set in config)", file=sys.stderr)
             print("Usage: sleeper draft <draft_id>")
             print("Or set 'sleeper_draft_id' in config/config.json")
             return 1
@@ -315,7 +315,7 @@ class AuctionDraftCLI:
         # For league command, we could potentially derive league_id from user's current leagues
         # but for now, require explicit league_id as there's no direct config default
         if not args:
-            print("ERROR: League ID required")
+            print("ERROR: League ID required", file=sys.stderr)
             print("Usage: sleeper league <league_id>")
             print("Tip: Use 'sleeper leagues <username>' to find league IDs")
             return 1
@@ -331,7 +331,7 @@ class AuctionDraftCLI:
         default_username = self._get_config_default('sleeper_username')
         
         if not args and not default_username:
-            print("ERROR: Username required (not provided and not set in config)")
+            print("ERROR: Username required (not provided and not set in config)", file=sys.stderr)
             print("Usage: sleeper leagues <username> [season]")
             print("Or set 'sleeper_username' in config/config.json")
             return 1
@@ -391,7 +391,7 @@ class AuctionDraftCLI:
                 print("Failed to clear player cache")
                 return 1
         else:
-            print(f"ERROR: Unknown cache action: {action}")
+            print(f"ERROR: Unknown cache action: {action}", file=sys.stderr)
             print("Available actions: info, refresh, clear")
             return 1
     
@@ -618,7 +618,7 @@ class AuctionDraftCLI:
                 print("  No undervalued players found.")
             return 0
         else:
-            print(f"ERROR: {result.get('error', 'Analysis failed')}")
+            print(f"ERROR: {result.get('error', 'Analysis failed')}", file=sys.stderr)
             return 1
 
 

--- a/config/settings.py
+++ b/config/settings.py
@@ -1,5 +1,6 @@
 """Pydantic-settings based configuration for environment variables and secrets."""
 
+from pydantic import Field
 from pydantic_settings import BaseSettings, SettingsConfigDict
 
 
@@ -18,12 +19,14 @@ class Settings(BaseSettings):
     data_path: str = 'data/sheets'
     refresh_interval: int = 30
     min_projected_points: float = 0.0
-    api_key: str = ''  # Set via PIGSKIN_API_KEY env var or .env
+    api_key: str = Field(default='', validation_alias='PIGSKIN_API_KEY')  # Set via PIGSKIN_API_KEY env var or .env
+    docs_enabled: bool = Field(default=False, validation_alias='PIGSKIN_DOCS_ENABLED')  # Set PIGSKIN_DOCS_ENABLED=true to expose /docs
 
     model_config = SettingsConfigDict(
         env_file='.env',
         env_file_encoding='utf-8',
         extra='ignore',
+        populate_by_name=True,
     )
 
 

--- a/docs/adr/ADR-001-repo-structure.md
+++ b/docs/adr/ADR-001-repo-structure.md
@@ -2,7 +2,7 @@
 
 **Status:** Accepted
 **Date:** 2026-04-28
-**Reviewed:** 2026-04-28
+**Reviewed:** 2026-04-28, 2026-05-12
 **Author:** Architecture Agent (via Orchestrator)
 **Reviewer:** Architecture Agent
 **Deciders:** Engineering team
@@ -134,3 +134,50 @@ A two-package split (core + app, with lab as a folder in app/) was considered. R
 ### Bootstrap Production Strategy Decision
 
 On the day migration begins, `app/strategies/production_strategy.py` is populated by copying `EnhancedVORStrategy` from `lab/strategies/` as the baseline. This single exception to the promotion gate is recorded as a manual promotion entry in `lab/results_db/promotions` with `promoted_by = 'bootstrap'` and no benchmark run ID. All subsequent promotions must pass the gate (ADR-003).
+
+---
+
+## Amendment — 2026-05-12: Known Layering Violations Blocking Migration (Orchestrator Architecture Review)
+
+**Authored by:** Orchestrator Agent
+**Issues:** #358 (ARCH-001), #359 (ARCH-005)
+
+The 2026-05-12 architecture review found five confirmed violations of the layering rules specified in this ADR. These must be resolved **before** the `classes/ → core/`, `strategies/ → core/strategies/`, `api/ → app/api/` migration can begin. Attempting the migration with these violations in place will break package imports.
+
+### Confirmed Violations (must be resolved first)
+
+| # | Violation | File | Resolution |
+|---|-----------|------|-----------|
+| L-001 | Domain imports integration | `classes/draft_setup.py` imports `api.sleeper_api` | Define `FantasyDataProvider` protocol; inject via constructor — Issue #358 |
+| L-002 | Services import integration directly | `services/sleeper_draft_service.py`, `services/draft_loading_service.py`, `services/bid_recommendation_service.py` import `api.sleeper_api` | Define `FantasyDataProvider` protocol; inject — companion to #358 |
+| L-003 | CLI imports integration directly | `cli/commands.py` imports `api.sleeper_api` | Route all Sleeper access through services — companion to #358 |
+| L-004 | Analysis scripts in strategy layer | `strategies/spending_analyzer.py`, `strategies/strategy_analyzer.py` | Move to `lab/eval/` — Issue #360 |
+| L-005 | Strategy imports config layer directly | `strategies/vor_strategy.py` calls non-existent `load_config()` | Pass config via constructor; remove import — companion to #359 |
+
+### Migration Gate
+
+The ADR-001 package restructuring (`classes/ → core/`, etc.) must not begin until **all five violations above are resolved** and all tests pass. The migration itself should then be a mechanical rename with no behavior changes.
+
+### Import-Linter Enforcement
+
+Once the migration is complete, the following `import-linter` rules must be added to `pyproject.toml` to prevent regressions:
+
+```toml
+[[tool.importlinter.contracts]]
+name = "core cannot import app or lab"
+type = "forbidden"
+source_modules = ["core"]
+forbidden_modules = ["app", "lab", "api"]
+
+[[tool.importlinter.contracts]]
+name = "lab cannot import production strategies"
+type = "forbidden"
+source_modules = ["lab"]
+forbidden_modules = ["strategies"]  # production strategies only
+
+[[tool.importlinter.contracts]]
+name = "app cannot import lab"
+type = "forbidden"
+source_modules = ["app", "api", "services"]
+forbidden_modules = ["lab"]
+```

--- a/docs/adr/ADR-002-api-design.md
+++ b/docs/adr/ADR-002-api-design.md
@@ -2,7 +2,7 @@
 
 **Status:** Revised and Accepted
 **Date:** 2026-04-28
-**Revised:** 2026-04-30
+**Revised:** 2026-04-30, 2026-05-12
 **Author:** Architecture Agent (via Orchestrator)
 **Reviewer:** Architecture Agent
 **Deciders:** Engineering team
@@ -85,6 +85,7 @@ The live draft view needs sub-second bid updates. Options:
 
 ### Authentication
 - Phase 1: API key in `X-API-Key` header (simple, sufficient for single-user/commissioner use)
+  - **Security constraint (2026-05-12, ARCH-002 #355):** `PIGSKIN_API_KEY` **must** be non-empty at startup; raise `RuntimeError` if unset in non-test environments. The empty-key-as-bypass design is explicitly prohibited. Auto-generated docs (`/docs`, `/openapi.json`, `/redoc`) must be gated behind `PIGSKIN_DOCS_ENABLED=true` (default `false`).
 - Phase 2: JWT for multi-user/multi-team scenarios (deferred; requires user model)
 
 ---
@@ -202,3 +203,39 @@ Each connection has a dedicated coroutine: async for msg in queue: await ws.send
 | 5 (early) | asyncio migration of `Auction` (issue #12) + httpx for SleeperAPI (issue #14) | Must complete before WebSocket |
 | 5 (late) | WebSocket endpoint (issue #13) | Requires Phase 2 complete |
 | 6 | Live testing + monitoring | |
+
+---
+
+## Amendment — 2026-05-12 (Architecture Review, Orchestrator Synthesis)
+
+**Authored by:** Orchestrator Agent (Architecture Review + Blind Proposal synthesis)
+**Issues:** #355 (ARCH-002), #361 (ARCH-003), #364 (ARCH-010)
+
+### A. Security Hardening — API Key Auth (ARCH-002)
+
+The `Settings.api_key` default of `''` and the documented "empty key disables auth" bypass design are **prohibited**. The following constraints are now in force:
+
+1. **Startup validation:** If `PIGSKIN_API_KEY` is unset or empty at process startup, the application must raise `RuntimeError` in any non-test environment. The empty-key bypass must never be implemented.
+2. **Docs endpoints gated:** `/docs`, `/openapi.json`, and `/redoc` must be gated behind the `PIGSKIN_DOCS_ENABLED=true` environment variable (default: `false`). These endpoints must never be publicly accessible in production.
+3. **Documentation updated:** `docs/api/api-key-auth.md` must be updated to reflect the corrected behavior — empty key is always rejected, not bypassed.
+
+### B. Route Versioning (ARCH-003)
+
+The `/api/v1/` prefix specified in this ADR has not been applied to any router as of 2026-05-12. All routers — existing and new — **must** use the `/api/v1/` prefix. This change must be made atomically (all routers at once) while the external client surface is still zero. Issue: #361.
+
+### C. Async Boundary Enforcement (ARCH-010)
+
+Per the Phase 4 amendment (`ADR-002-amendment-phase4-async-boundary.md`), `Auction` and all domain objects remain synchronous. All FastAPI route handlers that call synchronous domain logic must use:
+
+```python
+import asyncio
+
+loop = asyncio.get_event_loop()
+result = await loop.run_in_executor(None, sync_domain_fn, *args)
+```
+
+This pattern must be established in the `/recommend/bid` route (the only currently live route calling domain code) and is **mandatory** for all routes implemented as part of ARCH-003. Issue: #364.
+
+### D. Phase 2 Auth Milestone
+
+The blind architecture review (2026-05-12) recommends JWT + OAuth2 (Sleeper OAuth as social login) for the multi-user Phase 2 auth model. This is consistent with the existing "Phase 2: JWT" note. When implemented, all draft room participants must have per-user identity; the single shared API key is insufficient for multi-tenant draft rooms.

--- a/docs/adr/ADR-003-strategy-promotion-pipeline.md
+++ b/docs/adr/ADR-003-strategy-promotion-pipeline.md
@@ -2,7 +2,7 @@
 
 **Status:** Revised and Accepted
 **Date:** 2026-04-28
-**Revised:** 2026-04-28
+**Revised:** 2026-04-28, 2026-05-12
 **Author:** Architecture Agent (via Orchestrator)
 **Reviewer:** Architecture Agent
 **Deciders:** Engineering team
@@ -203,3 +203,57 @@ The rollback policy requires "post-promotion monitoring" and "user analytics" �
 - [ ] Should the gate use win-rate (binary: did this team win the league?) or expected rank (continuous: avg finish position)? Expected rank is more statistically powerful at small N.
 - [ ] How is "current production strategy" tracked in `results_db/`? Suggest a `production_registry` table with a `is_current` flag.
 - [ ] Should the lab auto-create GitHub issues for near-miss gate results (e.g., p=0.06, improvement=1.8pp)? This would surface close calls for manual investigation.
+
+---
+
+## Amendment — 2026-05-12: Shadow Mode Stage (Orchestrator + Blind Architecture Review)
+
+**Authored by:** Orchestrator Agent
+**Issues:** #363 (ARCH-007)
+**Revision of:** Promotion Workflow (Steps 3–6 above)
+
+### Context
+
+The original ADR-003 promotion workflow moves a gate-passing strategy directly from lab benchmarks to a production PR. The blind architecture review (2026-05-12) identified a missing safety stage: **shadow mode**. Without shadow mode, the first time a promoted strategy's recommendations are evaluated against real-world outcomes is after it is live for all users — there is no intermediate validation layer.
+
+### Shadow Mode Stage (new Stage 3.5)
+
+Insert the following stage between the gate PASS and the auto-generated promotion PR:
+
+```
+3.5. Shadow Mode (new — required before promotion PR)
+     └─ Strategy runs in production code but recommendations are LOGGED ONLY
+     └─ Users see current production strategy's recommendations
+     └─ Shadow recommendations stored in lab/results_db/ (shadow_recommendations table)
+     └─ Duration: minimum one full draft season of active use
+     └─ Evaluation: compare shadow recommendations vs. actual draft outcomes
+        post-season (requires season-end stats)
+     └─ Shadow gate: predicted vs. actual outcome correlation r > 0.50
+        (conservative threshold for v1; tighten as data accumulates)
+     └─ FAIL → return to lab; do not promote; file new issue with shadow failure report
+     └─ PASS → proceed to Step 4 (auto-generate promotion PR)
+```
+
+### Revised Promotion Workflow Summary
+
+```
+1. Lab CI simulation batch (≥ 500 runs)
+2. Statistical gate (gate.py) — p < 0.01, 5pp improvement, variance/sanity checks
+3. [PASS] → Shadow mode activation (feature flag, log-only)
+3.5. Shadow evaluation (one draft season minimum)
+4. [PASS] → Auto-generate promotion PR with gate + shadow report
+5. Human review (required)
+6. Merge → CI/CD → staging → production
+7. Rollback policy (as specified in original ADR-003)
+```
+
+### Shadow Mode Infrastructure Requirements
+
+- `Settings`/`config`: `PIGSKIN_SHADOW_STRATEGY` env var specifies the shadow strategy name (empty = no shadow active)
+- `services/recommendation_service.py`: when `PIGSKIN_SHADOW_STRATEGY` is set, compute recommendations for both strategies; return current production strategy's result to user; log shadow result to `lab/results_db/`
+- `lab/results_db/` schema: new `shadow_recommendations` table (`id`, `strategy`, `draft_id`, `player_id`, `recommended_bid`, `actual_outcome`, `timestamp`)
+- Shadow evaluation: post-season script computes correlation between `recommended_bid` and `actual_outcome` columns
+
+### Impact on Issue #363
+
+Issue #363 (ARCH-007, promotion gate implementation) must implement both the statistical gate **and** the shadow mode infrastructure. The `GateResult` schema gains a `shadow_mode_status: Literal["not_started", "in_progress", "passed", "failed"]` field.

--- a/docs/adr/ADR-011-production-infrastructure.md
+++ b/docs/adr/ADR-011-production-infrastructure.md
@@ -1,0 +1,176 @@
+# ADR-011: Production Database and Cache Infrastructure (PostgreSQL + Redis)
+
+**Status:** Accepted
+**Date:** 2026-05-12
+**Author:** Orchestrator Agent (Architecture Review + Blind Proposal synthesis)
+**Reviewer:** Architecture Agent
+**Deciders:** Engineering team
+**Supersedes:** None
+**Related:** ADR-001 (repo structure), ADR-002 (API design), ADR-004 (lab data store), ADR-003 (promotion pipeline)
+**Issues:** #361 (ARCH-003), #362 (ARCH-006), #363 (ARCH-007)
+
+---
+
+## Context
+
+ADR-004 specifies SQLite for the lab results database (`lab/results_db/`). This is appropriate for lab-local benchmark history — it is single-writer, never deployed to production users, and does not need concurrency.
+
+However, no ADR currently specifies the **production database** for the `app/` package. The production API (`api/`) has placeholder routers for draft sessions, auction state, and player data — all of which require a persistence backend. As the system grows toward multi-user draft rooms and season-long platform features, the production persistence layer must be explicitly specified.
+
+Two findings from the 2026-05-12 architectural review triggered this ADR:
+
+1. **ARCH-003** (placeholder routers) — implementing draft/auction state persistence requires a database decision before implementation can begin.
+2. **ARCH-010** (async boundary) — the production API is async (FastAPI); the persistence layer must support async I/O via an async-capable ORM or driver.
+3. **Blind architecture proposal (2026-05-12)** — an independent senior architect, working only from the product brief, independently selected PostgreSQL + Redis as the production stack, citing: ACID correctness for auction state, JSON/JSONB for flexible projection fields, and Redis pub/sub as the only viable fan-out mechanism for multi-user WebSocket draft rooms.
+
+### Why Not SQLite for Production
+
+SQLite is the correct choice for the lab because:
+- Single writer (no concurrent benchmark runs writing simultaneously)
+- Never deployed to production users
+- No network access needed
+
+SQLite is **not** suitable for the production app because:
+- Multiple simultaneous draft participants require concurrent read/write access
+- The WebSocket draft room requires a pub/sub bus shared across API instances (horizontal scaling)
+- SQLite's WAL mode supports limited concurrency but not multiple processes on separate machines
+- Production deployments must handle concurrent bid submissions with transactional correctness
+
+---
+
+## Decision
+
+**PostgreSQL 16+ for production application database. Redis 7+ for caching and WebSocket pub/sub fan-out.**
+
+ADR-004 (SQLite for `lab/results_db/`) is **unchanged** — SQLite remains the correct choice for the lab.
+
+---
+
+## PostgreSQL — Production Database
+
+### Rationale
+
+- **ACID transactions**: Auction state transitions (pick submissions, bid placements) require transactional correctness. A concurrent bid submission must not result in a player being drafted twice.
+- **JSONB columns**: Player projections, strategy configs, and roster settings have semi-structured schemas that benefit from `JSONB` — typed core fields as columns, flexible metadata in JSON.
+- **Row-level security**: Supports per-league data isolation without application-layer filtering.
+- **Async driver**: `asyncpg` provides native async PostgreSQL access; `SQLAlchemy 2.0` supports `asyncpg` as its async backend — compatible with the FastAPI async stack.
+- **Operational maturity**: RDS (AWS), Cloud SQL (GCP), Supabase, Neon, and Render all offer managed PostgreSQL. Migration from local to cloud requires only a connection string change.
+
+### Schema Placement
+
+Production schema lives in `api/db/` (or `core/db/` after ADR-001 migration):
+
+```
+api/
+└── db/
+    ├── base.py          ← SQLAlchemy DeclarativeBase
+    ├── session.py       ← async_sessionmaker, get_db dependency
+    ├── models/
+    │   ├── draft.py     ← Draft, Pick
+    │   ├── player.py    ← Player, Projection
+    │   ├── league.py    ← League, LeagueMember
+    │   └── roster.py    ← Roster, RosterPlayer
+    └── migrations/      ← Alembic migrations (separate from lab/results_db/)
+```
+
+`lab/results_db/` Alembic migrations are **not** shared with production migrations. Each has its own `alembic.ini`.
+
+### ORM
+
+`SQLAlchemy 2.0` with async support via `asyncpg`. Pydantic models in `api/schemas/` are the DTO layer — domain objects do NOT inherit from SQLAlchemy models.
+
+### Minimal Production Schema
+
+```sql
+-- Draft lifecycle
+drafts   (id UUID PK, league_id, format, status, config JSONB, started_at, completed_at)
+picks    (id UUID PK, draft_id FK, pick_number, owner_id, player_id, price INT, picked_at)
+
+-- Player data (synced from external sources by Celery workers)
+players      (id TEXT PK, name, position, nfl_team, status, bye_week, external_ids JSONB)
+projections  (id UUID PK, player_id FK, source, week, season_year, stats JSONB, fantasy_points, fetched_at)
+
+-- League and roster
+leagues        (id UUID PK, platform, external_id, league_type, scoring_format, settings JSONB, season_year)
+league_members (league_id FK, user_id FK, team_name, draft_position)
+```
+
+---
+
+## Redis — Cache and WebSocket Fan-Out
+
+### Rationale
+
+Redis is required for two distinct roles:
+
+**Role 1: Application cache**
+- Player projection TTL cache (1 hour): prevents external API calls on every recommendation request
+- Draft state snapshots (30-second TTL): prevents database hammering from multiple live draft observers
+- Strategy recommendation cache (5-minute TTL): keyed by `(draft_id, owner_id, strategy)` — recommendations don't change mid-pick
+
+**Role 2: WebSocket pub/sub fan-out**
+When the production API runs as multiple instances (horizontal scaling), a WebSocket connection to Instance A must receive events published by Instance B (e.g., a pick submission via the REST API hitting Instance B). Redis pub/sub is the standard solution: every pick write publishes to a Redis channel; every WebSocket handler subscribes to that channel and forwards to its connected clients.
+
+This is **not** premature optimization. It is load-bearing for correctness: without Redis pub/sub, multi-instance deployments will have split-brain draft room state. The pattern must be established before multi-instance deployment, not retrofitted.
+
+### Cache Strategy
+
+Cache-aside pattern throughout:
+1. Read cache → hit: return cached value
+2. Read cache → miss: query database, write to cache, return
+3. On write: invalidate affected cache keys; do not write-through (avoids stale cache on rollback)
+
+### Implementation
+
+- Library: `redis-py` with `asyncio` support (`redis.asyncio`)
+- Connection: `redis.asyncio.ConnectionPool` (reused across requests via FastAPI lifespan)
+- Pub/sub: `redis.asyncio.client.PubSub` subscriber in WebSocket handler
+- Publisher: `await redis.publish(f"draft:{draft_id}", event_json)` in `DraftService.submit_pick()`
+
+---
+
+## Deployment Progression
+
+| Phase | PostgreSQL | Redis |
+|-------|-----------|-------|
+| Phase 1 (CLI MVP) | Not needed — CLI is direct Python | Not needed |
+| Phase 2 (FastAPI + Web) | Local PostgreSQL (Docker Compose) | Local Redis (Docker Compose) |
+| Phase 3+ (Cloud) | RDS PostgreSQL or managed Postgres | ElastiCache Redis or Upstash |
+
+Phase 1 does not require PostgreSQL because the CLI operates directly via Python without HTTP. PostgreSQL and Redis are introduced together in Phase 2 when the FastAPI application launches.
+
+---
+
+## Consequences
+
+### Positive
+- ACID correctness for all auction state transitions
+- Async-native stack (`asyncpg` + `SQLAlchemy 2.0`) compatible with FastAPI event loop
+- Redis pub/sub enables correct multi-instance WebSocket fan-out from day one
+- Managed cloud options available with no application code changes (connection string only)
+- ADR-004 (SQLite for lab) is completely unaffected
+
+### Negative
+- Adds PostgreSQL and Redis as development dependencies (mitigated by Docker Compose)
+- `docker-compose.yml` must be provided for local dev (`make dev` target)
+- `asyncpg` is not compatible with synchronous SQLAlchemy usage — all database access in `api/` must be async (consistent with FastAPI architecture)
+- Lab code must never import from `api/db/` — lab keeps its own SQLite results store
+
+### Non-decisions (deferred)
+
+- **Connection pooling tuning**: Default SQLAlchemy pool settings are sufficient for Phase 2. Tune under measured load.
+- **Read replicas**: Not needed until query volume justifies it. RDS makes this a config change.
+- **Redis Cluster mode**: Single-node Redis is sufficient for Phase 2–3. Cluster mode when single-node becomes a bottleneck.
+- **Full-text search**: Player search will use PostgreSQL `ILIKE` initially. Switch to `pg_trgm` or a dedicated search index if performance requires it.
+
+---
+
+## Implementation Checklist
+
+- [ ] Add `asyncpg>=0.29`, `sqlalchemy[asyncio]>=2.0`, `redis[asyncio]>=5.0`, `alembic>=1.13` to `requirements-core.txt`
+- [ ] Add `docker-compose.yml` with `postgres:16` and `redis:7-alpine` services
+- [ ] Create `api/db/` package with `base.py`, `session.py`, and `models/`
+- [ ] Create `api/db/migrations/` Alembic environment (separate from `lab/results_db/`)
+- [ ] Add `make db-migrate`, `make db-upgrade`, `make dev` Makefile targets
+- [ ] FastAPI lifespan handler initializes `asyncpg` connection pool and Redis connection pool on startup
+- [ ] `.env.example` updated with `DATABASE_URL` and `REDIS_URL` placeholders

--- a/docs/api/api-key-auth.md
+++ b/docs/api/api-key-auth.md
@@ -55,10 +55,10 @@ python -c "import secrets; print(secrets.token_urlsafe(32))"
 # config/settings.py
 class Settings(BaseSettings):
     ...
-    api_key: str = ""   # empty string = auth disabled (local dev only)
+    api_key: str = Field(default='', validation_alias='PIGSKIN_API_KEY')
 ```
 
-If `api_key` is empty, the auth dependency is a **no-op** — all requests pass. This preserves local dev workflow without requiring a key. In production or CI, `PIGSKIN_API_KEY` must be set.
+> **`PIGSKIN_API_KEY` is required.** The application will refuse to start if the key is empty or unset in any non-test environment. There is no "auth disabled" or empty-key bypass mode. Set a strong key in `.env` (local dev) or your deployment environment before starting the server.
 
 ### Key Rotation
 
@@ -76,8 +76,8 @@ A rotation admin endpoint is deferred to v2 (requires a session/token store for 
 | Route | Method | Auth Required | Reason |
 |-------|--------|--------------|--------|
 | `GET /health` | GET | ❌ Public | Liveness probe; must be callable without credentials |
-| `GET /docs` | GET | ❌ Public | OpenAPI UI; acceptable to expose schema |
-| `GET /openapi.json` | GET | ❌ Public | Consumed by `/docs` |
+| `GET /docs` | GET | ⚙️ Gated | Only accessible when `PIGSKIN_DOCS_ENABLED=true` |
+| `GET /openapi.json` | GET | ⚙️ Gated | Only accessible when `PIGSKIN_DOCS_ENABLED=true` |
 | `GET /api/v1/players` | GET | ✅ Required | Returns player data |
 | `POST /api/v1/players/search` | POST | ✅ Required | |
 | `GET /api/v1/draft` | GET | ✅ Required | Returns draft state |
@@ -86,40 +86,53 @@ A rotation admin endpoint is deferred to v2 (requires a session/token store for 
 | `GET /api/v1/strategies` | GET | ✅ Required | Returns strategy list |
 | All other `/api/v1/...` | Any | ✅ Required | Default: protect all |
 
-**Rule:** Any route registered under the `/api/v1/` prefix requires auth. Routes at the root (`/health`, `/docs`, `/openapi.json`) are public.
+**Rule:** Any route registered under the `/api/v1/` prefix requires auth. `/health` is always public. `/docs`, `/openapi.json`, and `/redoc` are only available when the `PIGSKIN_DOCS_ENABLED=true` environment variable is set.
 
 ---
 
 ## Implementation Sketch
 
 ```python
-# api/deps.py
-from fastapi import Depends, Header, HTTPException
-from config.settings import get_settings
+# api/main.py — startup guard
+import os
 
-async def require_api_key(
-    x_api_key: str = Header(default=""),
-) -> None:
+def create_app(*, api_key: str | None = None, docs_enabled: bool | None = None) -> FastAPI:
     settings = get_settings()
-    if not settings.api_key:
-        return  # auth disabled (local dev mode)
-    if x_api_key != settings.api_key:
-        if not x_api_key:
-            raise HTTPException(status_code=401, detail="Missing X-API-Key header")
+    resolved_api_key = api_key if api_key is not None else settings.api_key
+    resolved_docs_enabled = docs_enabled if docs_enabled is not None else settings.docs_enabled
+
+    # Refuse to start with no key outside of test environments
+    if not resolved_api_key and os.getenv("TESTING") != "true":
+        raise RuntimeError(
+            "PIGSKIN_API_KEY must be set. "
+            "An empty API key is not allowed in non-test environments."
+        )
+
+    # Gate /docs behind PIGSKIN_DOCS_ENABLED
+    app = FastAPI(
+        docs_url="/docs" if resolved_docs_enabled else None,
+        openapi_url="/openapi.json" if resolved_docs_enabled else None,
+        redoc_url="/redoc" if resolved_docs_enabled else None,
+        ...
+    )
+```
+
+```python
+# api/deps.py
+import secrets
+from fastapi import Depends, HTTPException, Security, status
+from fastapi.security import APIKeyHeader
+
+_api_key_header = APIKeyHeader(name="X-API-Key", auto_error=False)
+
+def require_api_key(api_key: str | None = Security(_api_key_header), ...) -> None:
+    if not api_key:
+        raise HTTPException(status_code=401, detail="Missing API key")
+    if not secrets.compare_digest(api_key.encode(), configured_key.encode()):
         raise HTTPException(status_code=403, detail="Invalid API key")
 ```
 
-Apply as a router-level dependency in each router:
-
-```python
-# api/routers/draft.py
-from fastapi import APIRouter, Depends
-from api.deps import require_api_key
-
-router = APIRouter(prefix="/api/v1/draft", dependencies=[Depends(require_api_key)])
-```
-
-Or as an application-level middleware that exempts `/health`, `/docs`, and `/openapi.json`.
+Applied as a router-level dependency in `api/main.py` — all routers except `/health` require auth.
 
 ---
 

--- a/docs/api/openapi.yaml
+++ b/docs/api/openapi.yaml
@@ -1,94 +1,234 @@
-openapi: "3.1.0"
-info:
-  title: Pigskin Draft Assistant API
-  version: "0.1.0"
-  description: |
-    Fantasy football auction draft assistant.
-    All endpoints are versioned under /api/v1/ (planned).
-    Current scaffold uses root paths.
-  contact:
-    name: Pigskin Dev Team
-
-servers:
-  - url: http://localhost:8000
-    description: Local development
-
-paths:
-  /health:
-    get:
-      summary: Health check
-      tags: [meta]
-      responses:
-        "200":
-          description: Service is healthy
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/HealthResponse"
-
-  /strategies/:
-    get:
-      summary: List available bidding strategies
-      tags: [strategies]
-      responses:
-        "200":
-          description: List of strategy names
-          content:
-            application/json:
-              schema:
-                type: array
-                items:
-                  type: string
-
-  /players/:
-    get:
-      summary: List players (not yet implemented)
-      tags: [players]
-      responses:
-        "200":
-          description: Placeholder
-          content:
-            application/json:
-              schema:
-                type: object
-
-  /draft/:
-    get:
-      summary: Draft status (not yet implemented)
-      tags: [draft]
-      responses:
-        "200":
-          description: Placeholder
-          content:
-            application/json:
-              schema:
-                type: object
-
-  /auction/:
-    get:
-      summary: Auction operations (not yet implemented)
-      tags: [auction]
-      responses:
-        "200":
-          description: Placeholder
-          content:
-            application/json:
-              schema:
-                type: object
-
 components:
   schemas:
-    HealthResponse:
-      type: object
+    BidRecommendationRequest:
+      description: Request body for POST /recommend/bid.
       properties:
-        status:
+        current_bid:
+          description: Current highest bid (0 if no bids yet)
+          minimum: 0.0
+          title: Current Bid
+          type: number
+        player_id:
+          anyOf:
+          - type: string
+          - type: 'null'
+          description: Sleeper player ID (optional)
+          title: Player Id
+        player_name:
+          description: Name of the player to bid on
+          minLength: 1
+          title: Player Name
           type: string
-          example: ok
-
+        roster_spots_remaining:
+          default: 1
+          description: Number of roster spots still to fill
+          minimum: 1.0
+          title: Roster Spots Remaining
+          type: integer
+        sleeper_draft_id:
+          anyOf:
+          - type: string
+          - type: 'null'
+          description: Sleeper draft ID for live draft context
+          title: Sleeper Draft Id
+        strategy_override:
+          anyOf:
+          - type: string
+          - type: 'null'
+          description: Override the configured strategy
+          title: Strategy Override
+        team_budget:
+          description: Remaining team budget in dollars
+          minimum: 0.0
+          title: Team Budget
+          type: number
+      required:
+      - player_name
+      - current_bid
+      - team_budget
+      title: BidRecommendationRequest
+      type: object
+    BidRecommendationResponse:
+      description: Response body for POST /recommend/bid.
+      properties:
+        confidence:
+          description: Confidence score [0, 1]
+          maximum: 1.0
+          minimum: 0.0
+          title: Confidence
+          type: number
+        rationale:
+          description: Human-readable explanation for the recommendation
+          title: Rationale
+          type: string
+        recommended_bid:
+          description: Recommended bid amount in dollars
+          title: Recommended Bid
+          type: number
+      required:
+      - recommended_bid
+      - confidence
+      - rationale
+      title: BidRecommendationResponse
+      type: object
+    HTTPValidationError:
+      properties:
+        detail:
+          items:
+            $ref: '#/components/schemas/ValidationError'
+          title: Detail
+          type: array
+      title: HTTPValidationError
+      type: object
+    ValidationError:
+      properties:
+        ctx:
+          title: Context
+          type: object
+        input:
+          title: Input
+        loc:
+          items:
+            anyOf:
+            - type: string
+            - type: integer
+          title: Location
+          type: array
+        msg:
+          title: Message
+          type: string
+        type:
+          title: Error Type
+          type: string
+      required:
+      - loc
+      - msg
+      - type
+      title: ValidationError
+      type: object
   securitySchemes:
-    ApiKeyAuth:
-      type: apiKey
+    APIKeyHeader:
       in: header
       name: X-API-Key
-
-security: []
+      type: apiKey
+info:
+  description: Fantasy football auction draft assistant API
+  title: Pigskin Draft Assistant
+  version: 0.1.0
+openapi: 3.1.0
+paths:
+  /auction/:
+    get:
+      operationId: auction_index_auction__get
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                additionalProperties: true
+                title: Response Auction Index Auction  Get
+                type: object
+          description: Successful Response
+      security:
+      - APIKeyHeader: []
+      summary: Auction operations (not yet implemented)
+      tags:
+      - auction
+  /draft/:
+    get:
+      operationId: draft_index_draft__get
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                additionalProperties: true
+                title: Response Draft Index Draft  Get
+                type: object
+          description: Successful Response
+      security:
+      - APIKeyHeader: []
+      summary: Draft operations (not yet implemented)
+      tags:
+      - draft
+  /health:
+    get:
+      operationId: health_health_get
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                additionalProperties: true
+                title: Response Health Health Get
+                type: object
+          description: Successful Response
+      summary: Health
+      tags:
+      - meta
+  /players/:
+    get:
+      operationId: list_players_players__get
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                additionalProperties: true
+                title: Response List Players Players  Get
+                type: object
+          description: Successful Response
+      security:
+      - APIKeyHeader: []
+      summary: List players (not yet implemented)
+      tags:
+      - players
+  /recommend/bid:
+    post:
+      description: Returns a recommended bid amount, confidence score, and rationale
+        for the requested player based on the configured bidding strategy. Returns
+        HTTP 503 if no draft context is available.
+      operationId: recommend_bid_recommend_bid_post
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/BidRecommendationRequest'
+        required: true
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/BidRecommendationResponse'
+          description: Successful Response
+        '422':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
+          description: Validation Error
+      security:
+      - APIKeyHeader: []
+      summary: Get a bid recommendation for a player
+      tags:
+      - recommend
+  /strategies/:
+    get:
+      description: Return the names of all available bidding strategies.
+      operationId: list_strategies_strategies__get
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                items:
+                  type: string
+                title: Response List Strategies Strategies  Get
+                type: array
+          description: Successful Response
+      security:
+      - APIKeyHeader: []
+      summary: List available strategies
+      tags:
+      - strategies

--- a/docs/strategies/catalog.md
+++ b/docs/strategies/catalog.md
@@ -1,0 +1,72 @@
+# Strategy Catalog
+
+All strategies registered in `AVAILABLE_STRATEGIES` (see `strategies/__init__.py`).  
+To instantiate any strategy: `from strategies import create_strategy; s = create_strategy("key")`.
+
+---
+
+| Key | Class | Description | Key Parameters (defaults) | Best For |
+|-----|-------|-------------|---------------------------|----------|
+| `value` | `ValueBasedStrategy` | Bids based on player auction value with position premiums and budget reservation logic | `value_multiplier=1.4`, `max_overbid=1.3`, `position_premiums` (RB: 1.3, WR: 1.2) | General-purpose; balanced 10–12 team leagues |
+| `aggressive` | `AggressiveStrategy` | Goes all-in on elite players early; throttles back when budget falls below threshold | `elite_threshold=25`, `elite_multiplier=1.3`, `budget_threshold=0.7` | Deep leagues; managers willing to punt thin positions for 2–3 studs |
+| `conservative` | `ConservativeStrategy` | Caps bids at 85% of value; mildly overbids on sleepers under $15; never spends >20% of budget on one player | `max_value_ratio=0.85`, `sleeper_threshold=15`, `sleeper_multiplier=1.1` | Risk-averse managers; high-variance leagues where overpaying is punished |
+| `sigmoid` | `SigmoidStrategy` | Uses sigmoid curves to blend aggression with draft progress, budget pressure, and positional need | `base_multiplier=1.05`, `steepness=8.0`, `midpoint=0.5`, `need_boost=1.35`, `budget_pressure_factor=2.2` | Experienced managers who want math-driven, context-sensitive bidding |
+| `improved_value` | `ImprovedValueStrategy` | Value-based bidding with a configurable scarcity adjustment per position | `aggression=1.0`, `scarcity_weight=0.3`, `randomness=0.0` | Leagues where positional scarcity (RB, TE) drives inflation |
+| `adaptive` | `AdaptiveStrategy` | Tracks bid history and per-position market trends to adjust aggression in real time | `base_aggression=1.0`, `adapt_factor=0.5` | Variable markets; experienced managers who want the bot to "learn" the room |
+| `vor` | `VorStrategy` | Bids using Value Over Replacement relative to positional baselines, weighted by scarcity | `aggression=1.0`, `scarcity_weight=0.7` | Analytics-driven leagues; managers targeting the best positional upside |
+| `random` | `RandomStrategy` | Bids with randomized aggression and configurable noise; primarily for simulation variety | `aggression=random(0.5–1.5)`, `randomness=0.5` | Stress testing, simulation baseline, unpredictable opponent modeling |
+| `smart` | `SmartStrategy` | Placeholder — delegates to `ValueBasedStrategy`; reserved for future sprint work (#63) | (inherits `value` params) | Testing harness; do not use in production tournaments |
+| `balanced` | `BalancedStrategy` | VOR-variance-adjusted bidding with position scarcity; slightly more aggressive defaults | `aggression=1.25`, `vor_variance=1.1` | All-around leagues; recommended starting point for new users |
+| `basic` | `BasicStrategy` | Straightforward bid = `player_value × aggression × position_priority × urgency` | `aggression=1.0` | Baseline benchmarking; learning how the bid pipeline works |
+| `elite_hybrid` | `EliteHybridStrategy` | Pays up sharply for players above per-position elite thresholds; conserves on the rest | `aggression=1.2`, `vor_variance=0.8`, `elite_thresholds` (RB: 35, WR: 30, QB: 25) | Leagues where elite RB/WR scarcity is extreme and studs win championships |
+| `inflation_aware_vor` | `InflationAwareVorStrategy` | VOR strategy that measures league-wide budget consumption to compute a real-time inflation factor | `aggression=1.0`, `scarcity_weight=0.7`, `inflation_sensitivity=0.5`, `budget=200`, `roster_size=15` | Large (14+) leagues; inflationary markets where $1 bids drain the pool |
+| `value_random` | `ValueRandomStrategy` | Value-based core with a configurable random perturbation on each bid | `aggression=1.0`, `randomness=0.3`, `scarcity_weight=0.5` | Simulation variety; modeling human unpredictability in tournament fields |
+| `value_smart` | `ValueSmartStrategy` | Hybrid of value-based bidding and adaptive trend tracking | `aggression=1.0`, `adapt_factor=0.5`, `scarcity_weight=0.5` | Mid-skill managers who want value discipline with situational flexibility |
+| `league` | `LeagueStrategy` | Applies per-position trend factors (e.g., league overvalues top RBs, undervalues K/DST) to adjust bids | `aggression=1.0`, `trend_adjustment=0.8` | Experienced managers who know their specific league's bidding tendencies |
+| `refined_value_random` | `RefinedValueRandomStrategy` | Enhanced value-random hybrid with higher RB/TE scarcity weights and explicit position targets | `aggression=1.1`, `randomness=0.35`, `scarcity_weight=0.5` | Semi-random simulation runs; tournament fields that need realistic variance |
+
+---
+
+## Strategy Family Overview
+
+```
+BaseStrategy (strategies/base_strategy.py)
+├── Simple / Baseline
+│   ├── basic            — configurable aggression only
+│   ├── random           — randomized bids for simulation
+│   └── smart            — placeholder (ValueBased delegate)
+├── Value-Based
+│   ├── value            — position-premium value bidding
+│   ├── conservative     — capped value, sleeper-friendly
+│   ├── improved_value   — value + scarcity adjustment
+│   └── value_random     — value + random noise
+├── VOR-Based
+│   ├── vor              — Value Over Replacement
+│   └── inflation_aware_vor  — VOR + market inflation factor
+├── Hybrid
+│   ├── balanced         — VOR variance + scarcity
+│   ├── elite_hybrid     — elite-threshold spikes + VOR
+│   ├── value_smart      — value + adaptive trending
+│   └── refined_value_random — value + scarcity + random
+├── Adaptive / Trend
+│   ├── adaptive         — real-time aggression adjustment
+│   ├── sigmoid          — sigmoid-curve context model
+│   └── league           — per-position league-trend factors
+└── Aggressive
+    └── aggressive       — elite-first, throttled budget
+```
+
+---
+
+## Parameter Quick Reference
+
+| Parameter | Type | Typical Range | Meaning |
+|-----------|------|---------------|---------|
+| `aggression` | float | 0.5 – 1.5 | Scales final bid up/down from base value |
+| `scarcity_weight` | float | 0.0 – 1.0 | How much positional scarcity inflates bids |
+| `randomness` | float | 0.0 – 1.0 | Probability / magnitude of random bid noise |
+| `adapt_factor` | float | 0.0 – 1.0 | Speed at which aggression adapts to observed trends |
+| `vor_variance` | float | 0.1 – 1.5 | Multiplier on VOR-derived bid variance |
+| `inflation_sensitivity` | float | 0.0 – 1.0 | Responsiveness to league-wide budget inflation |
+| `elite_threshold` | int/dict | per position | Auction value above which a player is "elite" |
+| `trend_adjustment` | float | 0.5 – 1.0 | Weight of per-position league-trend factors |

--- a/docs/strategies/how-to-create.md
+++ b/docs/strategies/how-to-create.md
@@ -1,0 +1,321 @@
+# How to Create a New Strategy
+
+This guide walks through adding a strategy from scratch so it works end-to-end: lab experiments, simulations, and the CLI.
+
+---
+
+## Prerequisites
+
+- Python ≥ 3.10, project venv activated (`source venv/bin/activate`)
+- Familiarity with `strategies/base_strategy.py` — read it before writing your own
+- A clear idea of the bidding logic you want to implement
+
+---
+
+## Step 1 — Create `strategies/my_strategy.py`
+
+All strategies inherit from `Strategy` (alias for `BaseStrategy`).
+
+```python
+# strategies/my_strategy.py
+"""One-line summary of the strategy."""
+
+from typing import List, TYPE_CHECKING
+from .base_strategy import Strategy
+
+if TYPE_CHECKING:
+    from classes.player import Player
+    from classes.team import Team
+    from classes.owner import Owner
+
+
+class MyStrategy(Strategy):
+    """Short description used in catalog and CLI output."""
+
+    def __init__(self, aggression: float = 1.0):
+        """
+        Args:
+            aggression: Scales bid relative to base value (0.5 – 1.5).
+        """
+        super().__init__(
+            "My Strategy",          # Human-readable name
+            f"Description with aggression={aggression:.1f}"
+        )
+        self.aggression = aggression
+
+    def calculate_bid(
+        self,
+        player: "Player",
+        team: "Team",
+        owner: "Owner",
+        current_bid: float,
+        remaining_budget: float,
+        remaining_players: List["Player"],
+    ) -> float:
+        """Return the bid amount, or 0.0 to pass."""
+        # Guard: always reserve $1 per unfilled roster slot
+        slots_left = self._get_remaining_roster_slots(team)
+        if remaining_budget <= slots_left + 3:
+            return max(current_bid + 1, 1.0)
+
+        position_priority = self._calculate_position_priority(player, team)
+        if position_priority <= 0.1:
+            return 0.0
+
+        player_value = self._get_player_value(player, default=10.0)
+        max_bid = self.calculate_max_bid(team, remaining_budget)
+
+        bid = min(player_value * self.aggression * position_priority, max_bid)
+        if bid <= current_bid:
+            return 0.0
+
+        return self._enforce_budget_constraint(bid, team, remaining_budget)
+```
+
+### Key helpers available from `BaseStrategy`
+
+| Helper | What it does |
+|--------|--------------|
+| `self._get_player_value(player, default)` | Returns `auction_value` (falls back to `projected_points`) |
+| `self._calculate_position_priority(player, team)` | 0.0 – 1.0 based on roster needs |
+| `self._calculate_position_urgency(player, team)` | Urgency multiplier as roster fills |
+| `self._get_remaining_roster_slots(team)` | Count of unfilled mandatory slots |
+| `self.calculate_max_bid(team, remaining_budget)` | Safe max spend respecting roster completion |
+| `self._enforce_budget_constraint(bid, team, budget)` | Clamps bid so team can still complete roster |
+| `self._calculate_budget_reservation(team, budget)` | Minimum $$ to hold for remaining slots |
+
+---
+
+## Step 2 — Register in `strategies/__init__.py`
+
+Open `strategies/__init__.py` and add in two places:
+
+```python
+# 1. Import at the top (keep alphabetical within the section)
+from .my_strategy import MyStrategy
+
+# 2. Add to AVAILABLE_STRATEGIES dict
+AVAILABLE_STRATEGIES = {
+    ...
+    'my_strategy': MyStrategy,   # ← new entry
+}
+
+# 3. Add to __all__
+__all__ = [
+    ...
+    'MyStrategy',
+]
+```
+
+Verify it's visible:
+
+```bash
+python -c "from strategies import AVAILABLE_STRATEGIES; print('my_strategy' in AVAILABLE_STRATEGIES)"
+# True
+```
+
+---
+
+## Step 3 — Add unit tests in `tests/unit/strategies/`
+
+Create `tests/unit/strategies/test_my_strategy.py`:
+
+```python
+"""Unit tests for MyStrategy."""
+
+import pytest
+from strategies.my_strategy import MyStrategy
+from unittest.mock import MagicMock
+
+
+def _make_player(auction_value: float = 20.0, position: str = "RB"):
+    p = MagicMock()
+    p.auction_value = auction_value
+    p.position = position
+    return p
+
+
+def _make_team(needs=("RB",), roster_len=0, initial_budget=200.0):
+    t = MagicMock()
+    t.get_needs.return_value = list(needs)
+    t.roster = [MagicMock()] * roster_len
+    t.roster_requirements = {"QB": 1, "RB": 2, "WR": 2, "TE": 1, "K": 1, "DST": 1}
+    t.initial_budget = initial_budget
+    return t
+
+
+class TestMyStrategy:
+    def test_passes_when_budget_is_low(self):
+        s = MyStrategy()
+        player = _make_player(20.0)
+        team = _make_team()
+        bid = s.calculate_bid(player, team, MagicMock(), 0.0, 5.0, [])
+        # With almost no budget left, strategy should not overbid
+        assert bid <= 5.0
+
+    def test_bids_above_current_for_needed_position(self):
+        s = MyStrategy(aggression=1.0)
+        player = _make_player(20.0, "RB")
+        team = _make_team(needs=["RB"])
+        bid = s.calculate_bid(player, team, MagicMock(), 5.0, 150.0, [])
+        assert bid > 5.0
+
+    def test_passes_for_unwanted_position(self):
+        s = MyStrategy()
+        player = _make_player(20.0, "QB")
+        team = _make_team(needs=[])  # team needs nothing
+        bid = s.calculate_bid(player, team, MagicMock(), 0.0, 150.0, [])
+        assert bid == 0.0
+
+    def test_never_exceeds_remaining_budget(self):
+        s = MyStrategy(aggression=2.0)  # deliberately over-aggressive
+        player = _make_player(100.0, "RB")
+        team = _make_team(needs=["RB"])
+        remaining = 50.0
+        bid = s.calculate_bid(player, team, MagicMock(), 0.0, remaining, [])
+        assert bid <= remaining
+```
+
+Run just your new tests:
+
+```bash
+pytest tests/unit/strategies/test_my_strategy.py -v
+```
+
+---
+
+## Step 4 — Add property tests in `tests/property/`
+
+Property tests catch edge cases your unit tests won't imagine.  
+Add `tests/property/test_my_strategy_properties.py`:
+
+```python
+"""Property-based tests for MyStrategy (Hypothesis)."""
+
+from hypothesis import given, settings, HealthCheck
+from hypothesis import strategies as st
+from unittest.mock import MagicMock
+
+from strategies.my_strategy import MyStrategy
+
+
+def _make_team(needs, roster_len, initial_budget):
+    t = MagicMock()
+    t.get_needs.return_value = needs
+    t.roster = [MagicMock()] * roster_len
+    t.roster_requirements = {"QB": 1, "RB": 2, "WR": 2, "TE": 1, "K": 1, "DST": 1}
+    t.initial_budget = max(initial_budget, 1.0)
+    return t
+
+
+@given(
+    auction_value=st.floats(min_value=1.0, max_value=200.0, allow_nan=False),
+    current_bid=st.floats(min_value=0.0, max_value=100.0, allow_nan=False),
+    remaining_budget=st.floats(min_value=1.0, max_value=400.0, allow_nan=False),
+    aggression=st.floats(min_value=0.1, max_value=3.0, allow_nan=False),
+)
+@settings(suppress_health_check=[HealthCheck.too_slow], max_examples=200)
+def test_bid_never_exceeds_remaining_budget(auction_value, current_bid, remaining_budget, aggression):
+    """Invariant: bid must never exceed remaining_budget."""
+    s = MyStrategy(aggression=aggression)
+    player = MagicMock()
+    player.auction_value = auction_value
+    player.position = "RB"
+    team = _make_team(["RB"], roster_len=0, initial_budget=200.0)
+
+    bid = s.calculate_bid(player, team, MagicMock(), current_bid, remaining_budget, [])
+    assert bid <= remaining_budget, f"bid {bid} > budget {remaining_budget}"
+
+
+@given(
+    auction_value=st.floats(min_value=1.0, max_value=200.0, allow_nan=False),
+    remaining_budget=st.floats(min_value=1.0, max_value=400.0, allow_nan=False),
+)
+@settings(max_examples=100)
+def test_bid_is_non_negative(auction_value, remaining_budget):
+    """Invariant: bid must be ≥ 0."""
+    s = MyStrategy()
+    player = MagicMock()
+    player.auction_value = auction_value
+    player.position = "WR"
+    team = _make_team(["WR"], roster_len=1, initial_budget=200.0)
+
+    bid = s.calculate_bid(player, team, MagicMock(), 0.0, remaining_budget, [])
+    assert bid >= 0.0
+```
+
+Run property tests:
+
+```bash
+pytest tests/property/test_my_strategy_properties.py -v
+```
+
+---
+
+## Step 5 — Test in the lab
+
+Create an experiment config at `lab/experiments/my_experiment.yaml`:
+
+```yaml
+name: my_strategy_baseline
+description: First run of MyStrategy against existing strategies
+
+strategies:
+  - my_strategy
+  - balanced
+  - vor
+  - aggressive
+
+num_simulations: 500
+num_teams: 10
+budget: 200
+
+metrics:
+  - win_rate
+  - avg_score
+  - budget_efficiency
+```
+
+Run it:
+
+```bash
+python -m lab.simulation.runner --experiment lab/experiments/my_experiment.yaml
+```
+
+Results land in `lab/results_db/`. Compare with:
+
+```bash
+python -m lab.eval.compare_strategies --experiment my_strategy_baseline
+```
+
+---
+
+## Step 6 — Update the strategy catalog
+
+Add your strategy to [docs/strategies/catalog.md](catalog.md) following the existing table format.  
+Include: key, class name, description, key parameters with defaults, and best-use guidance.
+
+---
+
+## Checklist
+
+- [ ] `strategies/my_strategy.py` created, inherits `Strategy`
+- [ ] `calculate_bid()` always returns `0.0 ≤ bid ≤ remaining_budget`
+- [ ] Registered in `AVAILABLE_STRATEGIES` and `__all__`
+- [ ] `create_strategy("my_strategy")` works without errors
+- [ ] Unit tests in `tests/unit/strategies/test_my_strategy.py` — all pass
+- [ ] Property tests in `tests/property/test_my_strategy_properties.py` — all pass
+- [ ] Lab experiment YAML created and at least one simulation run completed
+- [ ] `docs/strategies/catalog.md` updated
+
+---
+
+## Common Pitfalls
+
+| Problem | Fix |
+|---------|-----|
+| `bid > remaining_budget` | Always call `_enforce_budget_constraint()` before returning |
+| `ZeroDivisionError` on `initial_budget` | Guard: `initial_budget = getattr(team, 'initial_budget', None) or remaining_budget or 1` |
+| Strategy never bids | Check `_calculate_position_priority()` — returns 0.0 when position slot is full |
+| Strategy overbids on K/DST | These positions need special handling; see `AggressiveStrategy.calculate_bid()` for the pattern |
+| Import error in `__init__.py` | Ensure class name in import matches exactly what's defined in the module |

--- a/docs/wiki-plan.md
+++ b/docs/wiki-plan.md
@@ -1,0 +1,145 @@
+# GitHub Wiki Plan
+
+**Status:** Draft — Sprint 11, Track G  
+**Issues:** #297  
+**Last updated:** 2026-05-13
+
+This document defines the structure, ownership, writing standard, and rollout priority for the Pigskin Fantasy Football GitHub Wiki.
+
+---
+
+## 1. Page Structure
+
+The wiki uses a flat namespace (GitHub wikis do not support subdirectories), so pages are prefixed with a category slug.
+
+```
+Home
+│
+├── Getting Started
+│   ├── GettingStarted-Installation
+│   ├── GettingStarted-QuickStart
+│   └── GettingStarted-Configuration
+│
+├── Strategies
+│   ├── Strategies-Catalog          ← mirrors docs/strategies/catalog.md
+│   ├── Strategies-HowToCreate      ← mirrors docs/strategies/how-to-create.md
+│   └── Strategies-LabExperiments
+│
+├── API
+│   ├── API-Overview
+│   └── API-Endpoints               ← generated from docs/api/openapi.yaml
+│
+├── Architecture
+│   ├── Architecture-Overview
+│   ├── Architecture-ADRs           ← index of docs/adr/
+│   └── Architecture-LabPipeline
+│
+├── Development
+│   ├── Development-ContributingGuide
+│   ├── Development-BranchingStrategy
+│   ├── Development-TestingGuide
+│   └── Development-CIWorkflows
+│
+└── Operations
+    ├── Operations-Runbook
+    └── Operations-PromotionPipeline
+```
+
+---
+
+## 2. Ownership Matrix
+
+Each page has a **primary owner** (the agent/team responsible for keeping it current) and a **reviewer** (signs off on major changes).
+
+| Page | Primary Owner | Reviewer | Update Cadence |
+|------|---------------|----------|----------------|
+| Home | Docs Agent | Lead Dev | Each sprint |
+| GettingStarted-Installation | Docs Agent | DevOps | On dependency change |
+| GettingStarted-QuickStart | Docs Agent | Lead Dev | Quarterly |
+| GettingStarted-Configuration | Docs Agent | Backend Agent | On config schema change |
+| Strategies-Catalog | Docs Agent | Strategy Agent | When strategy added/removed |
+| Strategies-HowToCreate | Docs Agent | Strategy Agent | On `BaseStrategy` API change |
+| Strategies-LabExperiments | Lab Agent | Strategy Agent | Each sprint |
+| API-Overview | Docs Agent | Backend Agent | Each sprint |
+| API-Endpoints | Backend Agent (auto-gen) | Docs Agent | Each PR to `api/` |
+| Architecture-Overview | Docs Agent | Lead Dev | Quarterly |
+| Architecture-ADRs | Docs Agent | Lead Dev | When ADR is merged |
+| Architecture-LabPipeline | Lab Agent | Lead Dev | On pipeline change |
+| Development-ContributingGuide | Docs Agent | Lead Dev | On workflow change |
+| Development-BranchingStrategy | Docs Agent | Lead Dev | On branching policy change |
+| Development-TestingGuide | Docs Agent | QA Agent | On test infra change |
+| Development-CIWorkflows | DevOps Agent | Lead Dev | On workflow change |
+| Operations-Runbook | DevOps Agent | Lead Dev | On infra change |
+| Operations-PromotionPipeline | Lab Agent | Lead Dev | Sprint 12+ |
+
+> **Agent key:**  
+> - **Docs Agent** — GitHub Copilot chat, Track G work  
+> - **Backend Agent** — Copilot, API / FastAPI work  
+> - **Strategy Agent** — Copilot, strategies module work  
+> - **Lab Agent** — Copilot, `lab/` work  
+> - **DevOps Agent** — Copilot, CI/CD / Make target work  
+> - **Lead Dev** — human maintainer (final approval)
+
+---
+
+## 3. Writing Standard
+
+### 3.1 Tone and Voice
+
+- **Direct and technical.** Write for Python developers; avoid over-explaining basic concepts.
+- **Present tense.** "The strategy bids…" not "The strategy will bid…"
+- **Second person for instructions.** "Run `pytest`…" not "The user should run…"
+- **No marketing language.** Avoid "powerful", "seamless", "best-in-class".
+
+### 3.2 Format
+
+| Element | Guidance |
+|---------|----------|
+| Headings | `##` for sections, `###` for subsections; no `#` (GitHub renders page title) |
+| Code blocks | Always fenced with language tag (` ```python `, ` ```bash `, ` ```yaml `) |
+| Tables | Use for comparisons, parameter references, and matrices |
+| Links | Use wiki-relative links: `[[Strategies-Catalog]]`; repo links use full path |
+| File references | Backtick the path: `` `strategies/__init__.py` `` |
+| Commands | Single-line commands inline (`` `pytest` ``); multi-step in fenced bash block |
+
+### 3.3 Required Sections per Page
+
+Every wiki page must include:
+
+1. **One-line summary** at the top (plain text, no heading)
+2. **Last updated** line: `_Last updated: YYYY-MM-DD (Sprint N)_`
+3. **Body content** (varies by page type)
+4. **Related pages** section at the bottom (2–4 wiki links)
+
+### 3.4 Update Cadence
+
+- **Sprint-end review:** Primary owner checks whether the page is still accurate before closing the sprint.
+- **Triggered updates:** Any PR that changes a documented behavior must update the relevant wiki page in the same PR (or file a follow-up issue tagged `docs`).
+- **Quarterly audit:** Lead Dev + Docs Agent review all pages for staleness each quarter.
+
+---
+
+## 4. Priority Pages (Sprint 12+)
+
+Pages to create first, in order of user impact:
+
+| Priority | Page | Rationale |
+|----------|------|-----------|
+| P0 | Home | Entry point; every visitor lands here |
+| P0 | GettingStarted-Installation | Needed to onboard new contributors |
+| P0 | Strategies-Catalog | Core reference; mirrors `catalog.md` (already written) |
+| P1 | GettingStarted-QuickStart | Reduces time-to-first-draft for new users |
+| P1 | Development-ContributingGuide | Needed before external contributions |
+| P1 | Strategies-HowToCreate | Mirrors `how-to-create.md` (already written) |
+| P2 | API-Endpoints | Auto-generated from `openapi.yaml` via `make openapi` |
+| P2 | Architecture-ADRs | Index pointing to `docs/adr/` for decision history |
+| P3 | Development-TestingGuide | Property test infra is non-obvious; guide reduces friction |
+| P3 | Architecture-LabPipeline | Important once lab promotion (Sprint 12) is live |
+
+---
+
+## 5. Tooling Notes
+
+- **Source of truth:** The `docs/` directory in the repo is canonical for ADRs, the strategy catalog, and the API spec. Wiki pages that mirror repo docs should note this and link to the source file.
+- **Auto-generation:** `API-Endpoints` can be generated from `docs/api/openapi.yaml` using a script in `Makefile` (target TBD in Sprint 12).
+- **Sync script:** Consider a `make wiki-sync` target (Sprint 13+) that pushes `docs/strategies/catalog.md` and `docs/strategies/how-to-create.md` to the wiki automatically on merge to `main`.

--- a/lab/README.md
+++ b/lab/README.md
@@ -12,13 +12,13 @@ promoted to the core `pigskin` package via the gate process in `lab/promotion/`.
 | `strategies/` | Experimental strategy implementations | #82 |
 | `gridiron_sage/` | GridironSage MCTS training | #83 |
 | `simulation/` | Tournament runner | #187 |
-| `benchmarks/` | Strategy comparison harness | — |
-| `promotion/` | Gate evaluation for production promotion | #80 |
-| `results_db/` | SQLite results store + Alembic migrations | #79 |
-| `experiments/` | Named experiment configuration files | — |
-| `data/` | Auction data scraper, projection snapshots | #192 |
-| `backtest/` | Value-efficiency replay harness | — |
-| `eval/` | Projection accuracy evaluator | — |
+| `benchmarks/` | Strategy comparison harness | #227 |
+| `promotion/` | Gate evaluation for production promotion | #80, #227 |
+| `results_db/` | SQLite results store + Alembic migrations | #79, #228 |
+| `experiments/` | Named experiment configuration files | #226 |
+| `data/` | Auction data scraper, projection snapshots | #192, #228 |
+| `backtest/` | Value-efficiency replay harness | #228 |
+| `eval/` | Projection accuracy evaluator | #228 |
 
 ## Usage
 

--- a/lab/backtest/__init__.py
+++ b/lab/backtest/__init__.py
@@ -1,0 +1,1 @@
+"""Auction replay backtest harness for strategy value-efficiency evaluation."""

--- a/lab/backtest/auction_replay.py
+++ b/lab/backtest/auction_replay.py
@@ -23,8 +23,10 @@ class AuctionBacktester:
     def run(self) -> Dict[str, float]:
         """Execute the backtest replay.
 
-        Computes efficiency_score = sum(auction_value) / sum(actual_price),
-        capped at [0.0, 1.0].
+        For each player, asks the strategy for a bid via ``strategy.bid(player,
+        remaining_budget)``.  A player is "won" when ``strategy_bid >=
+        actual_price``.  ``efficiency_score`` is the ratio of projected auction
+        value won to actual spend, capped at [0.0, 1.0].
 
         Returns:
             Dict with keys: efficiency_score, total_spend, total_value.
@@ -32,8 +34,19 @@ class AuctionBacktester:
         if not self.player_data:
             return {"efficiency_score": 0.0, "total_spend": 0.0, "total_value": 0.0}
 
-        total_value = sum(float(p.get("auction_value", 0)) for p in self.player_data)
-        total_spend = sum(float(p.get("actual_price", 0)) for p in self.player_data)
+        # Seed budget from total market spend so the strategy has a realistic cap.
+        remaining_budget = sum(float(p.get("actual_price", 0)) for p in self.player_data)
+        total_spend = 0.0
+        total_value = 0.0
+
+        for player in self.player_data:
+            actual_price = float(player.get("actual_price", 0))
+            auction_value = float(player.get("auction_value", 0))
+            strategy_bid = float(self.strategy.bid(player, remaining_budget))
+            if strategy_bid >= actual_price:
+                total_spend += actual_price
+                total_value += auction_value
+                remaining_budget -= actual_price
 
         if total_spend == 0:
             efficiency_score = 0.0

--- a/lab/backtest/auction_replay.py
+++ b/lab/backtest/auction_replay.py
@@ -1,0 +1,34 @@
+"""Auction replay backtest harness for strategy value-efficiency evaluation.
+
+Replays historical auction pick data against a given strategy and measures
+how efficiently the strategy would have allocated budget. Implementation
+tracked by issue #228.
+"""
+
+from __future__ import annotations
+
+from typing import Any, List
+
+
+class AuctionBacktester:
+    """Replays historical auction data against a strategy to measure value efficiency.
+
+    Args:
+        strategy: An instantiated strategy object with a ``pick()`` interface.
+        player_data: List of player records from the auction corpus.
+    """
+
+    def __init__(self, strategy: Any, player_data: List[dict]) -> None:
+        self.strategy = strategy
+        self.player_data = player_data
+
+    def run(self) -> dict:
+        """Execute the backtest replay.
+
+        Returns:
+            A dict of evaluation metrics (e.g. roster value, budget efficiency).
+
+        Raises:
+            NotImplementedError: Until issue #228 is implemented.
+        """
+        raise NotImplementedError("AuctionBacktester.run — tracked by #228")

--- a/lab/backtest/auction_replay.py
+++ b/lab/backtest/auction_replay.py
@@ -1,20 +1,18 @@
-"""Auction replay backtest harness for strategy value-efficiency evaluation.
+"""AuctionBacktester — replays historical auction data with a candidate strategy.
 
-Replays historical auction pick data against a given strategy and measures
-how efficiently the strategy would have allocated budget. Implementation
-tracked by issue #228.
+Issue #196: AuctionBacktester(strategy, player_data).run() implementation.
 """
 
 from __future__ import annotations
 
-from typing import Any, List
+from typing import Any, Dict, List
 
 
 class AuctionBacktester:
     """Replays historical auction data against a strategy to measure value efficiency.
 
     Args:
-        strategy: An instantiated strategy object with a ``pick()`` interface.
+        strategy: An instantiated strategy object with a pick() interface.
         player_data: List of player records from the auction corpus.
     """
 
@@ -22,13 +20,28 @@ class AuctionBacktester:
         self.strategy = strategy
         self.player_data = player_data
 
-    def run(self) -> dict:
+    def run(self) -> Dict[str, float]:
         """Execute the backtest replay.
 
-        Returns:
-            A dict of evaluation metrics (e.g. roster value, budget efficiency).
+        Computes efficiency_score = sum(auction_value) / sum(actual_price),
+        capped at [0.0, 1.0].
 
-        Raises:
-            NotImplementedError: Until issue #228 is implemented.
+        Returns:
+            Dict with keys: efficiency_score, total_spend, total_value.
         """
-        raise NotImplementedError("AuctionBacktester.run — tracked by #228")
+        if not self.player_data:
+            return {"efficiency_score": 0.0, "total_spend": 0.0, "total_value": 0.0}
+
+        total_value = sum(float(p.get("auction_value", 0)) for p in self.player_data)
+        total_spend = sum(float(p.get("actual_price", 0)) for p in self.player_data)
+
+        if total_spend == 0:
+            efficiency_score = 0.0
+        else:
+            efficiency_score = min(1.0, total_value / total_spend)
+
+        return {
+            "efficiency_score": efficiency_score,
+            "total_spend": total_spend,
+            "total_value": total_value,
+        }

--- a/lab/benchmarks/__init__.py
+++ b/lab/benchmarks/__init__.py
@@ -1,0 +1,1 @@
+"""Strategy benchmarking and comparison harness."""

--- a/lab/benchmarks/reporter.py
+++ b/lab/benchmarks/reporter.py
@@ -1,0 +1,35 @@
+"""Benchmark report generator for strategy comparison results.
+
+Formats aggregate benchmark results into human-readable or machine-readable
+reports. Implementation tracked by issue #227.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Dict
+
+
+class BenchmarkReporter:
+    """Generates reports from benchmark run results.
+
+    Args:
+        results: Mapping of strategy name → aggregate metrics, as returned by
+            :class:`~lab.benchmarks.runner.BenchmarkRunner`.
+    """
+
+    def __init__(self, results: Dict[str, Any]) -> None:
+        self.results = results
+
+    def generate_report(self, output_format: str = "text") -> str:
+        """Render benchmark results as a formatted report.
+
+        Args:
+            output_format: One of ``"text"``, ``"markdown"``, or ``"json"``.
+
+        Returns:
+            The formatted report as a string.
+
+        Raises:
+            NotImplementedError: Until issue #227 is implemented.
+        """
+        raise NotImplementedError("BenchmarkReporter.generate_report — tracked by #227")

--- a/lab/benchmarks/runner.py
+++ b/lab/benchmarks/runner.py
@@ -1,0 +1,33 @@
+"""Benchmark runner for multi-strategy auction draft comparisons.
+
+Runs a configurable number of simulated drafts for each registered strategy
+and records aggregate metrics. Implementation tracked by issue #227.
+"""
+
+from __future__ import annotations
+
+from typing import List
+
+
+class BenchmarkRunner:
+    """Orchestrates benchmark runs across multiple strategies.
+
+    Args:
+        strategies: List of strategy names to benchmark.
+        runs: Number of simulation runs per strategy.
+    """
+
+    def __init__(self, strategies: List[str], runs: int = 100) -> None:
+        self.strategies = strategies
+        self.runs = runs
+
+    def run(self) -> dict:
+        """Execute benchmark runs for all configured strategies.
+
+        Returns:
+            A mapping of strategy name → aggregate result metrics.
+
+        Raises:
+            NotImplementedError: Until issue #227 is implemented.
+        """
+        raise NotImplementedError("BenchmarkRunner.run — tracked by #227")

--- a/lab/data/__init__.py
+++ b/lab/data/__init__.py
@@ -1,0 +1,1 @@
+"""Lab data acquisition: auction scrapers and projection snapshots."""

--- a/lab/data/sleeper_auction_scraper.py
+++ b/lab/data/sleeper_auction_scraper.py
@@ -1,18 +1,8 @@
-"""lab/data/sleeper_auction_scraper.py — transforms Sleeper API picks to corpus rows.
+"""lab/data/sleeper_auction_scraper.py — fetches historical auction data from Sleeper API.
 
-Issue #234: SleeperAuctionScraper.scrape_league(league_id, season) writes to
-real_auction_picks and related tables via SQLAlchemy async session.
-
-Field mapping:
-  Sleeper pick → RealAuctionPick:
-    player_id     → sleeper_player_id
-    position      → position
-    nfl_team      → nfl_team
-    auction_price → winner_bid
-    draft_id      → via RealAuctionDraft FK
-    budget_pct    = winner_bid / league_budget  (stored in AuctionCorpus)
-
-Deduplication: (draft_id, player_id) unique constraint prevents duplicate rows.
+Dual-mode implementation:
+  - New API (issue #195): SleeperAuctionScraper(league_id, season) + fetch()
+  - Legacy API (issue #234): SleeperAuctionScraper(db_url, client) + scrape_league()
 """
 
 from __future__ import annotations
@@ -21,61 +11,129 @@ import asyncio
 import json
 import logging
 from datetime import datetime
-from typing import Optional
-
-from sqlalchemy import select
-from sqlalchemy.ext.asyncio import AsyncSession, create_async_engine
-from sqlalchemy.orm import sessionmaker
-
-from lab.data.sleeper_client import AuctionPick, SleeperLabClient
-from lab.results_db.models import (
-    AuctionCorpus,
-    Base,
-    RealAuctionDraft,
-    RealAuctionPick,
-)
+from typing import Any, Dict, List, Optional
 
 logger = logging.getLogger(__name__)
 
 
 def _make_session_factory(db_url: str):
+    from sqlalchemy.ext.asyncio import AsyncSession, create_async_engine
+    from sqlalchemy.orm import sessionmaker
+
     engine = create_async_engine(db_url, echo=False)
     return sessionmaker(engine, class_=AsyncSession, expire_on_commit=False), engine
 
 
 class SleeperAuctionScraper:
-    """Scrapes real auction draft data from Sleeper and persists to the lab DB."""
+    """Fetches historical auction draft data for a Sleeper league/season.
+
+    Supports two constructor signatures:
+      - SleeperAuctionScraper(league_id, season)  →  use fetch() [issue #195]
+      - SleeperAuctionScraper(db_url, client)     →  use scrape_league() [issue #234]
+    """
 
     def __init__(
         self,
-        db_url: str = "sqlite+aiosqlite:///./lab/results_db/pigskin_lab.db",
-        client: Optional[SleeperLabClient] = None,
+        league_id: Optional[str] = None,
+        season: Optional[str] = None,
+        *,
+        db_url: Optional[str] = None,
+        client: Optional[Any] = None,
     ) -> None:
-        self._db_url = db_url
-        self._client = client or SleeperLabClient()
-        self._session_factory, self._engine = _make_session_factory(db_url)
+        # New API: (league_id, season)
+        self.league_id = league_id
+        self.season = season
+        self._cache: Optional[List[Dict]] = None
+
+        # Legacy DB-backed API: (db_url, client)
+        if db_url is not None or client is not None:
+            _db_url = db_url or "sqlite+aiosqlite:///./lab/results_db/pigskin_lab.db"
+            from lab.data.sleeper_client import SleeperLabClient
+            self._client = client or SleeperLabClient()
+            self._session_factory, self._engine = _make_session_factory(_db_url)
+        else:
+            self._client = None
+            self._session_factory = None
+            self._engine = None
 
     # ------------------------------------------------------------------
-    # Public API
+    # New public API (issue #195)
+    # ------------------------------------------------------------------
+
+    def fetch(self) -> List[Dict]:
+        """Return auction data as a list of dicts with required keys.
+
+        Returns cached results on subsequent calls.
+        Each dict has: player_name, position, auction_value, actual_price.
+        """
+        if self._cache is not None:
+            return self._cache
+        raw = self._fetch_from_api()
+        self._cache = self._normalize(raw)
+        return self._cache
+
+    def _fetch_from_api(self) -> list:
+        """Fetch raw pick data from the Sleeper API.
+
+        Returns an empty list on any error (network, auth, missing data).
+        Override or patch this method in tests to inject fixture data.
+        """
+        try:
+            from lab.data.sleeper_client import SleeperLabClient
+            client = SleeperLabClient()
+            drafts = client.get_league_drafts(self.league_id) or []
+            picks: list = []
+            for draft in drafts:
+                draft_id = str(draft.get("draft_id", ""))
+                if draft_id:
+                    raw_picks = client.get_draft_picks(draft_id) or []
+                    picks.extend(raw_picks)
+            return picks
+        except Exception:
+            logger.debug(
+                "SleeperAuctionScraper._fetch_from_api failed for league=%s",
+                self.league_id,
+            )
+            return []
+
+    def _normalize(self, raw: list) -> List[Dict]:
+        """Normalize raw pick data to the required schema."""
+        result = []
+        for item in raw:
+            if not isinstance(item, dict):
+                try:
+                    result.append({
+                        "player_name": str(getattr(item, "player_name", "Unknown")),
+                        "position": str(getattr(item, "position", "")),
+                        "auction_value": float(getattr(item, "auction_value", 0) or 0),
+                        "actual_price": float(getattr(item, "winner_bid", 0) or 0),
+                    })
+                except Exception:
+                    continue
+            else:
+                result.append({
+                    "player_name": item.get("player_name") or item.get("name", "Unknown"),
+                    "position": item.get("position", ""),
+                    "auction_value": float(item.get("auction_value") or item.get("value") or 0),
+                    "actual_price": float(item.get("actual_price") or item.get("winner_bid") or item.get("amount") or 0),
+                })
+        return result
+
+    # ------------------------------------------------------------------
+    # Legacy DB-backed API (issue #234)
     # ------------------------------------------------------------------
 
     def scrape_league(self, league_id: str, season: str) -> dict:
         """Scrape all drafts for a league-season and persist to the corpus DB.
-
-        Args:
-            league_id: Sleeper league ID.
-            season: NFL season year string, e.g. "2024".
 
         Returns:
             Summary dict: {'drafts_processed': int, 'picks_inserted': int, 'picks_skipped': int}
         """
         return asyncio.run(self._scrape_league_async(league_id, season))
 
-    # ------------------------------------------------------------------
-    # Async internals
-    # ------------------------------------------------------------------
-
     async def _scrape_league_async(self, league_id: str, season: str) -> dict:
+        from lab.results_db.models import Base
+
         drafts_meta = self._client.get_league_drafts(league_id)
         if not drafts_meta:
             logger.info("No drafts found for league %s / %s", league_id, season)
@@ -112,10 +170,9 @@ class SleeperAuctionScraper:
         league_id: str,
         season: str,
         draft_meta: dict,
-    ) -> tuple[int, int]:
+    ) -> tuple:
         """Persist one draft and its picks. Returns (inserted, skipped)."""
         async with self._session_factory() as session:
-            # Upsert draft row
             db_draft = await self._get_or_create_draft(
                 session, draft_id, league_id, season, draft_meta
             )
@@ -139,7 +196,6 @@ class SleeperAuctionScraper:
                 else:
                     skipped += 1
 
-            # Upsert corpus entry with quality score (budget_pct sum check)
             await self._upsert_corpus(session, db_draft, league_budget, picks)
             await session.commit()
             logger.info(
@@ -149,12 +205,15 @@ class SleeperAuctionScraper:
 
     async def _get_or_create_draft(
         self,
-        session: AsyncSession,
+        session: Any,
         sleeper_draft_id: str,
         league_id: str,
         season: str,
         meta: dict,
-    ) -> Optional[RealAuctionDraft]:
+    ) -> Optional[Any]:
+        from sqlalchemy import select
+        from lab.results_db.models import RealAuctionDraft
+
         result = await session.execute(
             select(RealAuctionDraft).where(
                 RealAuctionDraft.sleeper_draft_id == sleeper_draft_id
@@ -190,12 +249,13 @@ class SleeperAuctionScraper:
 
     async def _insert_pick(
         self,
-        session: AsyncSession,
-        db_draft: RealAuctionDraft,
-        pick: AuctionPick,
+        session: Any,
+        db_draft: Any,
+        pick: Any,
     ) -> bool:
-        """Insert one pick; return True if inserted, False if duplicate/skipped."""
-        # Deduplication: check existing (draft_id, sleeper_player_id)
+        from sqlalchemy import select
+        from lab.results_db.models import RealAuctionPick
+
         result = await session.execute(
             select(RealAuctionPick).where(
                 RealAuctionPick.draft_id == db_draft.id,
@@ -226,11 +286,14 @@ class SleeperAuctionScraper:
 
     async def _upsert_corpus(
         self,
-        session: AsyncSession,
-        db_draft: RealAuctionDraft,
+        session: Any,
+        db_draft: Any,
         league_budget: int,
-        picks: list[AuctionPick],
+        picks: list,
     ) -> None:
+        from sqlalchemy import select
+        from lab.results_db.models import AuctionCorpus
+
         result = await session.execute(
             select(AuctionCorpus).where(AuctionCorpus.draft_id == db_draft.id)
         )

--- a/lab/eval/__init__.py
+++ b/lab/eval/__init__.py
@@ -1,0 +1,1 @@
+"""Projection accuracy evaluation module."""

--- a/lab/experiments/__init__.py
+++ b/lab/experiments/__init__.py
@@ -1,0 +1,1 @@
+"""Named experiment configuration and management module."""

--- a/lab/experiments/config.py
+++ b/lab/experiments/config.py
@@ -1,25 +1,30 @@
 """Experiment configuration loader for named lab experiments.
 
 Provides :class:`ExperimentConfig`, which loads experiment parameters from
-a YAML or JSON config file. Implementation tracked by issue #226.
+a YAML or JSON config file. Closes #188.
 """
 
 from __future__ import annotations
 
+import json
+from pathlib import Path
+from typing import Any, Dict, List
+
 
 class ExperimentConfig:
-    """Configuration for a named lab experiment.
+    """Configuration for a named lab experiment loaded from a YAML or JSON file."""
 
-    Attributes will be populated from a config file by :meth:`load_from_file`.
-    """
+    REQUIRED_FIELDS = ("name", "strategies", "num_simulations")
 
-    def __init__(self) -> None:
-        self.name: str = ""
-        self.params: dict = {}
+    def __init__(self, name: str, strategies: List[str], num_simulations: int, **extra: Any) -> None:
+        self.name = name
+        self.strategies = strategies
+        self.num_simulations = num_simulations
+        self._extra = extra
 
     @classmethod
     def load_from_file(cls, path: str) -> "ExperimentConfig":
-        """Load experiment configuration from a YAML or JSON file.
+        """Load experiment config from a YAML (.yaml/.yml) or JSON (.json) file.
 
         Args:
             path: Filesystem path to the config file.
@@ -28,6 +33,47 @@ class ExperimentConfig:
             A populated :class:`ExperimentConfig` instance.
 
         Raises:
-            NotImplementedError: Until issue #226 is implemented.
+            FileNotFoundError: If the file does not exist.
+            ValueError: If required fields are missing or invalid.
+            ImportError: If PyYAML is not installed for YAML files.
         """
-        raise NotImplementedError("ExperimentConfig.load_from_file — tracked by #226")
+        file_path = Path(path)
+        if not file_path.exists():
+            raise FileNotFoundError(f"Config file not found: {path}")
+
+        raw: Dict[str, Any]
+        suffix = file_path.suffix.lower()
+        if suffix in (".yaml", ".yml"):
+            try:
+                import yaml  # type: ignore[import]
+            except ImportError as exc:
+                raise ImportError(
+                    "PyYAML is required for YAML config files: pip install pyyaml"
+                ) from exc
+            with open(file_path) as f:
+                raw = yaml.safe_load(f) or {}
+        elif suffix == ".json":
+            with open(file_path) as f:
+                raw = json.load(f)
+        else:
+            raise ValueError(f"Unsupported config format: {suffix!r}. Use .yaml or .json")
+
+        return cls._validate_and_build(raw)
+
+    @classmethod
+    def _validate_and_build(cls, raw: Dict[str, Any]) -> "ExperimentConfig":
+        """Validate raw config dict and return an :class:`ExperimentConfig`."""
+        for field_name in cls.REQUIRED_FIELDS:
+            if field_name not in raw:
+                raise ValueError(f"Missing required field: {field_name!r}")
+
+        num_sim = raw["num_simulations"]
+        if not isinstance(num_sim, int) or num_sim <= 0:
+            raise ValueError(f"num_simulations must be a positive integer, got {num_sim!r}")
+
+        strategies = raw["strategies"]
+        if not isinstance(strategies, list) or not strategies:
+            raise ValueError("strategies must be a non-empty list")
+
+        extra = {k: v for k, v in raw.items() if k not in cls.REQUIRED_FIELDS}
+        return cls(name=raw["name"], strategies=strategies, num_simulations=num_sim, **extra)

--- a/lab/experiments/config.py
+++ b/lab/experiments/config.py
@@ -1,0 +1,33 @@
+"""Experiment configuration loader for named lab experiments.
+
+Provides :class:`ExperimentConfig`, which loads experiment parameters from
+a YAML or JSON config file. Implementation tracked by issue #226.
+"""
+
+from __future__ import annotations
+
+
+class ExperimentConfig:
+    """Configuration for a named lab experiment.
+
+    Attributes will be populated from a config file by :meth:`load_from_file`.
+    """
+
+    def __init__(self) -> None:
+        self.name: str = ""
+        self.params: dict = {}
+
+    @classmethod
+    def load_from_file(cls, path: str) -> "ExperimentConfig":
+        """Load experiment configuration from a YAML or JSON file.
+
+        Args:
+            path: Filesystem path to the config file.
+
+        Returns:
+            A populated :class:`ExperimentConfig` instance.
+
+        Raises:
+            NotImplementedError: Until issue #226 is implemented.
+        """
+        raise NotImplementedError("ExperimentConfig.load_from_file — tracked by #226")

--- a/lab/promotion/__init__.py
+++ b/lab/promotion/__init__.py
@@ -1,0 +1,1 @@
+"""Promotion gate for evaluating lab strategies for production promotion."""

--- a/lab/promotion/gate.py
+++ b/lab/promotion/gate.py
@@ -1,1 +1,25 @@
-# stub — implementation tracked by #80
+"""Promotion gate criteria checker for lab strategy graduation.
+
+Evaluates whether a lab strategy meets the performance thresholds required
+for promotion to the core production package. Implementation tracked by #80.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Dict
+
+
+def check_promotion_criteria(strategy_name: str, metrics: Dict[str, Any]) -> bool:
+    """Evaluate whether a strategy meets promotion thresholds.
+
+    Args:
+        strategy_name: The registered name of the strategy to evaluate.
+        metrics: Aggregate benchmark metrics for the strategy.
+
+    Returns:
+        ``True`` if all promotion criteria are met, ``False`` otherwise.
+
+    Raises:
+        NotImplementedError: Until issue #80 is implemented.
+    """
+    raise NotImplementedError("check_promotion_criteria — tracked by #80")

--- a/lab/promotion/promote.py
+++ b/lab/promotion/promote.py
@@ -1,23 +1,83 @@
-"""Promotion executor for graduating lab strategies to production.
+#!/usr/bin/env python3
+"""Lab strategy promotion script.
 
-Applies the promotion gate result to copy a validated strategy from the lab
-package into the core ``strategies/`` package. Implementation tracked by #227.
+Evaluates a lab strategy against a benchmark threshold and optionally copies
+it from ``lab/strategies/`` into the production ``strategies/`` package.
+Real benchmark score integration is deferred to Sprint 12 (issue #227).
+
+Usage:
+    python lab/promotion/promote.py --dry-run
+    python lab/promotion/promote.py --dry-run --strategy my_strategy
+    python lab/promotion/promote.py --strategy my_strategy --threshold 0.75
 """
 
 from __future__ import annotations
 
+import argparse
+import sys
+from pathlib import Path
 
-def promote_strategy(strategy_name: str, dry_run: bool = False) -> None:
-    """Promote a lab strategy to the core production package.
 
-    Copies strategy source, updates ``strategies/__init__.py`` registration,
-    and records promotion metadata.
+def promote_strategy(strategy_name: str, threshold: float, dry_run: bool = False) -> bool:
+    """Evaluate and optionally promote a lab strategy to main strategies/.
 
     Args:
         strategy_name: The registered name of the strategy to promote.
-        dry_run: If ``True``, validate without making filesystem changes.
+        threshold: Minimum efficiency score required for promotion.
+        dry_run: If ``True``, print what would happen without modifying files.
 
-    Raises:
-        NotImplementedError: Until issue #227 is implemented.
+    Returns:
+        ``True`` if promotion criteria are met (or dry-run succeeds), ``False`` otherwise.
     """
-    raise NotImplementedError("promote_strategy — tracked by #227")
+    lab_path = Path("lab/strategies") / f"{strategy_name}.py"
+    prod_path = Path("strategies") / f"{strategy_name}.py"
+
+    if not lab_path.exists():
+        print(f"ERROR: Lab strategy not found: {lab_path}", file=sys.stderr)
+        return False
+
+    if dry_run:
+        print(f"[DRY RUN] Would evaluate {strategy_name} against threshold {threshold}")
+        print(f"[DRY RUN] Source: {lab_path}")
+        print(f"[DRY RUN] Target: {prod_path}")
+        print("[DRY RUN] No files modified.")
+        return True
+
+    # Placeholder: fetch benchmark score from results_db (Sprint 12 / #227)
+    print("ERROR: Live promotion not yet implemented — use --dry-run (tracked by #227)", file=sys.stderr)
+    return False
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Lab strategy promotion tool")
+    parser.add_argument("--strategy", default=None, help="Strategy name to promote")
+    parser.add_argument(
+        "--threshold",
+        type=float,
+        default=0.70,
+        help="Minimum efficiency threshold (default: 0.70)",
+    )
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Print what would be done without making changes",
+    )
+    args = parser.parse_args()
+
+    if args.dry_run:
+        if args.strategy:
+            promote_strategy(args.strategy, args.threshold, dry_run=True)
+        else:
+            print("[DRY RUN] No strategy specified. Pass --strategy <name> to evaluate.")
+        sys.exit(0)
+
+    if not args.strategy:
+        print("ERROR: --strategy is required in non-dry-run mode", file=sys.stderr)
+        sys.exit(1)
+
+    success = promote_strategy(args.strategy, args.threshold, dry_run=False)
+    sys.exit(0 if success else 1)
+
+
+if __name__ == "__main__":
+    main()

--- a/lab/promotion/promote.py
+++ b/lab/promotion/promote.py
@@ -1,0 +1,23 @@
+"""Promotion executor for graduating lab strategies to production.
+
+Applies the promotion gate result to copy a validated strategy from the lab
+package into the core ``strategies/`` package. Implementation tracked by #227.
+"""
+
+from __future__ import annotations
+
+
+def promote_strategy(strategy_name: str, dry_run: bool = False) -> None:
+    """Promote a lab strategy to the core production package.
+
+    Copies strategy source, updates ``strategies/__init__.py`` registration,
+    and records promotion metadata.
+
+    Args:
+        strategy_name: The registered name of the strategy to promote.
+        dry_run: If ``True``, validate without making filesystem changes.
+
+    Raises:
+        NotImplementedError: Until issue #227 is implemented.
+    """
+    raise NotImplementedError("promote_strategy — tracked by #227")

--- a/lab/results_db/__init__.py
+++ b/lab/results_db/__init__.py
@@ -1,0 +1,1 @@
+"""SQLite results store and Alembic migration management (ADR-004)."""

--- a/lab/simulation/__init__.py
+++ b/lab/simulation/__init__.py
@@ -1,0 +1,1 @@
+"""Simulation runner module for multi-strategy auction draft benchmarking."""

--- a/lab/simulation/runner.py
+++ b/lab/simulation/runner.py
@@ -23,7 +23,7 @@ import uuid
 from concurrent.futures import ThreadPoolExecutor, as_completed
 from dataclasses import dataclass, field
 from datetime import datetime
-from typing import Dict, List, Optional
+from typing import Dict, List, Optional, Union, overload
 
 from classes.tournament import Tournament  # type: ignore
 
@@ -194,7 +194,11 @@ class SimulationRunner:
     # Public API
     # ------------------------------------------------------------------
 
-    def run(self, n_simulations: int = None) -> "List[SimulationResult] | Dict[str, Dict]":
+    @overload
+    def run(self, n_simulations: int) -> List[SimulationResult]: ...
+    @overload
+    def run(self, n_simulations: None = None) -> Dict[str, Dict]: ...
+    def run(self, n_simulations: Optional[int] = None) -> Union[List[SimulationResult], Dict[str, Dict]]:
         """Run simulations and return results.
 
         When *n_simulations* is provided, runs that many individual simulations

--- a/lab/simulation/runner.py
+++ b/lab/simulation/runner.py
@@ -20,12 +20,23 @@ import json
 import logging
 import subprocess
 import uuid
+from concurrent.futures import ThreadPoolExecutor, as_completed
+from dataclasses import dataclass, field
 from datetime import datetime
 from typing import Dict, List, Optional
 
 from classes.tournament import Tournament  # type: ignore
 
 logger = logging.getLogger(__name__)
+
+
+@dataclass
+class SimulationResult:
+    """Result of a single simulation run."""
+
+    strategy_name: str
+    score: float
+    rank: int = field(default=0)
 
 
 def _git_sha() -> str:
@@ -168,6 +179,7 @@ class SimulationRunner:
         num_opponents: int = 11,
         db_url: str = "sqlite+aiosqlite:///lab/results_db/pigskin_lab.db",
         experiment_id: Optional[str] = None,
+        max_workers: int = 4,
     ) -> None:
         self.strategies = strategies or ["all"]
         self.runs = runs
@@ -176,14 +188,71 @@ class SimulationRunner:
         self.num_opponents = num_opponents
         self.db_url = db_url
         self.experiment_id = experiment_id or str(uuid.uuid4())[:8]
+        self.max_workers = max_workers
 
     # ------------------------------------------------------------------
     # Public API
     # ------------------------------------------------------------------
 
-    def run(self) -> Dict[str, Dict]:
-        """Execute the benchmark synchronously. Returns per-strategy summaries."""
+    def run(self, n_simulations: int = None) -> "List[SimulationResult] | Dict[str, Dict]":
+        """Run simulations and return results.
+
+        When *n_simulations* is provided, runs that many individual simulations
+        in parallel via :class:`ThreadPoolExecutor` and returns a ranked
+        ``List[SimulationResult]`` (rank 1 = highest score).
+
+        When called with no arguments (legacy mode), executes the full benchmark
+        pipeline via ``asyncio`` and returns per-strategy summary dicts.
+        """
+        if n_simulations is not None:
+            return self._run_parallel(n_simulations)
         return asyncio.run(self._run_async())
+
+    def _run_parallel(self, n_simulations: int) -> List[SimulationResult]:
+        """Run *n_simulations* individual simulations via ThreadPoolExecutor."""
+        results: List[SimulationResult] = []
+        workers = min(self.max_workers, n_simulations)
+        with ThreadPoolExecutor(max_workers=workers) as executor:
+            futures = {
+                executor.submit(self._run_single, i): i
+                for i in range(n_simulations)
+            }
+            for future in as_completed(futures):
+                sim_id = futures[future]
+                try:
+                    results.append(future.result())
+                except Exception as exc:  # noqa: BLE001
+                    logger.warning("Simulation %d failed: %s", sim_id, exc)
+                    results.append(SimulationResult(strategy_name="error", score=0.0))
+
+        results.sort(key=lambda r: r.score, reverse=True)
+        for rank, result in enumerate(results, start=1):
+            result.rank = rank
+        return results
+
+    def _run_single(self, sim_id: int) -> SimulationResult:
+        """Run one simulation and return a :class:`SimulationResult`.
+
+        The strategy is cycled from :attr:`strategies` by *sim_id* index.
+        Exceptions are propagated so the caller can record an error result.
+        """
+        keys = [
+            k for k in (self.strategies or [])
+            if k != "all"
+        ] or ["balanced"]
+        strategy_key = keys[sim_id % len(keys)]
+        players = _load_players()
+        all_results = _run_tournament_for_strategy(
+            strategy_key=strategy_key,
+            players=players,
+            budget=self.budget,
+            roster_size=self.roster_size,
+            num_opponents=self.num_opponents,
+            runs=1,
+        )
+        focal = all_results.get(strategy_key, {})
+        score = float(focal.get("win_rate", 0.0))
+        return SimulationResult(strategy_name=strategy_key, score=score)
 
     # ------------------------------------------------------------------
     # Internals

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,6 +24,7 @@ dependencies = [
     "pydantic-settings>=2.0.0",
     "fastapi>=0.110.0",
     "uvicorn[standard]>=0.29.0",
+    "pyyaml>=6.0",
 ]
 
 [project.scripts]

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,3 +8,4 @@ colorama>=0.4.6
 pydantic-settings>=2.0.0
 fastapi>=0.110.0
 uvicorn[standard]>=0.29.0
+pyyaml>=6.0

--- a/services/sleeper_draft_service.py
+++ b/services/sleeper_draft_service.py
@@ -20,8 +20,8 @@ logger = logging.getLogger(__name__)
 class SleeperDraftService:
     """Service for fetching and displaying Sleeper draft information."""
     
-    def __init__(self):
-        self.sleeper_api = SleeperAPI()
+    def __init__(self, sleeper_api: SleeperAPI = None):
+        self.sleeper_api = sleeper_api if sleeper_api is not None else SleeperAPI()
         
     async def get_user_drafts(self, username: str, season: str = str(datetime.date.today().year)) -> Dict[str, Any]:
         """

--- a/services/sleeper_draft_service.py
+++ b/services/sleeper_draft_service.py
@@ -8,7 +8,7 @@ including draft order, picks, and league information.
 import asyncio
 import datetime
 import logging
-from typing import Dict, Any
+from typing import Dict, Any, Optional
 
 from api.sleeper_api import SleeperAPI
 from utils.print_module import print_sleeper_draft, print_sleeper_league
@@ -20,7 +20,7 @@ logger = logging.getLogger(__name__)
 class SleeperDraftService:
     """Service for fetching and displaying Sleeper draft information."""
     
-    def __init__(self, sleeper_api: SleeperAPI = None):
+    def __init__(self, sleeper_api: Optional[SleeperAPI] = None):
         self.sleeper_api = sleeper_api if sleeper_api is not None else SleeperAPI()
         
     async def get_user_drafts(self, username: str, season: str = str(datetime.date.today().year)) -> Dict[str, Any]:

--- a/strategies/__init__.py
+++ b/strategies/__init__.py
@@ -38,7 +38,7 @@ AVAILABLE_STRATEGIES = {
     'balanced': BalancedStrategy,
     'basic': BasicStrategy,
     'elite_hybrid': EliteHybridStrategy,
-    'inflation_vor': InflationAwareVorStrategy,
+    'inflation_aware_vor': InflationAwareVorStrategy,
     'value_random': ValueRandomStrategy,
     'value_smart': ValueSmartStrategy,
     'league': LeagueStrategy,

--- a/strategies/enhanced_vor_strategy.py
+++ b/strategies/enhanced_vor_strategy.py
@@ -21,12 +21,14 @@ if TYPE_CHECKING:
 class InflationAwareVorStrategy(Strategy):
     """Enhanced VOR strategy that adjusts for market inflation."""
     
-    def __init__(self, aggression: float = 1.0, scarcity_weight: float = 0.7, inflation_sensitivity: float = 0.5):
-        super().__init__("inflation_vor", "VOR strategy with market inflation adjustment")
+    def __init__(self, aggression: float = 1.0, scarcity_weight: float = 0.7, inflation_sensitivity: float = 0.5, budget: float = 200, roster_size: int = 15):
+        super().__init__("inflation_aware_vor", "VOR strategy with market inflation adjustment")
         
         self.aggression = aggression
         self.scarcity_weight = scarcity_weight
         self.inflation_sensitivity = inflation_sensitivity
+        self.budget = budget
+        self.roster_size = roster_size
         
         # Position baselines for VOR calculation
         self.position_baselines = {
@@ -115,8 +117,8 @@ class InflationAwareVorStrategy(Strategy):
         # Calculate average budget per remaining slot
         avg_budget_per_slot = total_remaining_budget / total_remaining_slots if total_remaining_slots > 0 else 1.0
         
-        # Standard budget per slot in a typical auction (e.g., $200/15 slots = $13.33)
-        standard_budget_per_slot = 200 / 15  # ~$13.33
+        # Standard budget per slot derived from configured budget and roster size
+        standard_budget_per_slot = self.budget / self.roster_size
         
         # Calculate raw inflation ratio
         raw_inflation = avg_budget_per_slot / standard_budget_per_slot

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -3,6 +3,12 @@
 Provides common Player, Team, Owner, and Draft fixtures to reduce
 boilerplate duplication across test files.
 """
+import os
+
+# Mark this process as a test environment so create_app() does not raise
+# RuntimeError for a missing PIGSKIN_API_KEY (see api/main.py).
+os.environ.setdefault("TESTING", "true")
+
 import pytest
 
 from classes.player import Player

--- a/tests/test_strategies.py
+++ b/tests/test_strategies.py
@@ -43,7 +43,7 @@ class TestStrategies(BaseTestCase):
         expected_strategies = [
             'value', 'aggressive', 'conservative', 'sigmoid', 'improved_value',
             'adaptive', 'vor', 'random', 'balanced', 'basic', 'elite_hybrid',
-            'value_random', 'value_smart', 'inflation_vor',
+            'value_random', 'value_smart', 'inflation_aware_vor',
             'league', 'refined_value_random'
         ]
         

--- a/tests/unit/api/test_api_key_security.py
+++ b/tests/unit/api/test_api_key_security.py
@@ -1,0 +1,136 @@
+"""P0 security tests for API key validation and /docs gating — issue #355.
+
+Tests (all written before implementation — expected to fail first):
+  1. Empty PIGSKIN_API_KEY at startup raises RuntimeError (non-test env)
+  2. Unauthenticated GET /health → 200 (public endpoint)
+  3. Unauthenticated GET /recommend → 401 (protected endpoint)
+  4. PIGSKIN_DOCS_ENABLED unset → GET /docs returns 404
+  5. PIGSKIN_DOCS_ENABLED=true → GET /docs returns 200
+"""
+import pytest
+from fastapi.testclient import TestClient
+
+from api.main import create_app
+
+
+_VALID_KEY = "test-secure-key-xyz987-abcdefghijklm"
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _make_client(api_key: str = _VALID_KEY, docs_enabled: bool = False) -> TestClient:
+    """Create a TestClient with dependency-overridden settings."""
+    _app = create_app(
+        docs_enabled=docs_enabled,
+        api_key=api_key,
+    )
+    return TestClient(_app, raise_server_exceptions=False)
+
+
+# ---------------------------------------------------------------------------
+# Test 1: RuntimeError on empty API key at startup (non-test environment)
+# ---------------------------------------------------------------------------
+
+class TestEmptyApiKeyStartupError:
+    def test_empty_api_key_raises_runtime_error_outside_testing(self, monkeypatch):
+        """create_app() must raise RuntimeError when api_key is empty and
+        TESTING env var is not 'true'."""
+        monkeypatch.delenv("TESTING", raising=False)
+        with pytest.raises(RuntimeError, match="PIGSKIN_API_KEY"):
+            create_app(api_key="")
+
+    def test_empty_api_key_allowed_in_test_environment(self, monkeypatch):
+        """create_app() must NOT raise when TESTING=true even with empty key."""
+        monkeypatch.setenv("TESTING", "true")
+        # Should not raise
+        app = create_app(api_key="")
+        assert app is not None
+
+
+# ---------------------------------------------------------------------------
+# Test 2: /health is always public
+# ---------------------------------------------------------------------------
+
+class TestHealthPublic:
+    def test_health_no_key_returns_200(self):
+        client = _make_client()
+        resp = client.get("/health")
+        assert resp.status_code == 200
+
+    def test_health_unauthenticated_no_key_header_returns_200(self):
+        """Even with no X-API-Key header, /health must respond 200."""
+        client = _make_client()
+        resp = client.get("/health")
+        assert resp.status_code == 200, f"Expected 200, got {resp.status_code}"
+
+
+# ---------------------------------------------------------------------------
+# Test 3: Protected endpoint /recommend requires auth
+# ---------------------------------------------------------------------------
+
+class TestProtectedEndpoint:
+    def test_unauthenticated_recommend_returns_401(self):
+        client = _make_client()
+        resp = client.post("/recommend/bid", json={})
+        assert resp.status_code in (401, 403), (
+            f"Expected 401/403 for unauthenticated /recommend/bid, got {resp.status_code}"
+        )
+
+    def test_authenticated_recommend_does_not_return_401(self):
+        client = _make_client()
+        resp = client.post("/recommend/bid", json={}, headers={"X-API-Key": _VALID_KEY})
+        assert resp.status_code != 401, (
+            f"Valid key should not return 401, got {resp.status_code}"
+        )
+
+
+# ---------------------------------------------------------------------------
+# Test 4: /docs is gated — disabled by default
+# ---------------------------------------------------------------------------
+
+class TestDocsGating:
+    def test_docs_not_accessible_when_disabled(self):
+        """With docs_enabled=False (default), /docs must return 404."""
+        client = _make_client(docs_enabled=False)
+        resp = client.get("/docs")
+        assert resp.status_code == 404, (
+            f"Expected 404 for /docs when disabled, got {resp.status_code}"
+        )
+
+    def test_openapi_json_not_accessible_when_disabled(self):
+        """With docs_enabled=False, /openapi.json must return 404."""
+        client = _make_client(docs_enabled=False)
+        resp = client.get("/openapi.json")
+        assert resp.status_code == 404, (
+            f"Expected 404 for /openapi.json when disabled, got {resp.status_code}"
+        )
+
+    def test_redoc_not_accessible_when_disabled(self):
+        """With docs_enabled=False, /redoc must return 404."""
+        client = _make_client(docs_enabled=False)
+        resp = client.get("/redoc")
+        assert resp.status_code == 404, (
+            f"Expected 404 for /redoc when disabled, got {resp.status_code}"
+        )
+
+    # ---------------------------------------------------------------------------
+    # Test 5: /docs accessible when PIGSKIN_DOCS_ENABLED=true
+    # ---------------------------------------------------------------------------
+
+    def test_docs_accessible_when_enabled(self):
+        """With docs_enabled=True, GET /docs must return 200."""
+        client = _make_client(docs_enabled=True)
+        resp = client.get("/docs")
+        assert resp.status_code == 200, (
+            f"Expected 200 for /docs when enabled, got {resp.status_code}"
+        )
+
+    def test_openapi_json_accessible_when_enabled(self):
+        """With docs_enabled=True, GET /openapi.json must return 200."""
+        client = _make_client(docs_enabled=True)
+        resp = client.get("/openapi.json")
+        assert resp.status_code == 200, (
+            f"Expected 200 for /openapi.json when enabled, got {resp.status_code}"
+        )

--- a/tests/unit/api/test_sleeper_api.py
+++ b/tests/unit/api/test_sleeper_api.py
@@ -187,7 +187,10 @@ class TestSleeperAPIUserMethods:
         
         assert len(result) == 2
         assert result[0]['league_id'] == 'league1'
-        self.api._make_request.assert_called_once_with('/user/user123/leagues/nfl/2024')
+        from datetime import datetime
+        self.api._make_request.assert_called_once_with(
+            f'/user/user123/leagues/nfl/{datetime.now().year}'
+        )
     
     async def test_get_user_leagues_custom_season(self):
         """Test getting user leagues for custom season."""
@@ -335,7 +338,10 @@ class TestSleeperAPIPlayerMethods:
         
         assert 'player1' in result
         assert result['player1']['pts'] == 300.5
-        self.api._make_request.assert_called_once_with('/projections/nfl/regular/2024')
+        from datetime import datetime
+        self.api._make_request.assert_called_once_with(
+            f'/projections/nfl/regular/{datetime.now().year}'
+        )
     
     async def test_get_player_projections_with_week(self):
         """Test getting player projections for specific week."""

--- a/tests/unit/cli/test_cli_season_default.py
+++ b/tests/unit/cli/test_cli_season_default.py
@@ -24,10 +24,6 @@ class TestCliSeasonDefault:
 
     CURRENT_YEAR = str(datetime.now().year)
 
-    @pytest.mark.xfail(
-        strict=True,
-        reason="handle_sleeper_status() still uses hardcoded '2024' (issue #171)",
-    )
     def test_handle_sleeper_status_uses_current_year_as_default(self):
         """handle_sleeper_status() with no season arg must use the current year.
 
@@ -60,10 +56,6 @@ class TestCliSeasonDefault:
             f"got '{captured_season[0]}' — hardcoded '2024' not yet removed (#171)"
         )
 
-    @pytest.mark.xfail(
-        strict=True,
-        reason="handle_sleeper_leagues() still uses hardcoded '2024' (issue #171)",
-    )
     def test_handle_sleeper_leagues_uses_current_year_as_default(self):
         """handle_sleeper_leagues() with no season arg must use the current year."""
         from cli.main import AuctionDraftCLI
@@ -110,10 +102,6 @@ class TestCliSingletonDependencies:
     instances.  After #172 is fixed they must share a single instance.
     """
 
-    @pytest.mark.xfail(
-        strict=True,
-        reason="ConfigManager is instantiated twice per CLI run (issue #172)",
-    )
     def test_config_manager_instantiated_once(self):
         """ConfigManager() is constructed exactly once when AuctionDraftCLI is created.
 
@@ -138,10 +126,6 @@ class TestCliSingletonDependencies:
             "expected exactly 1.  Duplicate instantiation not yet removed (#172)."
         )
 
-    @pytest.mark.xfail(
-        strict=True,
-        reason="SleeperAPI is instantiated twice per CLI run (issue #172)",
-    )
     def test_sleeper_api_instantiated_once(self):
         """SleeperAPI() is constructed exactly once when AuctionDraftCLI is created.
 
@@ -166,10 +150,6 @@ class TestCliSingletonDependencies:
             "expected exactly 1.  Duplicate instantiation not yet removed (#172)."
         )
 
-    @pytest.mark.xfail(
-        strict=True,
-        reason="ConfigManager instance not shared between AuctionDraftCLI and CommandProcessor (issue #172)",
-    )
     def test_command_processor_receives_shared_config_manager(self):
         """CommandProcessor must use the same ConfigManager instance as AuctionDraftCLI."""
         from cli.main import AuctionDraftCLI
@@ -180,10 +160,6 @@ class TestCliSingletonDependencies:
             "different objects — the instance is not shared (#172)."
         )
 
-    @pytest.mark.xfail(
-        strict=True,
-        reason="SleeperAPI instance not shared between AuctionDraftCLI and CommandProcessor (issue #172)",
-    )
     def test_command_processor_receives_shared_sleeper_api(self):
         """CommandProcessor must use the same SleeperAPI instance as AuctionDraftCLI."""
         from cli.main import AuctionDraftCLI

--- a/tests/unit/cli/test_cli_season_default.py
+++ b/tests/unit/cli/test_cli_season_default.py
@@ -1,0 +1,171 @@
+"""Failing tests for CLI season default and dependency deduplication.
+
+Issue #171: cli/main.py hard-codes the season string '2024' in
+            handle_sleeper_status() and handle_sleeper_leagues().  The default
+            must be datetime.now().year (as a string).
+
+Issue #172: ConfigManager and SleeperAPI are each instantiated twice per CLI
+            run — once in AuctionDraftCLI.__init__() and again in
+            CommandProcessor.__init__().  They must be instantiated exactly once
+            and the single instance must be shared between both objects.
+"""
+
+import pytest
+from datetime import datetime
+from unittest.mock import patch, MagicMock
+
+
+# ---------------------------------------------------------------------------
+# Issue #171 — Season default must be the current year
+# ---------------------------------------------------------------------------
+
+class TestCliSeasonDefault:
+    """The CLI must default to the current calendar year, not the hardcoded '2024'."""
+
+    CURRENT_YEAR = str(datetime.now().year)
+
+    def test_handle_sleeper_status_uses_current_year_as_default(self):
+        """handle_sleeper_status() with no season arg must use the current year.
+
+        The command currently defaults to '2024'; this test fails until #171 is
+        fixed.
+        """
+        from cli.main import AuctionDraftCLI
+
+        cli = AuctionDraftCLI()
+
+        # Provide a username but NO season argument — the default must kick in.
+        captured_season = []
+
+        def _fake_get_status(username, season):
+            captured_season.append(season)
+            return {"success": True}
+
+        cli.command_processor.get_sleeper_draft_status = _fake_get_status
+        # Patch load_config to return an object without sleeper_username so our
+        # explicit arg is used.
+        mock_config = MagicMock()
+        mock_config.sleeper_username = None
+        cli.config_manager.load_config = MagicMock(return_value=mock_config)
+
+        cli.handle_sleeper_status(["testuser"])  # no season arg
+
+        assert len(captured_season) == 1, "get_sleeper_draft_status was not called"
+        assert captured_season[0] == self.CURRENT_YEAR, (
+            f"Expected default season '{self.CURRENT_YEAR}', "
+            f"got '{captured_season[0]}' — hardcoded '2024' not yet removed (#171)"
+        )
+
+    def test_handle_sleeper_leagues_uses_current_year_as_default(self):
+        """handle_sleeper_leagues() with no season arg must use the current year."""
+        from cli.main import AuctionDraftCLI
+
+        cli = AuctionDraftCLI()
+
+        captured_season = []
+
+        def _fake_list_leagues(username, season):
+            captured_season.append(season)
+            return {"success": True}
+
+        cli.command_processor.list_sleeper_leagues = _fake_list_leagues
+        mock_config = MagicMock()
+        mock_config.sleeper_username = None
+        cli.config_manager.load_config = MagicMock(return_value=mock_config)
+
+        cli.handle_sleeper_leagues(["testuser"])  # no season arg
+
+        assert len(captured_season) == 1, "list_sleeper_leagues was not called"
+        assert captured_season[0] == self.CURRENT_YEAR, (
+            f"Expected default season '{self.CURRENT_YEAR}', "
+            f"got '{captured_season[0]}' — hardcoded '2024' not yet removed (#171)"
+        )
+
+    def test_season_default_matches_current_year_not_literal_2024(self):
+        """The CLI default season must not be the literal string '2024'."""
+        assert self.CURRENT_YEAR != "2024" or pytest.skip(
+            "This test is only meaningful when the calendar year is not 2024"
+        )
+        # If CURRENT_YEAR != '2024' then any test above that captured '2024'
+        # will already fail.  This test documents the intent explicitly.
+        assert self.CURRENT_YEAR == str(datetime.now().year)
+
+
+# ---------------------------------------------------------------------------
+# Issue #172 — ConfigManager and SleeperAPI instantiated exactly once
+# ---------------------------------------------------------------------------
+
+class TestCliSingletonDependencies:
+    """ConfigManager and SleeperAPI must be created exactly once per CLI run.
+
+    Currently AuctionDraftCLI and CommandProcessor each create their own
+    instances.  After #172 is fixed they must share a single instance.
+    """
+
+    def test_config_manager_instantiated_once(self):
+        """ConfigManager() is constructed exactly once when AuctionDraftCLI is created.
+
+        Currently it is constructed twice (once in AuctionDraftCLI.__init__ and
+        again in CommandProcessor.__init__), so this test fails until #172 is fixed.
+        """
+        from config.config_manager import ConfigManager
+        from cli.main import AuctionDraftCLI
+
+        instance_ids: list = []
+        original_init = ConfigManager.__init__
+
+        def _tracking_init(self_inner, *args, **kwargs):
+            instance_ids.append(id(self_inner))
+            original_init(self_inner, *args, **kwargs)
+
+        with patch.object(ConfigManager, "__init__", _tracking_init):
+            AuctionDraftCLI()
+
+        assert len(instance_ids) == 1, (
+            f"ConfigManager.__init__ was called {len(instance_ids)} time(s); "
+            "expected exactly 1.  Duplicate instantiation not yet removed (#172)."
+        )
+
+    def test_sleeper_api_instantiated_once(self):
+        """SleeperAPI() is constructed exactly once when AuctionDraftCLI is created.
+
+        Currently it is constructed twice (once in AuctionDraftCLI.__init__ and
+        again in CommandProcessor.__init__), so this test fails until #172 is fixed.
+        """
+        from api.sleeper_api import SleeperAPI
+        from cli.main import AuctionDraftCLI
+
+        instance_ids: list = []
+        original_init = SleeperAPI.__init__
+
+        def _tracking_init(self_inner, *args, **kwargs):
+            instance_ids.append(id(self_inner))
+            original_init(self_inner, *args, **kwargs)
+
+        with patch.object(SleeperAPI, "__init__", _tracking_init):
+            AuctionDraftCLI()
+
+        assert len(instance_ids) == 1, (
+            f"SleeperAPI.__init__ was called {len(instance_ids)} time(s); "
+            "expected exactly 1.  Duplicate instantiation not yet removed (#172)."
+        )
+
+    def test_command_processor_receives_shared_config_manager(self):
+        """CommandProcessor must use the same ConfigManager instance as AuctionDraftCLI."""
+        from cli.main import AuctionDraftCLI
+
+        cli = AuctionDraftCLI()
+        assert cli.config_manager is cli.command_processor.config_manager, (
+            "AuctionDraftCLI.config_manager and CommandProcessor.config_manager are "
+            "different objects — the instance is not shared (#172)."
+        )
+
+    def test_command_processor_receives_shared_sleeper_api(self):
+        """CommandProcessor must use the same SleeperAPI instance as AuctionDraftCLI."""
+        from cli.main import AuctionDraftCLI
+
+        cli = AuctionDraftCLI()
+        assert cli.sleeper_api is cli.command_processor.sleeper_api, (
+            "AuctionDraftCLI.sleeper_api and CommandProcessor.sleeper_api are "
+            "different objects — the instance is not shared (#172)."
+        )

--- a/tests/unit/cli/test_cli_season_default.py
+++ b/tests/unit/cli/test_cli_season_default.py
@@ -24,6 +24,10 @@ class TestCliSeasonDefault:
 
     CURRENT_YEAR = str(datetime.now().year)
 
+    @pytest.mark.xfail(
+        strict=True,
+        reason="handle_sleeper_status() still uses hardcoded '2024' (issue #171)",
+    )
     def test_handle_sleeper_status_uses_current_year_as_default(self):
         """handle_sleeper_status() with no season arg must use the current year.
 
@@ -56,6 +60,10 @@ class TestCliSeasonDefault:
             f"got '{captured_season[0]}' — hardcoded '2024' not yet removed (#171)"
         )
 
+    @pytest.mark.xfail(
+        strict=True,
+        reason="handle_sleeper_leagues() still uses hardcoded '2024' (issue #171)",
+    )
     def test_handle_sleeper_leagues_uses_current_year_as_default(self):
         """handle_sleeper_leagues() with no season arg must use the current year."""
         from cli.main import AuctionDraftCLI
@@ -102,6 +110,10 @@ class TestCliSingletonDependencies:
     instances.  After #172 is fixed they must share a single instance.
     """
 
+    @pytest.mark.xfail(
+        strict=True,
+        reason="ConfigManager is instantiated twice per CLI run (issue #172)",
+    )
     def test_config_manager_instantiated_once(self):
         """ConfigManager() is constructed exactly once when AuctionDraftCLI is created.
 
@@ -126,6 +138,10 @@ class TestCliSingletonDependencies:
             "expected exactly 1.  Duplicate instantiation not yet removed (#172)."
         )
 
+    @pytest.mark.xfail(
+        strict=True,
+        reason="SleeperAPI is instantiated twice per CLI run (issue #172)",
+    )
     def test_sleeper_api_instantiated_once(self):
         """SleeperAPI() is constructed exactly once when AuctionDraftCLI is created.
 
@@ -150,6 +166,10 @@ class TestCliSingletonDependencies:
             "expected exactly 1.  Duplicate instantiation not yet removed (#172)."
         )
 
+    @pytest.mark.xfail(
+        strict=True,
+        reason="ConfigManager instance not shared between AuctionDraftCLI and CommandProcessor (issue #172)",
+    )
     def test_command_processor_receives_shared_config_manager(self):
         """CommandProcessor must use the same ConfigManager instance as AuctionDraftCLI."""
         from cli.main import AuctionDraftCLI
@@ -160,6 +180,10 @@ class TestCliSingletonDependencies:
             "different objects — the instance is not shared (#172)."
         )
 
+    @pytest.mark.xfail(
+        strict=True,
+        reason="SleeperAPI instance not shared between AuctionDraftCLI and CommandProcessor (issue #172)",
+    )
     def test_command_processor_receives_shared_sleeper_api(self):
         """CommandProcessor must use the same SleeperAPI instance as AuctionDraftCLI."""
         from cli.main import AuctionDraftCLI

--- a/tests/unit/cli/test_main.py
+++ b/tests/unit/cli/test_main.py
@@ -65,7 +65,8 @@ class TestAuctionDraftCLI:
         result = {'success': False, 'error': 'Test error'}
         exit_code = cli._handle_command_result(result)
         assert exit_code == 1
-        mock_print.assert_called_with("ERROR: Test error")
+        import sys
+        mock_print.assert_called_with("ERROR: Test error", file=sys.stderr)
 
 
 class TestCommandRouting:

--- a/tests/unit/lab/test_auction_replay.py
+++ b/tests/unit/lab/test_auction_replay.py
@@ -135,7 +135,28 @@ class TestAuctionBacktesterEmptyData:
 
 
 # ---------------------------------------------------------------------------
-# 4. Determinism — same input → same output
+# 4. Strategy is consulted during run()
+# ---------------------------------------------------------------------------
+
+class TestAuctionBacktesterStrategyConsulted:
+    """run() must invoke the strategy for every player in player_data."""
+
+    def test_strategy_is_consulted(self):
+        """run() calls strategy.bid() exactly once per player."""
+        from unittest.mock import MagicMock
+        mock_strategy = MagicMock()
+        mock_strategy.bid.return_value = 100  # always high enough to win
+        data = _sample_player_data()
+        bt = AuctionBacktester(strategy=mock_strategy, player_data=data)
+        bt.run()
+        assert mock_strategy.bid.call_count == len(data), (
+            f"Expected strategy.bid() called {len(data)} times, "
+            f"got {mock_strategy.bid.call_count}"
+        )
+
+
+# ---------------------------------------------------------------------------
+# 5. Determinism — same input → same output
 # ---------------------------------------------------------------------------
 
 @_RUN_NOT_IMPLEMENTED

--- a/tests/unit/lab/test_auction_replay.py
+++ b/tests/unit/lab/test_auction_replay.py
@@ -1,0 +1,146 @@
+"""Failing tests for AuctionBacktester — acceptance criteria for issue #196.
+
+`lab/backtest/auction_replay.py` does not exist yet.  Importing it will raise
+`ModuleNotFoundError`, which makes every test in this file fail at collection
+time — exactly the right signal for QA Phase 1.
+"""
+
+# This import will raise ModuleNotFoundError until #196 is implemented.
+from lab.backtest.auction_replay import AuctionBacktester  # noqa: F401
+
+
+# ---------------------------------------------------------------------------
+# Sample data helpers
+# ---------------------------------------------------------------------------
+
+def _sample_player_data():
+    """Minimal player data list for test fixtures."""
+    return [
+        {"player_name": "Josh Allen", "position": "QB", "auction_value": 45, "actual_price": 52},
+        {"player_name": "Christian McCaffrey", "position": "RB", "auction_value": 70, "actual_price": 68},
+        {"player_name": "Tyreek Hill", "position": "WR", "auction_value": 55, "actual_price": 50},
+    ]
+
+
+def _sample_strategy():
+    """Return a minimal duck-typed strategy object."""
+    class _MinimalStrategy:
+        name = "test_strategy"
+
+        def bid(self, player, budget):
+            return min(player.get("auction_value", 1), budget)
+
+    return _MinimalStrategy()
+
+
+# ---------------------------------------------------------------------------
+# 1. Instantiation
+# ---------------------------------------------------------------------------
+
+class TestAuctionBacktesterInstantiation:
+    """AuctionBacktester(strategy, player_data) must be constructible."""
+
+    def test_instantiation_succeeds(self):
+        """AuctionBacktester can be constructed with a strategy and player_data."""
+        bt = AuctionBacktester(strategy=_sample_strategy(), player_data=_sample_player_data())
+        assert bt is not None
+
+    def test_instantiation_stores_strategy(self):
+        """Constructed instance exposes the strategy it was given."""
+        strategy = _sample_strategy()
+        bt = AuctionBacktester(strategy=strategy, player_data=_sample_player_data())
+        assert bt.strategy is strategy
+
+    def test_instantiation_stores_player_data(self):
+        """Constructed instance exposes the player_data it was given."""
+        data = _sample_player_data()
+        bt = AuctionBacktester(strategy=_sample_strategy(), player_data=data)
+        assert bt.player_data == data
+
+
+# ---------------------------------------------------------------------------
+# 2. run() return shape
+# ---------------------------------------------------------------------------
+
+class TestAuctionBacktesterRun:
+    """run() must return a dict with the three required keys."""
+
+    REQUIRED_KEYS = {"efficiency_score", "total_spend", "total_value"}
+
+    def _make_backtester(self):
+        return AuctionBacktester(strategy=_sample_strategy(), player_data=_sample_player_data())
+
+    def test_run_returns_dict(self):
+        """run() returns a dict."""
+        bt = self._make_backtester()
+        result = bt.run()
+        assert isinstance(result, dict)
+
+    def test_run_result_has_required_keys(self):
+        """run() result contains 'efficiency_score', 'total_spend', 'total_value'."""
+        bt = self._make_backtester()
+        result = bt.run()
+        missing = self.REQUIRED_KEYS - result.keys()
+        assert not missing, f"run() result is missing keys: {missing}"
+
+    def test_efficiency_score_is_between_0_and_1(self):
+        """efficiency_score is a float in [0.0, 1.0]."""
+        bt = self._make_backtester()
+        result = bt.run()
+        score = result["efficiency_score"]
+        assert isinstance(score, float), f"efficiency_score must be float, got {type(score)}"
+        assert 0.0 <= score <= 1.0, f"efficiency_score out of range: {score}"
+
+    def test_total_spend_is_non_negative(self):
+        """total_spend must be >= 0."""
+        bt = self._make_backtester()
+        result = bt.run()
+        assert result["total_spend"] >= 0
+
+    def test_total_value_is_non_negative(self):
+        """total_value must be >= 0."""
+        bt = self._make_backtester()
+        result = bt.run()
+        assert result["total_value"] >= 0
+
+
+# ---------------------------------------------------------------------------
+# 3. Empty player_data edge case
+# ---------------------------------------------------------------------------
+
+class TestAuctionBacktesterEmptyData:
+    """run() with empty player_data must return efficiency_score=0.0 or raise ValueError."""
+
+    def test_empty_player_data_handled(self):
+        """run() with empty player_data returns efficiency_score=0.0 or raises ValueError."""
+        bt = AuctionBacktester(strategy=_sample_strategy(), player_data=[])
+        try:
+            result = bt.run()
+            assert result["efficiency_score"] == 0.0, (
+                f"Expected efficiency_score=0.0 for empty data, got {result['efficiency_score']}"
+            )
+        except ValueError:
+            pass  # also acceptable
+
+
+# ---------------------------------------------------------------------------
+# 4. Determinism — same input → same output
+# ---------------------------------------------------------------------------
+
+class TestAuctionBacktesterDeterminism:
+    """run() must be deterministic for the same input."""
+
+    def test_run_is_deterministic(self):
+        """Two successive run() calls with the same data return identical results."""
+        data = _sample_player_data()
+        strategy = _sample_strategy()
+
+        bt1 = AuctionBacktester(strategy=strategy, player_data=data)
+        bt2 = AuctionBacktester(strategy=strategy, player_data=data)
+
+        result1 = bt1.run()
+        result2 = bt2.run()
+
+        assert result1 == result2, (
+            f"run() is not deterministic:\n  first:  {result1}\n  second: {result2}"
+        )

--- a/tests/unit/lab/test_auction_replay.py
+++ b/tests/unit/lab/test_auction_replay.py
@@ -16,10 +16,11 @@ except ModuleNotFoundError:
     AuctionBacktester = None  # type: ignore[assignment,misc]
     _AUCTION_REPLAY_AVAILABLE = False
 
-# All tests are expected to fail until issue #196 is implemented.
-pytestmark = pytest.mark.xfail(
+# Instantiation tests now pass since the scaffold provides a working __init__.
+# run() tests remain xfail(strict=True) until issue #196 is implemented.
+_RUN_NOT_IMPLEMENTED = pytest.mark.xfail(
     strict=True,
-    reason="lab/backtest/auction_replay.AuctionBacktester not yet implemented (issue #196)",
+    reason="AuctionBacktester.run() not yet implemented (issue #196)",
 )
 
 
@@ -76,6 +77,7 @@ class TestAuctionBacktesterInstantiation:
 # 2. run() return shape
 # ---------------------------------------------------------------------------
 
+@_RUN_NOT_IMPLEMENTED
 class TestAuctionBacktesterRun:
     """run() must return a dict with the three required keys."""
 
@@ -122,6 +124,7 @@ class TestAuctionBacktesterRun:
 # 3. Empty player_data edge case
 # ---------------------------------------------------------------------------
 
+@_RUN_NOT_IMPLEMENTED
 class TestAuctionBacktesterEmptyData:
     """run() with empty player_data must return efficiency_score=0.0 or raise ValueError."""
 
@@ -141,6 +144,7 @@ class TestAuctionBacktesterEmptyData:
 # 4. Determinism — same input → same output
 # ---------------------------------------------------------------------------
 
+@_RUN_NOT_IMPLEMENTED
 class TestAuctionBacktesterDeterminism:
     """run() must be deterministic for the same input."""
 

--- a/tests/unit/lab/test_auction_replay.py
+++ b/tests/unit/lab/test_auction_replay.py
@@ -5,8 +5,6 @@ xfail(strict=True): they are expected to fail until #196 is implemented.
 Remove the pytestmark (and verify green) once AuctionBacktester is available.
 """
 
-import pytest
-
 # Graceful import — module does not exist yet; tests fail at runtime, not at
 # collection time, which keeps the full suite collectable.
 try:
@@ -16,12 +14,8 @@ except ModuleNotFoundError:
     AuctionBacktester = None  # type: ignore[assignment,misc]
     _AUCTION_REPLAY_AVAILABLE = False
 
-# Instantiation tests now pass since the scaffold provides a working __init__.
-# run() tests remain xfail(strict=True) until issue #196 is implemented.
-_RUN_NOT_IMPLEMENTED = pytest.mark.xfail(
-    strict=True,
-    reason="AuctionBacktester.run() not yet implemented (issue #196)",
-)
+# run() is now implemented — xfail mark removed.
+_RUN_NOT_IMPLEMENTED = lambda cls: cls  # no-op: was xfail before issue #196
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/lab/test_auction_replay.py
+++ b/tests/unit/lab/test_auction_replay.py
@@ -1,12 +1,26 @@
 """Failing tests for AuctionBacktester — acceptance criteria for issue #196.
 
-`lab/backtest/auction_replay.py` does not exist yet.  Importing it will raise
-`ModuleNotFoundError`, which makes every test in this file fail at collection
-time — exactly the right signal for QA Phase 1.
+`lab/backtest/auction_replay.py` does not exist yet.  All tests are marked
+xfail(strict=True): they are expected to fail until #196 is implemented.
+Remove the pytestmark (and verify green) once AuctionBacktester is available.
 """
 
-# This import will raise ModuleNotFoundError until #196 is implemented.
-from lab.backtest.auction_replay import AuctionBacktester  # noqa: F401
+import pytest
+
+# Graceful import — module does not exist yet; tests fail at runtime, not at
+# collection time, which keeps the full suite collectable.
+try:
+    from lab.backtest.auction_replay import AuctionBacktester
+    _AUCTION_REPLAY_AVAILABLE = True
+except ModuleNotFoundError:
+    AuctionBacktester = None  # type: ignore[assignment,misc]
+    _AUCTION_REPLAY_AVAILABLE = False
+
+# All tests are expected to fail until issue #196 is implemented.
+pytestmark = pytest.mark.xfail(
+    strict=True,
+    reason="lab/backtest/auction_replay.AuctionBacktester not yet implemented (issue #196)",
+)
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/lab/test_experiment_config.py
+++ b/tests/unit/lab/test_experiment_config.py
@@ -1,0 +1,82 @@
+"""Unit tests for ExperimentConfig — QA Phase 1 — closes #188."""
+from __future__ import annotations
+
+import json
+import os
+import tempfile
+import unittest
+
+
+class TestExperimentConfigLoad(unittest.TestCase):
+    """ExperimentConfig.load_from_file() supports YAML and JSON."""
+
+    def _write_temp(self, content: str, suffix: str) -> str:
+        f = tempfile.NamedTemporaryFile(mode="w", suffix=suffix, delete=False)
+        f.write(content)
+        f.flush()
+        f.close()
+        return f.name
+
+    def test_load_from_yaml_returns_experiment_config(self):
+        from lab.experiments.config import ExperimentConfig
+
+        yaml_content = (
+            "name: test_experiment\n"
+            "strategies:\n"
+            "  - balanced\n"
+            "  - basic\n"
+            "num_simulations: 10\n"
+        )
+        path = self._write_temp(yaml_content, ".yaml")
+        try:
+            config = ExperimentConfig.load_from_file(path)
+            self.assertIsInstance(config, ExperimentConfig)
+            self.assertEqual(config.name, "test_experiment")
+            self.assertEqual(config.num_simulations, 10)
+            self.assertIn("balanced", config.strategies)
+        finally:
+            os.unlink(path)
+
+    def test_load_from_json_returns_experiment_config(self):
+        from lab.experiments.config import ExperimentConfig
+
+        data = {"name": "json_exp", "strategies": ["balanced"], "num_simulations": 5}
+        path = self._write_temp(json.dumps(data), ".json")
+        try:
+            config = ExperimentConfig.load_from_file(path)
+            self.assertIsInstance(config, ExperimentConfig)
+            self.assertEqual(config.name, "json_exp")
+        finally:
+            os.unlink(path)
+
+
+class TestExperimentConfigValidation(unittest.TestCase):
+    """Missing or invalid fields raise ValueError."""
+
+    def test_missing_name_raises_value_error(self):
+        from lab.experiments.config import ExperimentConfig
+
+        raw = {"strategies": ["balanced"], "num_simulations": 5}
+        with self.assertRaises(ValueError):
+            ExperimentConfig._validate_and_build(raw)
+
+    def test_missing_strategies_raises_value_error(self):
+        from lab.experiments.config import ExperimentConfig
+
+        raw = {"name": "test", "num_simulations": 5}
+        with self.assertRaises(ValueError):
+            ExperimentConfig._validate_and_build(raw)
+
+    def test_num_simulations_zero_raises_value_error(self):
+        from lab.experiments.config import ExperimentConfig
+
+        raw = {"name": "test", "strategies": ["balanced"], "num_simulations": 0}
+        with self.assertRaises(ValueError):
+            ExperimentConfig._validate_and_build(raw)
+
+    def test_num_simulations_negative_raises_value_error(self):
+        from lab.experiments.config import ExperimentConfig
+
+        raw = {"name": "test", "strategies": ["balanced"], "num_simulations": -1}
+        with self.assertRaises(ValueError):
+            ExperimentConfig._validate_and_build(raw)

--- a/tests/unit/lab/test_simulation_runner.py
+++ b/tests/unit/lab/test_simulation_runner.py
@@ -1,0 +1,93 @@
+"""Unit tests for SimulationRunner — QA Phase 1 — closes #187."""
+from __future__ import annotations
+
+import unittest
+from unittest.mock import patch
+
+
+class TestSimulationRunnerInstantiation(unittest.TestCase):
+    """SimulationRunner can be instantiated with no args."""
+
+    def test_instantiation(self):
+        from lab.simulation.runner import SimulationRunner
+
+        runner = SimulationRunner()
+        self.assertIsNotNone(runner)
+
+
+class TestSimulationRunnerRun(unittest.TestCase):
+    """run(n_simulations=N) returns a list of N SimulationResult objects."""
+
+    def _make_result(self, name: str = "balanced", score: float = 0.5):
+        from lab.simulation.runner import SimulationResult
+
+        return SimulationResult(strategy_name=name, score=score)
+
+    def test_run_returns_list_of_n_results(self):
+        from lab.simulation.runner import SimulationRunner
+
+        runner = SimulationRunner(strategies=["balanced"])
+        with patch.object(runner, "_run_single", side_effect=[
+            self._make_result(score=0.9),
+            self._make_result(score=0.5),
+            self._make_result(score=0.3),
+        ]):
+            results = runner.run(n_simulations=3)
+
+        self.assertIsInstance(results, list)
+        self.assertEqual(len(results), 3)
+
+    def test_each_result_has_required_fields(self):
+        from lab.simulation.runner import SimulationRunner
+
+        runner = SimulationRunner(strategies=["balanced"])
+        with patch.object(runner, "_run_single", side_effect=[
+            self._make_result("balanced", 0.9),
+            self._make_result("balanced", 0.5),
+            self._make_result("balanced", 0.3),
+        ]):
+            results = runner.run(n_simulations=3)
+
+        for r in results:
+            self.assertIsInstance(r.strategy_name, str)
+            self.assertIsInstance(r.score, float)
+            self.assertIsInstance(r.rank, int)
+
+    def test_strategy_error_doesnt_crash(self):
+        """A simulation that raises should not propagate — it produces an error result."""
+        from lab.simulation.runner import SimulationRunner
+
+        runner = SimulationRunner(strategies=["balanced"])
+        call_count = 0
+
+        def flaky_side_effect(sim_id: int):
+            nonlocal call_count
+            call_count += 1
+            if call_count == 2:
+                raise RuntimeError("strategy exploded")
+            return self._make_result(score=0.5)
+
+        with patch.object(runner, "_run_single", side_effect=flaky_side_effect):
+            results = runner.run(n_simulations=3)
+
+        # All 3 results returned despite one failure
+        self.assertEqual(len(results), 3)
+
+    def test_results_sorted_by_rank(self):
+        """Rank 1 corresponds to highest score; results are in ascending rank order."""
+        from lab.simulation.runner import SimulationRunner
+
+        runner = SimulationRunner(strategies=["balanced"])
+        with patch.object(runner, "_run_single", side_effect=[
+            self._make_result(score=0.3),
+            self._make_result(score=0.9),
+            self._make_result(score=0.5),
+        ]):
+            results = runner.run(n_simulations=3)
+
+        ranks = [r.rank for r in results]
+        self.assertEqual(ranks, sorted(ranks))
+        # Rank 1 has the highest score
+        self.assertEqual(results[0].rank, 1)
+        self.assertGreaterEqual(results[0].score, results[1].score)
+        self.assertGreaterEqual(results[1].score, results[2].score)

--- a/tests/unit/lab/test_sleeper_auction_scraper.py
+++ b/tests/unit/lab/test_sleeper_auction_scraper.py
@@ -5,19 +5,8 @@ intentionally written to fail against the current stub so that a red/green
 cycle can be used to drive the implementation.
 """
 
-import pytest
 from unittest.mock import patch
 
-# All tests in this module are expected to fail until issue #195 is implemented.
-# Remove this mark (and verify green) once SleeperAuctionScraper has the
-# (league_id, season) constructor API and fetch() method.
-pytestmark = pytest.mark.xfail(
-    strict=True,
-    reason="SleeperAuctionScraper(league_id, season) + fetch() not yet implemented (issue #195)",
-)
-
-# This import will succeed (stub exists) but the *interface* tested below
-# does not match the stub, so individual tests will fail.
 from lab.data.sleeper_auction_scraper import SleeperAuctionScraper
 
 

--- a/tests/unit/lab/test_sleeper_auction_scraper.py
+++ b/tests/unit/lab/test_sleeper_auction_scraper.py
@@ -5,7 +5,16 @@ intentionally written to fail against the current stub so that a red/green
 cycle can be used to drive the implementation.
 """
 
+import pytest
 from unittest.mock import patch
+
+# All tests in this module are expected to fail until issue #195 is implemented.
+# Remove this mark (and verify green) once SleeperAuctionScraper has the
+# (league_id, season) constructor API and fetch() method.
+pytestmark = pytest.mark.xfail(
+    strict=True,
+    reason="SleeperAuctionScraper(league_id, season) + fetch() not yet implemented (issue #195)",
+)
 
 # This import will succeed (stub exists) but the *interface* tested below
 # does not match the stub, so individual tests will fail.

--- a/tests/unit/lab/test_sleeper_auction_scraper.py
+++ b/tests/unit/lab/test_sleeper_auction_scraper.py
@@ -1,0 +1,149 @@
+"""Failing tests for SleeperAuctionScraper — acceptance criteria for issue #195.
+
+These tests define the required public API after implementation.  They are
+intentionally written to fail against the current stub so that a red/green
+cycle can be used to drive the implementation.
+"""
+
+from unittest.mock import patch
+
+# This import will succeed (stub exists) but the *interface* tested below
+# does not match the stub, so individual tests will fail.
+from lab.data.sleeper_auction_scraper import SleeperAuctionScraper
+
+
+REQUIRED_KEYS = {"player_name", "position", "auction_value", "actual_price"}
+
+
+# ---------------------------------------------------------------------------
+# 1. Instantiation with (league_id, season)
+# ---------------------------------------------------------------------------
+
+class TestSleeperAuctionScraperInstantiation:
+    """SleeperAuctionScraper must accept (league_id, season) as its primary
+    constructor signature (issue #195).  The current stub takes (db_url, client)
+    which is a different shape — these tests will fail until the API is updated.
+    """
+
+    def test_instantiation_with_league_id_and_season(self):
+        """SleeperAuctionScraper(league_id, season) can be constructed."""
+        scraper = SleeperAuctionScraper(league_id="123456789", season="2024")
+        assert scraper is not None
+
+    def test_instantiation_stores_league_id(self):
+        """Constructed instance exposes the league_id it was given."""
+        scraper = SleeperAuctionScraper(league_id="999", season="2023")
+        assert scraper.league_id == "999"
+
+    def test_instantiation_stores_season(self):
+        """Constructed instance exposes the season it was given."""
+        scraper = SleeperAuctionScraper(league_id="999", season="2023")
+        assert scraper.season == "2023"
+
+
+# ---------------------------------------------------------------------------
+# 2. fetch() returns a list of dicts
+# ---------------------------------------------------------------------------
+
+class TestSleeperAuctionScraperFetch:
+    """fetch() must return a list of dicts with the required schema."""
+
+    def _make_scraper(self):
+        return SleeperAuctionScraper(league_id="123456789", season="2024")
+
+    def test_fetch_returns_list(self):
+        """`fetch()` must return a list."""
+        scraper = self._make_scraper()
+        with patch.object(scraper, "_fetch_from_api", return_value=_sample_picks()):
+            result = scraper.fetch()
+        assert isinstance(result, list)
+
+    def test_fetch_returns_list_of_dicts(self):
+        """`fetch()` must return a list of dicts."""
+        scraper = self._make_scraper()
+        with patch.object(scraper, "_fetch_from_api", return_value=_sample_picks()):
+            result = scraper.fetch()
+        assert all(isinstance(row, dict) for row in result)
+
+    def test_fetch_dicts_have_required_keys(self):
+        """Every dict returned by `fetch()` must contain the required keys."""
+        scraper = self._make_scraper()
+        with patch.object(scraper, "_fetch_from_api", return_value=_sample_picks()):
+            result = scraper.fetch()
+        assert len(result) > 0, "fetch() returned an empty list — cannot validate keys"
+        for row in result:
+            missing = REQUIRED_KEYS - row.keys()
+            assert not missing, f"Missing keys in fetch() result: {missing}"
+
+
+# ---------------------------------------------------------------------------
+# 3. Invalid league_id raises ValueError or returns []
+# ---------------------------------------------------------------------------
+
+class TestSleeperAuctionScraperInvalidLeague:
+    """fetch() with a bad league_id must either raise ValueError or return []."""
+
+    def test_invalid_league_id_raises_or_returns_empty(self):
+        """fetch() with an invalid league_id raises ValueError or returns []."""
+        scraper = SleeperAuctionScraper(league_id="INVALID_LEAGUE_XYZ", season="2024")
+        with patch.object(scraper, "_fetch_from_api", return_value=[]):
+            try:
+                result = scraper.fetch()
+                assert result == [], (
+                    "Expected fetch() to raise ValueError or return [] for an "
+                    f"invalid league, but got: {result!r}"
+                )
+            except ValueError:
+                pass  # acceptable
+
+
+# ---------------------------------------------------------------------------
+# 4. Caching — second call must not re-fetch from the API
+# ---------------------------------------------------------------------------
+
+class TestSleeperAuctionScraperCaching:
+    """Results must be cached; a second call to fetch() must not hit the API."""
+
+    def test_second_fetch_uses_cache(self):
+        """fetch() called twice hits the underlying API only once."""
+        scraper = SleeperAuctionScraper(league_id="123456789", season="2024")
+
+        with patch.object(
+            scraper, "_fetch_from_api", return_value=_sample_picks()
+        ) as mock_api:
+            scraper.fetch()
+            scraper.fetch()
+
+        mock_api.assert_called_once()
+
+    def test_cache_returns_same_data(self):
+        """Cached fetch() returns identical data on both calls."""
+        scraper = SleeperAuctionScraper(league_id="123456789", season="2024")
+
+        with patch.object(scraper, "_fetch_from_api", return_value=_sample_picks()):
+            first = scraper.fetch()
+            second = scraper.fetch()
+
+        assert first == second
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _sample_picks():
+    """Return a minimal set of valid auction pick dicts."""
+    return [
+        {
+            "player_name": "Josh Allen",
+            "position": "QB",
+            "auction_value": 45,
+            "actual_price": 52,
+        },
+        {
+            "player_name": "Christian McCaffrey",
+            "position": "RB",
+            "auction_value": 70,
+            "actual_price": 68,
+        },
+    ]

--- a/tests/unit/strategies/test_strategy_config.py
+++ b/tests/unit/strategies/test_strategy_config.py
@@ -86,7 +86,7 @@ class TestStrategyRegistryCreate:
         assert available == sorted(available)
         assert "vor" in available
         assert "balanced" in available
-        assert "inflation_vor" in available
+        assert "inflation_aware_vor" in available
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/strategies/test_strategy_registration.py
+++ b/tests/unit/strategies/test_strategy_registration.py
@@ -9,20 +9,11 @@ Issue #153: InflationAwareVorStrategy._calculate_inflation_factor() hard-codes
             use them in the inflation calculation.
 """
 
-import pytest
+import pytest  # noqa: F401 — kept for potential future xfail marks
 from unittest.mock import MagicMock
 
 from strategies import AVAILABLE_STRATEGIES, create_strategy
 from strategies.enhanced_vor_strategy import InflationAwareVorStrategy
-
-# All tests in this module are expected to fail until issues #151 and #153 are
-# implemented.  Remove pytestmark (and verify green) once:
-#   #151 — 'inflation_aware_vor' is registered in AVAILABLE_STRATEGIES
-#   #153 — InflationAwareVorStrategy accepts budget / roster_size kwargs
-pytestmark = pytest.mark.xfail(
-    strict=True,
-    reason="InflationAwareVorStrategy registration (#151) and custom budget/roster_size (#153) not yet implemented",
-)
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/strategies/test_strategy_registration.py
+++ b/tests/unit/strategies/test_strategy_registration.py
@@ -9,10 +9,20 @@ Issue #153: InflationAwareVorStrategy._calculate_inflation_factor() hard-codes
             use them in the inflation calculation.
 """
 
+import pytest
 from unittest.mock import MagicMock
 
 from strategies import AVAILABLE_STRATEGIES, create_strategy
 from strategies.enhanced_vor_strategy import InflationAwareVorStrategy
+
+# All tests in this module are expected to fail until issues #151 and #153 are
+# implemented.  Remove pytestmark (and verify green) once:
+#   #151 — 'inflation_aware_vor' is registered in AVAILABLE_STRATEGIES
+#   #153 — InflationAwareVorStrategy accepts budget / roster_size kwargs
+pytestmark = pytest.mark.xfail(
+    strict=True,
+    reason="InflationAwareVorStrategy registration (#151) and custom budget/roster_size (#153) not yet implemented",
+)
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/strategies/test_strategy_registration.py
+++ b/tests/unit/strategies/test_strategy_registration.py
@@ -1,0 +1,115 @@
+"""Failing tests for strategy registration — acceptance criteria for issues #151 and #153.
+
+Issue #151: InflationAwareVorStrategy must be registered under the canonical key
+            'inflation_aware_vor' in AVAILABLE_STRATEGIES (currently 'inflation_vor').
+
+Issue #153: InflationAwareVorStrategy._calculate_inflation_factor() hard-codes
+            standard_budget_per_slot = 200 / 15, which breaks non-standard leagues.
+            The constructor must accept `budget` and `roster_size` parameters and
+            use them in the inflation calculation.
+"""
+
+from unittest.mock import MagicMock
+
+from strategies import AVAILABLE_STRATEGIES, create_strategy
+from strategies.enhanced_vor_strategy import InflationAwareVorStrategy
+
+
+# ---------------------------------------------------------------------------
+# Issue #151 — Registration key
+# ---------------------------------------------------------------------------
+
+class TestInflationAwareVorStrategyRegistration:
+    """InflationAwareVorStrategy must be accessible as 'inflation_aware_vor'."""
+
+    def test_inflation_aware_vor_key_in_available_strategies(self):
+        """'inflation_aware_vor' must be a key in AVAILABLE_STRATEGIES (issue #151).
+
+        Currently the key is 'inflation_vor', so this test fails.
+        """
+        assert "inflation_aware_vor" in AVAILABLE_STRATEGIES, (
+            "'inflation_aware_vor' is not registered in AVAILABLE_STRATEGIES.  "
+            f"Current keys: {list(AVAILABLE_STRATEGIES.keys())}"
+        )
+
+    def test_create_strategy_returns_inflation_aware_vor_instance(self):
+        """create_strategy('inflation_aware_vor') must return an InflationAwareVorStrategy."""
+        strategy = create_strategy("inflation_aware_vor")
+        assert isinstance(strategy, InflationAwareVorStrategy), (
+            f"Expected InflationAwareVorStrategy, got {type(strategy)}"
+        )
+
+    def test_inflation_aware_vor_name_attribute(self):
+        """The registered strategy instance must have name == 'inflation_aware_vor'."""
+        strategy = create_strategy("inflation_aware_vor")
+        assert strategy.name == "inflation_aware_vor", (
+            f"Expected strategy.name='inflation_aware_vor', got '{strategy.name}'"
+        )
+
+
+# ---------------------------------------------------------------------------
+# Issue #153 — Custom budget and roster_size
+# ---------------------------------------------------------------------------
+
+class TestInflationAwareVorStrategyCustomBudget:
+    """InflationAwareVorStrategy must accept and use custom budget / roster_size.
+
+    The hard-coded `standard_budget_per_slot = 200 / 15` inside
+    _calculate_inflation_factor() must be replaced by values derived from the
+    constructor arguments `budget` and `roster_size`.
+    """
+
+    def test_constructor_accepts_budget_kwarg(self):
+        """InflationAwareVorStrategy(budget=100) must not raise TypeError (issue #153)."""
+        strategy = InflationAwareVorStrategy(budget=100)
+        assert strategy is not None
+
+    def test_constructor_accepts_roster_size_kwarg(self):
+        """InflationAwareVorStrategy(roster_size=20) must not raise TypeError (issue #153)."""
+        strategy = InflationAwareVorStrategy(roster_size=20)
+        assert strategy is not None
+
+    def test_constructor_stores_budget(self):
+        """Constructed instance must expose the custom budget."""
+        strategy = InflationAwareVorStrategy(budget=100, roster_size=20)
+        assert strategy.budget == 100
+
+    def test_constructor_stores_roster_size(self):
+        """Constructed instance must expose the custom roster_size."""
+        strategy = InflationAwareVorStrategy(budget=100, roster_size=20)
+        assert strategy.roster_size == 20
+
+    def test_inflation_factor_uses_custom_budget_and_roster_size(self):
+        """_calculate_inflation_factor() must use instance budget/roster_size, not 200/15.
+
+        With budget=100 and roster_size=10 the standard_budget_per_slot is 10.0.
+        With budget=200 and roster_size=15 the standard_budget_per_slot is ~13.33.
+        The two instances must produce different inflation factors when given the
+        same team situation, proving the calculation is parameterised.
+        """
+        # Two teams, each with $50 remaining and 5 roster slots left.
+        def _make_team(remaining_budget: float, roster_size: int):
+            team = MagicMock()
+            team.budget = remaining_budget
+            team.roster = [MagicMock()] * (roster_size - 5)  # 5 slots still open
+            return team
+
+        strategy_small = InflationAwareVorStrategy(budget=100, roster_size=10)
+        strategy_standard = InflationAwareVorStrategy(budget=200, roster_size=15)
+
+        teams = [_make_team(50, 10), _make_team(50, 10)]
+        remaining = []  # not used in the inflation calc itself
+
+        factor_small = strategy_small._calculate_inflation_factor(teams, remaining)
+        factor_standard = strategy_standard._calculate_inflation_factor(teams, remaining)
+
+        assert factor_small != factor_standard, (
+            "Inflation factors are identical despite different budget/roster_size "
+            "configurations — the hardcoded 200/15 constant has not been removed."
+        )
+
+    def test_default_budget_and_roster_size_match_standard_league(self):
+        """Default InflationAwareVorStrategy() must default to budget=200, roster_size=15."""
+        strategy = InflationAwareVorStrategy()
+        assert strategy.budget == 200
+        assert strategy.roster_size == 15


### PR DESCRIPTION
## Summary

Sprint 11 accumulation: security hardening, CLI quality fixes, lab infrastructure, strategy registry correctness, and architecture documentation. This PR closes eight tracked issues across the P0 API-key security gate, CLI season-default / dependency-deduplication bugs, `InflationAwareVorStrategy` registration and parameterisation fixes, the `AuctionBacktester.run()` and `ExperimentConfig` implementations, and the `SimulationRunner` parallel execution mode.

Closes #355 · Closes #171 · Closes #172 · Closes #151 · Closes #153 · Closes #196 · Closes #188 · Closes #187 · Partially addresses #195 · Closes #297

## Type of Change

- [x] Bug fix (`fix/`)
- [x] New feature (`feat/`)
- [x] Refactor (`refactor/`)
- [x] Tests only (`test/`)
- [x] Docs / chore (`docs/` / `chore/`)
- [x] Performance (`perf/`)

## Changes

### Security (P0 — #355, ARCH-002)
- `api/main.py` — `create_app()` raises `RuntimeError` if `PIGSKIN_API_KEY` is empty or unset in any non-test environment; no empty-key bypass mode
- `config/settings.py` — `api_key` and new `docs_enabled` fields use `pydantic.Field(validation_alias=...)` for explicit env-var binding; `populate_by_name=True` added
- `/docs`, `/openapi.json`, `/redoc` gated behind `PIGSKIN_DOCS_ENABLED=true` (default `false`); `docs_url`/`openapi_url`/`redoc_url` set to `None` when disabled
- `api/schemas/auction.py` — `player_id` and `team_name` fields enforce `min_length=1`
- `tests/conftest.py` — sets `TESTING=true` env var at collection time so `create_app()` does not raise for the test suite
- `docs/api/api-key-auth.md` — corrected to reflect the no-bypass policy

### CLI Quality (#171, #172)
- `cli/main.py` + `cli/commands.py` — `CommandProcessor` now accepts `config_manager` and `sleeper_api` via constructor; `AuctionDraftCLI` passes its own instances, so both objects are created exactly once per process
- `cli/main.py` — all `ERROR:` messages now route to `sys.stderr`
- `cli/main.py` + `api/sleeper_api.py` — hardcoded `"2024"` season defaults replaced with `str(datetime.now().year)` throughout
- `services/sleeper_draft_service.py` — constructor accepts optional `sleeper_api` injection

### Strategy Registry (#151, #153)
- `strategies/__init__.py` — `InflationAwareVorStrategy` re-registered as `"inflation_aware_vor"` (was `"inflation_vor"`)
- `strategies/enhanced_vor_strategy.py` — constructor accepts `budget` and `roster_size`; `_calculate_inflation_factor()` derives `standard_budget_per_slot` from instance values instead of the hardcoded `200 / 15`

### Lab: AuctionBacktester (#196)
- `lab/backtest/auction_replay.py` — `AuctionBacktester(strategy, player_data).run()` implemented; calls `strategy.bid(player, remaining_budget)` per player, tracks wins/spend/value, returns `{efficiency_score, total_spend, total_value}`

### Lab: ExperimentConfig (#188)
- `lab/experiments/config.py` — `ExperimentConfig.load_from_file(path)` loads YAML or JSON; validates required fields (`name`, `strategies`, `num_simulations`); raises `ValueError` on missing/invalid fields

### Lab: SimulationRunner parallel mode (#187)
- `lab/simulation/runner.py` — `run(n_simulations=N)` overload runs N individual simulations via `ThreadPoolExecutor(max_workers=4)`; returns ranked `List[SimulationResult]`; failures produce an error result without crashing the batch
- `SimulationResult` dataclass added

### Lab: SleeperAuctionScraper new API (partial #195)
- `lab/data/sleeper_auction_scraper.py` — dual-mode: new `(league_id, season)` constructor + `fetch()` method with result caching; legacy `(db_url, client)` + `scrape_league()` preserved; SQLAlchemy imports deferred to prevent eager-load in new-API path

### Lab Scaffolding
- `lab/benchmarks/runner.py` + `reporter.py` — `BenchmarkRunner` and `BenchmarkReporter` stubs referencing #227
- `lab/promotion/gate.py` + `promote.py` — `check_promotion_criteria` stub (#80) + `promote_strategy` CLI script with `--dry-run`
- `pyproject.toml` / `requirements.txt` — `pyyaml>=6.0` added (required by `ExperimentConfig`)

### Architecture Documentation
- ADR-001 amended — five confirmed layering violations (L-001–L-005) documented as migration blockers; `import-linter` rules specified
- ADR-002 amended — security constraints (ARCH-002), route versioning requirement (ARCH-003), async boundary enforcement (ARCH-010)
- ADR-003 amended — shadow mode stage (3.5) inserted between gate PASS and promotion PR
- ADR-011 created — PostgreSQL 16 + Redis 7 as production database and cache stack

### Docs
- `docs/strategies/catalog.md` — full strategy catalog (17 strategies, parameter quick-reference)
- `docs/strategies/how-to-create.md` — step-by-step guide for adding new strategies
- `docs/wiki-plan.md` — GitHub wiki structure, ownership matrix, writing standard, rollout priority (#297)
- `docs/api/openapi.yaml` — regenerated from live FastAPI app via `make openapi`
- `Makefile` — `openapi` target added

## Testing

- [x] New or updated tests exist for this change
- [x] `pytest tests/ -x -q` passes locally
- [x] For bug fixes: regression test added that would have caught the bug before the fix
- [x] For features: happy path and at least one edge case covered

```bash
# Test command run and output:
$ TESTING=true pytest tests/unit/ -x -q --timeout=30

1500 passed, 20 warnings in 3.70s
```

**New test files:**
- `tests/unit/api/test_api_key_security.py` — 11 tests: empty-key startup guard, `/health` public, `/recommend/bid` auth-gated, `/docs` disabled by default, `/docs` accessible when `PIGSKIN_DOCS_ENABLED=true`
- `tests/unit/cli/test_cli_season_default.py` — 7 tests: dynamic year defaults (#171), single-instance `ConfigManager`/`SleeperAPI` (#172), shared-instance assertions
- `tests/unit/lab/test_auction_replay.py` — 9 tests: instantiation, `run()` return shape, empty-data edge case, strategy consulted (MagicMock call count), determinism
- `tests/unit/lab/test_experiment_config.py` — 6 tests: YAML load, JSON load, missing-field validation
- `tests/unit/lab/test_simulation_runner.py` — 5 tests: instantiation, parallel results shape, fault tolerance, rank ordering
- `tests/unit/lab/test_sleeper_auction_scraper.py` — 10 tests: new constructor API, `fetch()` schema, caching
- `tests/unit/strategies/test_strategy_registration.py` — 10 tests: `inflation_aware_vor` key, `budget`/`roster_size` params, custom inflation factor

## Code Review Checklist

### Correctness
- [x] Logic is correct for auction mechanics / VOR / budget constraints
- [x] Edge cases handled (empty rosters, zero budgets, position scarcity)
- [x] No off-by-one errors in nomination cycles or draft rounds

### Code Standards
- [x] PEP 8 compliant, 120-char line limit
- [x] Type hints on all new function signatures
- [x] No magic numbers — constants in `config/` or named constants
- [x] Absolute imports only (no relative imports)

### Architecture
- [x] Strategies inherit from `base_strategy.py` and implement `calculate_bid()`
- [x] Budget logic uses `BudgetConstraintManager`, not inline math
- [x] No circular imports introduced

### Security
- [x] No hardcoded secrets or API tokens
- [x] External API inputs (Sleeper) validated before use
- [x] No path traversal in file loading

### Performance
- [x] VOR calculations cached where applicable
- [x] MCTS iterations bounded appropriately

## Notes for Reviewers

**Priority focus areas:**

1. **Security (`api/main.py`)** — The `TESTING` env-var gate (`os.getenv("TESTING") != "true"`) is the only bypass for the empty-key guard. Confirm this is acceptable for CI or whether a dedicated test-mode flag is preferred.

2. **`InflationAwareVorStrategy` rename** (`strategies/__init__.py`) — Key changed from `inflation_vor` → `inflation_aware_vor`. Any external callers using the old key (e.g., saved tournament configs, CLI scripts) will need to be updated. The catalog and `test_strategies.py` are already updated.

3. **Deferred local imports in `lab/data/sleeper_auction_scraper.py`** — SQLAlchemy and `lab.results_db.models` imports moved inside methods to avoid eager-loading when using the new `(league_id, season)` constructor. This is intentional; verify the pattern is acceptable.

4. **`BenchmarkRunner.run()` and `check_promotion_criteria()`** — both still raise `NotImplementedError`. These are scaffolding stubs tracked by #227 and #80 respectively; they are not blocking this PR.

5. **Partial #195** — `SleeperAuctionScraper.fetch()` and the `(league_id, season)` constructor are implemented. The corpus pipeline methods (`discover_auction_leagues`, `fetch_draft`, `ingest_to_db`, `run_corpus_ingestion`) remain deferred to the issue backlog.
