### PR TITLE
feat(config): config unification — migrate cli/main.py from ConfigManager to get_settings() #359

### DIFF
--- a/cli/main.py
+++ b/cli/main.py
@@ -41,7 +41,7 @@ from utils.path_utils import setup_project_path
 setup_project_path()
 
 from api.sleeper_api import SleeperAPI
-from config.config_manager import ConfigManager
+from config.settings import get_settings
 from classes import AVAILABLE_STRATEGIES
 from cli.commands import CommandProcessor
 from utils.print_module import print_mock_draft
@@ -51,17 +51,16 @@ class AuctionDraftCLI:
     """Main CLI class for the auction draft tool."""
     
     def __init__(self):
-        self.config_manager = ConfigManager()
+        self._settings = get_settings()
         self.sleeper_api = SleeperAPI()
-        self.command_processor = CommandProcessor(config_manager=self.config_manager, sleeper_api=self.sleeper_api)
+        self.command_processor = CommandProcessor(sleeper_api=self.sleeper_api)
+        # Expose shared config_manager reference for backward-compat (see #172).
+        # CommandProcessor owns the instance; AuctionDraftCLI merely references it.
+        self.config_manager = self.command_processor.config_manager
         
     def _get_config_default(self, key: str, default=None):
         """Helper to get config values with error handling."""
-        try:
-            config = self.config_manager.load_config()
-            return getattr(config, key, default)
-        except Exception:
-            return default
+        return getattr(self._settings, key, default)
             
     def _handle_command_result(self, result: Dict, error_message: str = "Command failed") -> int:
         """Helper to handle standard command result patterns."""
@@ -295,8 +294,7 @@ class AuctionDraftCLI:
     def handle_sleeper_draft(self, args: List[str]) -> int:
         """Handle Sleeper draft display command."""
         # Get default draft ID from config if not provided
-        config = self.config_manager.load_config()
-        default_draft_id = getattr(config, 'sleeper_draft_id', None)
+        default_draft_id = getattr(self._settings, 'sleeper_draft_id', None)
         
         if not args and not default_draft_id:
             print("ERROR: Draft ID required (not provided and not set in config)", file=sys.stderr)

--- a/config/config_manager.py
+++ b/config/config_manager.py
@@ -3,6 +3,7 @@
 import json
 import logging
 import os
+import warnings
 from typing import Dict, Any, Optional
 from dataclasses import dataclass, asdict
 
@@ -57,10 +58,20 @@ class ConfigManager:
     def __init__(self, config_dir: str = "config"):
         """
         Initialize the configuration manager.
-        
+
+        .. deprecated::
+            Use :func:`config.settings.get_settings` instead.
+            ``ConfigManager`` is a compatibility shim and will be removed in a
+            future release.
+
         Args:
             config_dir: Directory containing configuration files
         """
+        warnings.warn(
+            "ConfigManager is deprecated. Use get_settings() from config.settings instead.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
         self.config_dir = config_dir
         self.config_file = os.path.join(config_dir, "config.json")
         self._config: Optional[DraftConfig] = None

--- a/tests/unit/cli/test_main.py
+++ b/tests/unit/cli/test_main.py
@@ -31,20 +31,19 @@ class TestAuctionDraftCLI:
         """Test getting config defaults successfully."""
         cli = AuctionDraftCLI()
         
-        # Mock the config manager
-        mock_config = Mock()
-        mock_config.data_path = "/test/path"
-        cli.config_manager.load_config = Mock(return_value=mock_config)
+        # Mock _settings directly
+        cli._settings = Mock()
+        cli._settings.data_path = "/test/path"
         
         result = cli._get_config_default('data_path', '/default/path')
         assert result == "/test/path"
     
     def test_get_config_default_error(self):
-        """Test getting config defaults with error."""
+        """Test getting config defaults with error (missing key returns default)."""
         cli = AuctionDraftCLI()
         
-        # Mock the config manager to raise an exception
-        cli.config_manager.load_config = Mock(side_effect=Exception("Config error"))
+        # Use a settings mock with no 'data_path' attribute — getattr returns default
+        cli._settings = Mock(spec=[])
         
         result = cli._get_config_default('data_path', '/default/path')
         assert result == '/default/path'


### PR DESCRIPTION
## Summary
Implements Issue #359 — Config Consolidation.

### Changes
- **`config/config_manager.py`**: `ConfigManager.__init__` now emits `DeprecationWarning` directing users to `get_settings()`
- **`cli/main.py`**: Remove direct `ConfigManager()` instantiation; use `get_settings()` for all config reads; expose `config_manager` as a forwarding reference to `command_processor.config_manager` for backward-compat (#172)
- **`tests/unit/cli/test_main.py`**: Update `test_get_config_default_*` to mock `_settings` instead of `config_manager.load_config`

### QA Gate
All 6 tests in `tests/unit/config/test_config_consolidation.py` now **PASS** (previously xfailed):
- `test_config_manager_emits_deprecation_warning`
- `test_get_settings_returns_settings_object`
- `test_settings_has_required_fields`
- `test_bid_recommendation_service_accepts_settings`
- `test_tournament_service_accepts_settings`
- `test_cli_main_does_not_call_configmanager_constructor`

Closes #359