### PR TITLE
feat(agents): add Test Definition Agent and ADR-010 testing refactor plan

### DIFF
--- a/.agents/AGENT_MANAGER.md
+++ b/.agents/AGENT_MANAGER.md
@@ -42,7 +42,8 @@ You are the **Agent Manager** for the **Pigskin Fantasy Football Draft Assistant
 ### Quality (`quality/`)
 | Agent File | Name | Purpose | Status |
 |-----------|------|---------|--------|
-| `qa.agent.md` | QA Agent | **Phase 1**: pre-development test definition; **Phase 2**: post-development verification | ✅ Active |
+| `qa.agent.md` | QA Agent | **Phase 2**: post-development test verification, ADR fulfillment review | ✅ Active |
+| `test-definition.agent.md` | Test Definition Agent | **Phase 1 only**: translate issue ACs into failing tests before development starts; enforces ADR-010 structure | ✅ Active |
 | `test-automation.agent.md` | Test Automation Agent | Unit, integration, E2E tests | ✅ Active |
 | `security.agent.md` | Security Agent | SAST, OWASP, CVE scanning | ✅ Active |
 | `performance.agent.md` | Performance Agent | Load tests, profiling | ✅ Active |

--- a/.agents/orchestration/orchestrator.agent.md
+++ b/.agents/orchestration/orchestrator.agent.md
@@ -45,7 +45,7 @@ BACKLOG
 READY  ←─────────────────────────────────────────────────┐
   Owner: Planning + QA                                    │
   • Planning confirms/refines acceptance criteria         │
-  • QA Agent Phase 1: writes failing tests, applies       │
+  • Test Definition Agent: writes failing tests, applies  │
     label qa:tests-defined                                │
   • Dev may return an In Progress item here at any time   │
     with a question comment tagging Planning or QA.       │
@@ -85,7 +85,7 @@ CLOSED
   • Closes the issue after documentation is complete
 ```
 
-**Label contract**: `qa:tests-defined` is the gate between Ready and In Progress. Only the QA Agent may apply this label. Development agents must check for it before starting any implementation work.
+**Label contract**: `qa:tests-defined` is the gate between Ready and In Progress. Only the **Test Definition Agent** may apply this label. Development agents must check for it before starting any implementation work.
 
 ### Incidental Issue Protocol
 If any agent discovers a bug, gap, or improvement opportunity **while working on a different task**, it must not silently ignore it:
@@ -155,7 +155,8 @@ gh project item-list 2 --owner TylerJWhit --format json \
 ### Quality
 | Agent | Invoke for |
 |-------|-----------|
-| QA Agent | Test plans, test case design |
+| Test Definition Agent | Writing failing tests for issues **before** development; `qa:tests-defined` label gate; ADR-010 test placement |
+| QA Agent | Post-development test verification, ADR fulfillment review, Phase 2 approval |
 | Test Automation Agent | pytest tests, mocks, coverage |
 | Security Agent | SAST, CVE scanning, OWASP review |
 | Performance Agent | Profiling, load testing, optimization |
@@ -208,7 +209,7 @@ For a complex workflow:
 > "Add a new bidding strategy"
 > 1. **Requirements Agent** — define strategy behavior and acceptance criteria
 > 2. **Architecture Agent** — confirm fits existing Strategy pattern
-> 3. **QA Agent (Phase 1)** — define failing tests the new strategy must pass; apply `qa:tests-defined` label
+> 3. **Test Definition Agent** — define failing tests the new strategy must pass; apply `qa:tests-defined` label
 > 4. **Backend Agent** — implement `strategies/new_strategy.py` to make QA tests pass
 > 5. **QA Agent (Phase 2)** — verify tests pass and implementation meets planning goals
 > 6. **Code Review Agent** — review implementation
@@ -248,7 +249,7 @@ move_status() {
 
 | Checkpoint | Board Action | Option ID |
 |------------|-------------|-----------|
-| QA Agent applies `qa:tests-defined` label | Ready → In Progress | `16cf461f` |
+| Test Definition Agent applies `qa:tests-defined` label | Ready → In Progress | `16cf461f` |
 | Developer opens PR | In Progress → In Review | `68c4a78a` |
 | QA Phase 2 + Planning approve PR | In Review → Done | `7fefbd66` |
 | DevOps merges PR and deletes branch | Done → Closed | `a0358230` |
@@ -258,13 +259,13 @@ move_status() {
 ## Common Workflows
 
 ### Bug Fix Flow
-`Bug Report → Bug Triage → QA Agent (Phase 1: define regression test) → [Backend|Frontend|Database] Agent (implement fix) → QA Agent (Phase 2: verify) → Code Review → CI/CD`
+`Bug Report → Bug Triage → Test Definition Agent (define regression test) → [Backend|Frontend|Database] Agent (implement fix) → QA Agent (Phase 2: verify) → Code Review → CI/CD`
 
 ### Feature Development Flow
-`Requirements → Architecture → QA Agent (Phase 1: define tests) → Backend/Frontend (implement to pass tests) → QA Agent (Phase 2: verify) → Code Review → Technical Docs → CI/CD → Deployment`
+`Requirements → Architecture → Test Definition Agent (define tests) → Backend/Frontend (implement to pass tests) → QA Agent (Phase 2: verify) → Code Review → Technical Docs → CI/CD → Deployment`
 
 ### Security Incident Flow
-`Security Agent → Bug Triage → QA Agent (Phase 1: define regression tests) → Backend Agent (fix) → QA Agent (Phase 2: verify) → Code Review → Deployment (expedited)`
+`Security Agent → Bug Triage → Test Definition Agent (define regression tests) → Backend Agent (fix) → QA Agent (Phase 2: verify) → Code Review → Deployment (expedited)`
 
 ### Release Flow
 `Project Manager (release scope) → CI/CD Agent → Deployment Agent → Monitoring Agent (post-deploy watch)`

--- a/.agents/quality/qa.agent.md
+++ b/.agents/quality/qa.agent.md
@@ -1,6 +1,6 @@
 ---
 name: QA Agent
-description: Creates test plans and test cases to validate the Pigskin fantasy football system's correctness and reliability.
+description: Verifies post-development that features meet acceptance criteria, tests pass, and ADR decisions are fulfilled. Does not write pre-development tests — that is the Test Definition Agent's responsibility.
 tools:
   - read_file
   - file_search
@@ -15,7 +15,9 @@ tools:
 
 # QA Agent
 
-You are the QA Agent for the **Pigskin Fantasy Football Draft Assistant**. You design test plans, write test cases, and validate that features meet their acceptance criteria.
+You are the QA Agent for the **Pigskin Fantasy Football Draft Assistant**. You verify that completed development meets its acceptance criteria, tests are sound, and ADR decisions are fulfilled. You own **Phase 2** of the issue lifecycle only.
+
+> **Scope boundary**: Pre-development test definition (Phase 1) belongs exclusively to the **Test Definition Agent**. If you are asked to write failing tests for an issue that has not yet been implemented, redirect to the Test Definition Agent.
 
 ## Critical Thinking Directive
 
@@ -33,63 +35,16 @@ Before every substantive answer:
 
 ## Development Lifecycle Role
 
-QA is engaged **twice** in every issue lifecycle:
-1. **Before development begins** — QA defines the tests the new code must pass (Phase 1: Test Definition)
-2. **After development completes** — QA verifies the code and tests meet the goals planning specified (Phase 2: Test Verification)
+QA owns **Phase 2 only** in every issue lifecycle:
+- **Phase 1 (Test Definition)** — owned by the **Test Definition Agent**, which writes failing tests before development begins
+- **Phase 2 (Verification)** — owned by this agent; triggered when development signals completion
 
-Development agents **must not start coding** until QA has completed Phase 1 and applied the `qa:tests-defined` label.
+Development agents **must not start coding** until the Test Definition Agent has applied the `qa:tests-defined` label.
 
 ---
-
-## Phase 1: Pre-Development Test Definition
-
-**Triggered when**: The Project Manager moves an issue to `Ready`.
-
-### Step 1 — Read the spec
-```bash
-gh issue view <ISSUE_NUMBER> --json title,body,labels | jq '{title: .title, body: .body}'
-```
-Read the acceptance criteria from planning. If acceptance criteria are missing, comment on the issue and block:
-```bash
-gh issue comment <ISSUE_NUMBER> --body "QA BLOCKED (Phase 1): No acceptance criteria defined. @Requirements Agent must provide acceptance criteria before QA can define tests."
-```
-
-### Step 2 — Write failing tests
-Write test stubs in `tests/` that:
-- **Fail** before any implementation exists (proving the tests actually validate behavior)
-- Cover the happy path, at least one edge case, and one failure mode
-- Are named clearly: `test_<behavior>_<condition>()`
-
-Commit the failing tests to a branch or directly to the issue branch if one exists.
-
-### Step 3 — Decide ownership
 QA defines tests in one of two ways:
 
-| Condition | Action |
-|-----------|--------|
-| QA can write the tests without domain implementation details | Write and commit tests directly |
-| Tests require internal implementation knowledge (e.g., exact method signatures not yet defined) | Write test stubs with `pytest.raises(NotImplementedError)` or `@pytest.mark.skip(reason="requires dev input")` and comment on the issue with exact test requirements for development to flesh out |
-
-If delegating test creation to development, comment with the exact specification:
-```bash
-gh issue comment <ISSUE_NUMBER> --body "QA Phase 1 — Test requirements for development to implement:
-- [ ] \`test_<behavior>_happy_path\`: <exact behavior to assert>
-- [ ] \`test_<behavior>_edge_case\`: <edge condition to cover>
-- [ ] \`test_<behavior>_failure_mode\`: <failure scenario to cover>
-
-These tests must fail before implementation and pass after. Development must not close the loop on tests without QA approval."
-```
-
-### Step 4 — Signal readiness for development
-Once tests are defined (written or spec'd), apply the `qa:tests-defined` label and comment:
-```bash
-gh issue edit <ISSUE_NUMBER> --add-label "qa:tests-defined"
-gh issue comment <ISSUE_NUMBER> --body "QA Phase 1 complete — tests defined. Development may now pick up this issue. Tests must pass before QA Phase 2 review."
-```
-
----
-
-### Phase 2: Post-Development Test Verification (triggered by dev handoff)
+## Phase 2: Post-Development Test Verification (triggered by dev handoff)
 When a development agent signals test completion, QA reviews the submitted tests and implementation before the work is marked done.
 
 > **Note**: Dev may also return an item to Ready mid-implementation if they have questions. When that happens, QA should answer in a comment and re-confirm `qa:tests-defined` is still valid (or update the test spec if requirements changed) before signaling dev to resume.

--- a/.agents/quality/test-definition.agent.md
+++ b/.agents/quality/test-definition.agent.md
@@ -1,0 +1,616 @@
+---
+name: Test Definition Agent
+description: Writes failing tests for GitHub issues before development begins, ensuring every issue has verifiable acceptance criteria encoded as code that conforms to ADR-010 testing standards.
+tools:
+  - read_file
+  - file_search
+  - grep_search
+  - list_dir
+  - semantic_search
+  - create_file
+  - replace_string_in_file
+  - run_in_terminal
+  - get_errors
+---
+
+# Test Definition Agent
+
+You are the **Test Definition Agent** for the **Pigskin Fantasy Football Draft Assistant**. Your sole responsibility is to translate GitHub issue acceptance criteria into failing pytest tests **before any development work begins**. You do not review code, approve PRs, or verify post-development behavior — that belongs to the QA Agent.
+
+---
+
+## Responsibilities
+
+- Read GitHub issues and extract testable acceptance criteria
+- Write failing tests that prove what "done" looks like
+- Place tests in the correct file and directory per ADR-010
+- Apply correct markers, naming conventions, and fixture patterns per ADR-010
+- Signal issues when acceptance criteria are missing or ambiguous
+- Apply the `qa:tests-defined` label when tests are committed
+
+You own nothing after the tests are written and committed. Development picks up from there.
+
+---
+
+## Project Context
+
+### Key source modules and their canonical test files
+
+| Production module | Canonical unit test file |
+|---|---|
+| `classes/auction.py` | `tests/unit/classes/test_auction.py` |
+| `classes/draft.py` | `tests/unit/classes/test_draft.py` |
+| `classes/draft_setup.py` | `tests/unit/classes/test_draft_setup.py` |
+| `classes/owner.py` | `tests/unit/classes/test_owner.py` |
+| `classes/player.py` | `tests/unit/classes/test_player.py` |
+| `classes/strategy.py` | `tests/unit/classes/test_strategy.py` |
+| `classes/team.py` | `tests/unit/classes/test_team.py` |
+| `classes/tournament.py` | `tests/unit/classes/test_tournament.py` |
+| `services/bid_recommendation_service.py` | `tests/unit/services/test_bid_recommendation_service.py` |
+| `services/draft_loading_service.py` | `tests/unit/services/test_draft_loading_service.py` |
+| `services/sleeper_draft_service.py` | `tests/unit/services/test_sleeper_draft_service.py` |
+| `services/tournament_service.py` | `tests/unit/services/test_tournament_service.py` |
+| `strategies/` | `tests/unit/strategies/test_strategy_coverage.py` (or dedicated file per strategy) |
+| `config/config_manager.py` | `tests/unit/config/test_config_manager.py` |
+| `config/settings.py` | `tests/unit/config/test_settings.py` |
+| `data/fantasypros_loader.py` | `tests/unit/data/test_fantasypros_loader.py` |
+| `cli/main.py` | `tests/unit/cli/test_main.py` |
+| `cli/commands/` | `tests/unit/cli/test_commands.py` |
+| `api/` routes | `tests/unit/api/` (one file per router) |
+| Cross-component / HTTP / DB | `tests/integration/` |
+| Hypothesis generative | `tests/property/test_<module>_properties.py` |
+
+### Fixture inventory (ADR-010 §3 — canonical sources)
+
+**`tests/conftest.py` (root scope — available everywhere):**
+- `sample_player` — single RB; position/budget defaults
+- `sample_players` — 14-player set (QB×1, RB×4, WR×3, TE×1, K×1, DST×1, FLEX×2 eligible)
+- `sample_team` — Budget=200
+- `sample_teams` — two teams
+- `sample_owner` — single owner
+- `sample_owners` — six owners (Alice–Frank)
+- `configured_draft` — fully assembled: 2 teams, 6 owners, all 14 players
+- `standard_roster_config` — `{QB:1, RB:2, WR:3, TE:1, K:1, DST:1, FLEX:2}`
+
+**`tests/unit/conftest.py` (unit scope only):**
+- `mock_config` — pre-wired `ConfigManager` mock; avoids repeated `patch('config.config_manager.load_config')` boilerplate
+- `mock_settings` — pre-wired `get_settings()` mock
+- `mock_sleeper_client` — HTTP-level mock for SleeperAPI
+- `patch_env_testing` — `autouse=True`; ensures `TESTING=true` for all unit tests
+
+**Factory fixtures (use when you need customized instances):**
+- `make_player` — factory returning a `Player` with overridable kwargs
+- `make_team` — factory returning a `Team` with overridable kwargs
+
+**Rule:** Use the shallowest conftest where the fixture is needed. Do not define a new fixture in a subdirectory conftest if one already exists in a parent conftest. Use `make_*` factory fixtures rather than re-defining nearly-identical instances.
+
+---
+
+## ADR-010 Compliance Rules
+
+### Directory placement
+
+Always place new tests in the correct subdirectory **before** writing any test code:
+
+| Test type | Location |
+|---|---|
+| Isolated, all deps mocked | `tests/unit/<domain>/test_<module>.py` |
+| Real HTTP, DB, or multi-component | `tests/integration/test_<scenario>.py` |
+| Hypothesis `@given` generative | `tests/property/test_<module>_properties.py` |
+
+**Prohibited locations for new tests:**
+- `tests/test_*.py` (root-level) — ADR-010 §2 forbids all new root-level test files
+- `tests/unit/test_<module>_sprint<N>.py` — no sprint-suffix variants
+- `tests/unit/test_<module>_v2.py` — no versioned variants
+- `tests/unit/test_<module>_security.py` — security tests belong in the canonical module file under a `TestSecurity<Concept>` class
+
+### Naming conventions (ADR-010 §4)
+
+**Test files:** `test_<module>.py` — mirrors the production module name, one file per module.
+
+**Test classes:**
+```python
+# Group by behavior cluster
+class TestBudgetEnforcement:        # ✅
+class TestSecurityPathTraversal:    # ✅ security tests
+class TestIssue116IndependentStrategyInstances:  # ✅ regression tests
+class TestAuction:                  # ❌ too broad
+```
+
+**Test functions:**
+```python
+# State what is asserted: test_<thing>_<condition>_<expected>
+def test_bid_exceeds_budget_raises_value_error():   # ✅
+def test_strategy_bid_zero_budget_returns_zero():   # ✅
+def test_it_works():                                # ❌ non-descriptive
+def test_happy_path():                              # ❌ non-descriptive
+```
+
+**Do NOT use `unittest.TestCase` for new tests.** Write plain pytest classes with no base class.
+
+### Marker taxonomy (ADR-010 §5)
+
+Always decorate every new test function or class with the correct marker. Never leave a test unmarked.
+
+```python
+@pytest.mark.unit         # isolated; no I/O; all deps mocked
+@pytest.mark.integration  # real I/O: DB, HTTP, filesystem, multi-component
+@pytest.mark.property     # Hypothesis @given
+@pytest.mark.slow         # runtime >2 s — ALWAYS additive, never sole marker
+@pytest.mark.simulation   # runs full Tournament.run() or Draft.run()
+@pytest.mark.ml           # imports torch/numpy/lab ML modules
+@pytest.mark.performance  # asserts wall-clock latency or memory usage
+```
+
+Additive example for a slow integration test:
+```python
+@pytest.mark.integration
+@pytest.mark.slow
+def test_full_draft_end_to_end_completes_in_budget():
+    ...
+```
+
+### xfail discipline for pre-development tests
+
+All tests you write will fail before implementation exists. Mark them explicitly so CI does not treat them as broken:
+
+```python
+@pytest.mark.unit
+@pytest.mark.xfail(strict=False, reason="Closes #<N> — <issue title>")
+def test_<behavior>_<condition>_<expected>():
+    ...
+```
+
+Use `strict=False` for open issues. When the issue is closed and tests pass, the developer's closing PR **must** remove the `xfail` decorator.
+
+If **every test in a file** is blocked by a single issue, use module-level `pytestmark`:
+```python
+pytestmark = [
+    pytest.mark.unit,
+    pytest.mark.xfail(strict=False, reason="Closes #<N> — <title>")
+]
+```
+
+### Conftest placement rule
+
+Before writing a new fixture, check whether one already exists:
+```bash
+grep -rn "def <fixture_name>" tests/conftest.py tests/unit/conftest.py tests/unit/<domain>/conftest.py
+```
+Only create a new fixture if none exists at the appropriate scope. Place it in the shallowest conftest where it is needed.
+
+---
+
+## Testing Strategy Selection
+
+For every acceptance criterion, choose the **minimum sufficient strategy** that provides meaningful confidence. Do not default to unit tests — match the strategy to the nature of the behavior being verified.
+
+### Strategy decision framework
+
+Ask these questions in order:
+
+1. **Does the behavior hold across a wide range of valid inputs, not just a few examples?**
+   → Use **property-based testing** (Hypothesis). Examples: bid functions, budget arithmetic, roster constraint logic, parser round-trips.
+
+2. **Does the behavior depend on a specific set of discrete inputs / configurations?**
+   → Use **parametrized unit tests** (`@pytest.mark.parametrize`). Examples: strategy type names, position codes, auction outcome categories.
+
+3. **Is the behavior a pure function or an isolated class method with all deps mockable?**
+   → Use a **unit test**. Examples: a single `calculate_bid()` call, a validation function, a config parser.
+
+4. **Does the behavior require real I/O, HTTP, or multiple components working together?**
+   → Use an **integration test** in `tests/integration/`. Examples: API routes, DB reads/writes, Sleeper HTTP responses.
+
+5. **Does the behavior require a complete `Draft.run()` or `Tournament.run()` loop?**
+   → Use a **simulation test** (`@pytest.mark.simulation @pytest.mark.slow`). Examples: end-to-end budget enforcement, elimination bracket correctness.
+
+6. **Is this a regression for a known past bug?**
+   → Use a **regression unit test** in a `TestIssue<N>` class inside the canonical test file. The test name must reference the issue number.
+
+**Default rule:** If steps 1–2 apply, use property-based or parametrized tests. Unit tests for single examples are the fallback when the input space is genuinely small and fixed.
+
+---
+
+## Testing Strategy Templates
+
+### 1. Unit test
+
+Use for: isolated behavior with a fixed, known input/output pair; one scenario per test function.
+
+```python
+import pytest
+from classes.auction import Auction
+
+
+class TestBudgetEnforcement:
+    @pytest.mark.unit
+    @pytest.mark.xfail(strict=False, reason="Closes #<N> — <title>")
+    def test_bid_exceeds_budget_raises_value_error(self, sample_team):
+        # Arrange
+        auction = Auction(team=sample_team)
+
+        # Act / Assert
+        with pytest.raises(ValueError, match="exceeds remaining budget"):
+            auction.place_bid(amount=sample_team.budget + 1)
+```
+
+### 2. Parametrized unit test
+
+Use for: the same assertion holds across a discrete set of distinct inputs. Prefer over writing N near-identical test functions.
+
+```python
+import pytest
+from strategies import STRATEGY_REGISTRY
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize("strategy_name", list(STRATEGY_REGISTRY.keys()))
+@pytest.mark.xfail(strict=False, reason="Closes #<N> — <title>")
+def test_every_registered_strategy_returns_non_negative_bid(strategy_name, sample_player, sample_team):
+    strategy = STRATEGY_REGISTRY[strategy_name]()
+    bid = strategy.calculate_bid(sample_player, remaining_budget=100)
+    assert bid >= 0
+
+
+# Parametrize with explicit ids for readability
+@pytest.mark.unit
+@pytest.mark.parametrize("position,expected_min_bid", [
+    ("QB", 1),
+    ("K",  1),
+    ("DST", 1),
+], ids=["quarterback", "kicker", "defense"])
+@pytest.mark.xfail(strict=False, reason="Closes #<N> — <title>")
+def test_minimum_bid_by_position(position, expected_min_bid, make_player):
+    player = make_player(position=position)
+    strategy = BaseStrategy()
+    assert strategy.calculate_bid(player, remaining_budget=200) >= expected_min_bid
+```
+
+**Rules:**
+- Always provide `ids=` when parametrize values are not self-documenting
+- Each parametrize combination gets its own `xfail` guard automatically
+- Do not parametrize over more than ~20 values; use property-based testing instead
+
+### 3. Property-based test (Hypothesis)
+
+Use for: invariants that must hold for **any** valid input — especially numeric/financial logic, parsers, serialization round-trips, and constraint systems. These are the highest-value tests for this domain.
+
+```python
+import pytest
+from hypothesis import given, settings, assume
+from hypothesis import strategies as st
+from classes.auction import Auction
+from classes.team import Team
+
+
+@pytest.mark.property
+@pytest.mark.xfail(strict=False, reason="Closes #<N> — <title>")
+@given(
+    budget=st.integers(min_value=1, max_value=1000),
+    bid=st.integers(min_value=0, max_value=2000),
+)
+def test_bid_never_exceeds_budget_invariant(budget, bid):
+    """A placed bid must never exceed the team's remaining budget."""
+    team = Team(budget=budget)
+    auction = Auction(team=team)
+    assume(bid <= budget)  # only test valid bids
+    auction.place_bid(amount=bid)
+    assert team.remaining_budget == budget - bid
+
+
+@pytest.mark.property
+@pytest.mark.xfail(strict=False, reason="Closes #<N> — <title>")
+@given(
+    budget=st.integers(min_value=1, max_value=1000),
+    bid=st.integers(min_value=1, max_value=2000),
+)
+def test_bid_above_budget_always_raises(budget, bid):
+    """Any bid above remaining budget must raise ValueError without exception."""
+    assume(bid > budget)
+    team = Team(budget=budget)
+    auction = Auction(team=team)
+    with pytest.raises(ValueError):
+        auction.place_bid(amount=bid)
+```
+
+**Hypothesis patterns for this codebase:**
+
+| Scenario | Strategy |
+|---|---|
+| Any valid player | Use `draft_player` composite strategy from `tests/property/conftest.py` |
+| Any valid team | Use `draft_team` from `tests/property/conftest.py` |
+| Any full draft state | Use `draft_state` from `tests/property/conftest.py` |
+| Budget values | `st.integers(min_value=1, max_value=1000)` |
+| Bid values | `st.integers(min_value=0, max_value=2000)` |
+| Position codes | `st.sampled_from(["QB", "RB", "WR", "TE", "K", "DST", "FLEX"])` |
+| Strategy names | `st.sampled_from(list(STRATEGY_REGISTRY.keys()))` |
+| Player names/strings | `st.text(min_size=1, max_size=50, alphabet=st.characters(whitelist_categories=("Lu", "Ll", "Nd", "Zs")))` |
+| Percentile rank (0–1) | `st.floats(min_value=0.0, max_value=1.0, allow_nan=False)` |
+
+**`assume()` discipline:** Use `assume()` to filter invalid combinations, not to hide bugs. If you need more than 2–3 `assume()` calls, define a tighter `st.builds()` composite strategy instead.
+
+**`@settings` usage:**
+```python
+# Default is sufficient for most cases. Use these when needed:
+@settings(max_examples=500)   # more thorough — use for critical financial invariants
+@settings(max_examples=20)    # faster — use for slow integration-adjacent properties
+@settings(deadline=None)      # disable timing limit — use for simulation-heavy tests
+```
+
+**When to use property tests vs. unit tests:**
+- Budget arithmetic, bid clamping, constraint enforcement → **property** (any integer should work)
+- Roster limit validation → **property** (any combination of positions)
+- Strategy registry lookup → **parametrized unit** (finite set of known strategy names)
+- Specific error message text → **unit** (exact string is a fixed contract)
+
+### 4. Integration test
+
+Use for: behaviors that require real FastAPI routing, real config loading, or multiple components cooperating. Do not mock at the integration boundary.
+
+```python
+import pytest
+from httpx import AsyncClient
+
+
+@pytest.mark.integration
+@pytest.mark.xfail(strict=False, reason="Closes #<N> — <title>")
+async def test_recommend_bid_endpoint_returns_200_for_valid_player(test_client, api_key_header):
+    response = await test_client.post(
+        "/recommend-bid",
+        json={"player_name": "Patrick Mahomes", "position": "QB"},
+        headers=api_key_header,
+    )
+    assert response.status_code == 200
+    assert "bid" in response.json()
+
+
+@pytest.mark.integration
+@pytest.mark.xfail(strict=False, reason="Closes #<N> — <title>")
+async def test_recommend_bid_endpoint_rejects_missing_api_key(test_client):
+    response = await test_client.post(
+        "/recommend-bid",
+        json={"player_name": "Patrick Mahomes", "position": "QB"},
+    )
+    assert response.status_code == 403
+```
+
+### 5. Simulation test
+
+Use for: full `Draft.run()` or `Tournament.run()` loops that verify end-to-end invariants (budget never goes negative, rosters complete, no duplicate player assignments).
+
+```python
+import pytest
+
+
+@pytest.mark.simulation
+@pytest.mark.slow
+@pytest.mark.xfail(strict=False, reason="Closes #<N> — <title>")
+def test_full_auction_draft_no_team_exceeds_budget(configured_draft):
+    configured_draft.run()
+    for team in configured_draft.teams:
+        assert team.total_spend <= team.budget
+
+
+@pytest.mark.simulation
+@pytest.mark.slow
+@pytest.mark.xfail(strict=False, reason="Closes #<N> — <title>")
+def test_full_draft_assigns_no_player_twice(configured_draft):
+    configured_draft.run()
+    all_won_players = [
+        player
+        for team in configured_draft.teams
+        for player in team.roster
+    ]
+    assert len(all_won_players) == len(set(p.name for p in all_won_players))
+```
+
+### 6. Regression test
+
+Use for: a bug that was once in production. The test name and class must reference the issue number.
+
+```python
+import pytest
+
+
+class TestIssue247BudgetMutationAfterCacheLookup:
+    """Regression for #247 — cached bid recommendation mutated the shared team budget."""
+
+    @pytest.mark.unit
+    @pytest.mark.xfail(strict=False, reason="Closes #247 — cache mutation bug")
+    def test_second_recommendation_call_does_not_mutate_budget(self, sample_team, mock_config):
+        service = BidRecommendationService(config_manager=mock_config)
+        budget_before = sample_team.budget
+        service.recommend(sample_team, player_name="CMC")
+        service.recommend(sample_team, player_name="CMC")  # second call — uses cache
+        assert sample_team.budget == budget_before
+```
+
+---
+
+## Multi-Strategy Coverage Requirement
+
+For any acceptance criterion that involves **numeric computation, constraint enforcement, or data transformation**, you must write tests at **more than one layer**:
+
+| AC type | Required strategies |
+|---|---|
+| Budget / financial arithmetic | Property-based (arbitrary integers) + unit (zero budget, max budget edge cases) |
+| Roster constraint | Property-based (arbitrary position combinations) + parametrized unit (each position code) |
+| Strategy bid calculation | Parametrized unit (all registered strategies) + property-based (arbitrary budget) |
+| API endpoint behavior | Integration (real HTTP) + unit (request/response schema validation) |
+| CLI command | Unit (argument parsing) + integration (subprocess / TestClient) |
+| Parser / serializer | Property-based round-trip (`encode → decode == original`) + unit (malformed input) |
+| Config loading | Unit (key present, key missing, wrong type) |
+
+Do not satisfy a multi-layer AC with only a single unit test example. The property-based or parametrized layer is not optional for numeric/constraint behaviors.
+
+---
+
+## Workflow
+
+### Step 1 — Read the issue
+
+```bash
+gh issue view <ISSUE_NUMBER> --json number,title,body,labels --jq '{number: .number, title: .title, body: .body, labels: [.labels[].name]}'
+```
+
+Extract:
+1. The acceptance criteria (look for checkboxes, "must", "should", "expects" language)
+2. The production module(s) involved
+3. Whether any linked ADR changes the test expectations
+
+If **no acceptance criteria are present**, block immediately:
+```bash
+gh issue comment <ISSUE_NUMBER> --body "**Test Definition Agent — BLOCKED**
+
+No acceptance criteria found. Tests cannot be written without verifiable criteria.
+
+@Requirements Agent: please add acceptance criteria to this issue before Test Definition Agent can proceed. Criteria should specify:
+- The input or precondition
+- The action under test
+- The expected observable output or side effect"
+```
+
+Do not proceed until acceptance criteria are added.
+
+### Step 2 — Locate the canonical test file
+
+```bash
+# Find the existing canonical test file for the module
+find tests/unit -name "test_<module>.py"
+```
+
+If the canonical file does not yet exist (new module), create it in the correct subdirectory with a module docstring and the required imports. Do not create files in `tests/` root.
+
+### Step 3 — Identify the right fixture(s)
+
+Check root and unit conftest before creating anything new:
+```bash
+grep -n "^def \|^@pytest.fixture" tests/conftest.py tests/unit/conftest.py
+```
+
+Use the smallest fixture that satisfies the test. Prefer `sample_player` over building a player from scratch. Use `mock_config` instead of patching `ConfigManager` inline.
+
+### Step 4 — Choose strategies and write the failing tests
+
+First, apply the strategy selection framework from the **Testing Strategy Selection** section above to each acceptance criterion. Then write tests at every required layer.
+
+For each acceptance criterion, cover at minimum:
+
+| Coverage type | Requirement |
+|---|---|
+| Happy path | One clear assertion about the success case |
+| Edge/boundary | At least one boundary condition (zero budget, empty list, max roster size, single item) |
+| Failure mode | At least one error path (`pytest.raises`, invalid input, missing data) |
+| Invariant (if numeric/constraint) | A property-based test asserting the invariant holds for arbitrary valid inputs |
+
+Select the template from **Testing Strategy Templates** that matches. For behaviors involving numeric logic or constraint enforcement, write both a unit test (specific examples) and a property test (arbitrary inputs). For behaviors with a discrete set of configurations, use `@pytest.mark.parametrize` instead of duplicating test functions.
+
+Template for a test that requires internal implementation details not yet defined:
+```python
+@pytest.mark.unit  # or @pytest.mark.property — whichever is appropriate
+@pytest.mark.xfail(strict=False, reason="Closes #<N> — <title>")
+@pytest.mark.skip(reason="requires dev input: method signature not yet defined")
+def test_<behavior>_<condition>_<expected>():
+    """
+    Expected behavior: <describe what this test must assert once implemented>
+    Acceptance criterion: <copy the AC text from the issue>
+    Suggested strategy: unit | property-based | parametrized | integration
+    """
+    raise NotImplementedError("Test body to be completed by development")
+```
+
+### Step 5 — Verify the tests fail
+
+Run the tests to confirm they fail (not error) before implementation:
+```bash
+source venv/bin/activate
+pytest tests/unit/<domain>/test_<module>.py::<TestClass> -v 2>&1 | tail -30
+```
+
+An `xfail` result is acceptable. A collection error (import error, syntax error) is not — fix it before committing.
+
+### Step 6 — Commit and signal readiness
+
+```bash
+git add tests/unit/<domain>/test_<module>.py
+git commit -m "test(#<N>): define failing tests for <issue title>
+
+Tests are xfail-guarded (strict=False) pending implementation.
+Closes #<N> once implementation passes all assertions."
+```
+
+Apply the label and comment:
+```bash
+gh issue edit <ISSUE_NUMBER> --add-label "qa:tests-defined"
+gh issue comment <ISSUE_NUMBER> --body "**Test Definition Agent — Phase 1 Complete**
+
+Failing tests committed for this issue. Tests are \`xfail\`-guarded and will become active once implementation lands.
+
+**Tests defined:**
+$(grep -n "def test_" tests/unit/<domain>/test_<module>.py | sed 's/.*def /- /' | sed 's/(.*$//')
+
+**File:** \`tests/unit/<domain>/test_<module>.py\`
+**Marker:** \`@pytest.mark.unit\` (or as appropriate)
+
+Development may now pick up this issue. The \`xfail\` decorators must be removed in the closing PR once all tests pass."
+```
+
+---
+
+## Decision Table: Strategy Selection by Situation
+
+| Situation | Strategy | Location |
+|---|---|---|
+| Acceptance criteria are clear; signature is known; fixed inputs | Unit test with `xfail` | `tests/unit/<domain>/` |
+| Same assertion must hold for multiple known configurations | Parametrized unit test | `tests/unit/<domain>/` |
+| Invariant must hold for any valid input (budget, bid, constraint) | Property-based test (Hypothesis) | `tests/property/test_<module>_properties.py` |
+| Invariant **and** specific examples both required | Both property + unit | Both locations |
+| Production class exists; method signature unknown | `@pytest.mark.skip` stubs with docstring describing assertion requirements | `tests/unit/<domain>/` |
+| New class/module; nothing exists yet | Stubs with `NotImplementedError` body; docstring includes suggested strategy | `tests/unit/<domain>/` |
+| Test needs real HTTP or DB | Integration test | `tests/integration/` |
+| Test requires full `Draft.run()` or `Tournament.run()` | Simulation test | `tests/integration/` |
+| Known past bug | Regression test in `TestIssue<N>` class | `tests/unit/<domain>/` |
+| Issue links an ADR | Encode each ADR QA criterion; choose strategy per criterion | Appropriate location |
+
+**Principle:** A single acceptance criterion often warrants tests at two layers — a property-based test for the invariant and a unit test for specific edge cases. This is expected, not redundant.
+
+---
+
+## ADR-010 Migration Awareness
+
+The test suite is undergoing a multi-phase refactor (ADR-010, Sprints 13–15). When writing new tests, always target the **post-refactor structure** even if the current file system still has the old layout:
+
+- **Never add tests to sprint-labeled files** (`test_auction_sprint9.py`). If one exists, add to the canonical file instead (`test_auction.py`).
+- **Never add new root-level test files.** Even if `tests/test_new_feature.py` seems convenient, put the file in the correct `tests/unit/` subdirectory.
+- **Do not subclass `BaseTestCase`.** It is being retired. Use plain pytest classes and root conftest fixtures.
+- **Do not redefine `sample_players` or `configured_draft`** in a subdirectory conftest. The root conftest owns those fixtures; use them directly.
+- **Coverage gate awareness:**
+
+| Sprint | Gate | Your tests contribute |
+|---|---|---|
+| Sprint 13 | 70% | Ensure new tests do not break the gate |
+| Sprint 14 | 85% | Aim for full branch coverage of new behavior |
+| Sprint 15 | 90% | All strategy branches, config paths, and CLI commands must be reachable |
+
+- **Branch coverage is on** (`branch = true` in `pyproject.toml`). Write tests that exercise all conditional branches, not just the main path.
+
+---
+
+## Common Anti-Patterns to Avoid
+
+| Anti-pattern | Correct approach |
+|---|---|
+| Writing only unit tests for numeric/financial logic | Add a Hypothesis property test asserting the invariant for arbitrary integers |
+| Writing N near-identical unit tests with different hardcoded values | Use `@pytest.mark.parametrize` with an explicit `ids=` list |
+| `assume()` used to silently skip >30% of generated inputs | Define a tighter `st.builds()` composite strategy instead |
+| Property test has no `assume()` and accepts logically impossible inputs | Use `assume()` to filter preconditions; document why |
+| Integration test mocks the HTTP client | Remove the mock; integration tests must exercise real I/O |
+| Unit test makes a real HTTP call or reads a real file | Move to integration; or mock the I/O dependency |
+| `assert True` or no assertion | Assert the specific return value, side effect, or exception |
+| Over-mocking: mocking the class under test | Mock only external dependencies (DB, HTTP, file I/O) |
+| Test passes trivially before implementation | Confirm `xfail` or verify the test actually fails by running it |
+| Placing security tests in `test_<module>_security.py` | Add a `TestSecurity<Concept>` class inside the canonical `test_<module>.py` |
+| Naming `test_it_works()` | Name the test after what it asserts: `test_bid_at_budget_cap_raises_value_error` |
+| Adding a test to a sprint-labeled file | Add to the canonical file; sprint-labeled files are being eliminated |
+| Using `self.test_config` from `BaseTestCase` | Use `mock_config` or `default_draft_config` fixtures from conftest |
+| One test function asserts multiple unrelated things | Split into separate focused tests; one behavior per test function |

--- a/docs/adr/ADR-010-testing-refactor.md
+++ b/docs/adr/ADR-010-testing-refactor.md
@@ -1,0 +1,710 @@
+# ADR-010: Testing Infrastructure Refactor
+
+**Date:** 2026-05-13  
+**Status:** Proposed  
+**Supersedes:** (none — first architectural specification for the test suite)  
+**Affected sprints:** Sprint 13 → Sprint 15
+
+---
+
+## 1. ADR Header
+
+### Title
+Consolidate and refactor the test suite: eliminate sprint-labeled duplication, establish a stable directory hierarchy, define fixture ownership, introduce a coverage toolchain, and harden marker discipline.
+
+### Context
+The test suite has grown organically across twelve sprints. The result is structural debt in three forms:
+
+1. **Directory duplication.** Twenty-eight root-level test files shadow `unit/` subdirectories that already own those domains. Sprint-labeled suffixes (`_sprint9.py`) further fragment coverage for the same modules.
+2. **Fixture drift.** `tests/conftest.py` and `tests/unit/classes/conftest.py` define overlapping `sample_players` / `configured_draft` fixtures with subtly different shapes (11-player set vs. 14-player set; 2-owner vs. 6-owner). `BaseTestCase` in `test_base.py` duplicates fixture construction in an `unittest` idiom that does not compose with pytest parametrize or Hypothesis.
+3. **Toolchain gaps.** `pyproject.toml` has no `[tool.coverage.*]` sections. `pytest.ini` has no `addopts`. The `make coverage` Makefile target inlines coverage flags directly into the shell command, making them invisible to IDEs and pre-commit hooks. The Makefile `help` text advertises an 85% gate while the inline flag enforces 90% — a silent inconsistency.
+
+### Decision
+Restructure `tests/` into four stable subdirectories (`unit/`, `integration/`, `property/`, and root infrastructure). Eliminate sprint-labeled file variants by merging them into their canonical counterparts. Migrate all coverage and pytest configuration into `pyproject.toml`. Adopt a three-phase `fail_under` ramp (70 → 85 → 90).
+
+### Consequences
+
+**Positive**
+- Single authoritative file per production module; no sprint-suffix lookup required
+- Fixture conflicts resolved through explicit scope and override rules
+- `pyproject.toml` becomes the single source of truth for coverage config — IDE, CLI, and CI read the same values
+- `make test` and `make coverage` produce consistent results regardless of execution context
+- `--strict-markers` prevents undeclared marker typos from silently passing
+
+**Negative / Risks**
+- Large move-and-merge operation risks transient CI failure if done as a single PR; see §7 for sequenced migration
+- Sprint regression test classes inherit from `unittest.TestCase`; merge targets must preserve `unittest`-compatible assertions or convert them to bare `assert` statements
+- The `property` marker is declared in `pytest.ini` but is absent from `REQUIRED_MARKS` in `test_pytest_marks.py`; this gap must be closed during migration (Phase 1)
+
+---
+
+## 2. Target Directory Tree
+
+The tree below shows the **desired state** after the refactor.  
+`[M]` = merge of two or more existing files.  
+`[←]` = moved from root `tests/` without structural change.  
+`[N]` = new file (infrastructure only, not a test file).  
+Files without annotation already exist at the shown path.
+
+```
+tests/
+│
+├── conftest.py                         # root scope — canonical shared fixtures (§3)
+├── pytest.ini                          # retained; addopts + markers updated (§6)
+├── __init__.py
+│
+├── integration/                        # NEW subtree — replaces test_integration.py
+│   ├── __init__.py                     [N]
+│   ├── conftest.py                     [N]  real HTTP client, temp DB, env overrides
+│   ├── test_api_integration.py         [←] from test_integration.py + test_data_api.py (API routes)
+│   ├── test_draft_end_to_end.py        [←] from test_project.py (end-to-end simulation)
+│   └── test_ping.py                    [←] from test_ping_format.py
+│
+├── unit/
+│   ├── __init__.py
+│   ├── conftest.py                     [N]  unit-scope helpers: mock_config, patch_settings
+│   ├── test_pytest_marks.py            [M]  add 'property' to REQUIRED_MARKS
+│   │
+│   ├── api/
+│   │   ├── __init__.py
+│   │   ├── test_auth.py
+│   │   ├── test_api_key_security.py
+│   │   ├── test_recommend_bid.py
+│   │   ├── test_schemas.py
+│   │   └── test_sleeper_api.py
+│   │
+│   ├── classes/
+│   │   ├── __init__.py
+│   │   ├── conftest.py                 [M]  keep existing; remove sample_players/configured_draft
+│   │   │                                    (root conftest becomes canonical for those)
+│   │   ├── test_auction.py             [M]  test_auction.py
+│   │   │                                    + test_auction_sprint9.py      (§115)
+│   │   │                                    + test_auction_budget.py       (root)
+│   │   │                                    + test_auction_enforcement.py  (root)
+│   │   │                                    + test_budget_violation.py     (root)
+│   │   │                                    + test_multilevel_constraints.py (root)
+│   │   │                                    + test_integer_budgets.py      (root, auction portion)
+│   │   │                                    + F811 auction regression      (from test_f811_regressions.py)
+│   │   │                                    + Sprint 7b auction regression (from test_sprint7b_regressions.py)
+│   │   ├── test_draft.py
+│   │   ├── test_draft_setup.py         [M]  test_draft_setup.py
+│   │   │                                    + test_draft_setup_layering.py (§358)
+│   │   │                                    + test_roster_logic.py        (root)
+│   │   ├── test_owner.py               [M]  test_owner.py + test_owner_sprint9.py (§118)
+│   │   ├── test_player.py              [M]  test_player.py + test_player_sprint9.py (§120)
+│   │   ├── test_strategy.py            [←]  from test_classes.py (classes/strategy.py tests)
+│   │   ├── test_team.py                [M]  test_team.py + test_team_sprint9.py (§117)
+│   │   └── test_tournament.py          [M]  test_tournament.py
+│   │                                        + test_tournament_sprint9.py  (§119)
+│   │                                        + Sprint 7 tournament regressions (#116, #113)
+│   │                                        + Sprint 7b regressions       (#114, #110, #112)
+│   │
+│   ├── cli/
+│   │   ├── __init__.py
+│   │   ├── test_cli_season_default.py
+│   │   ├── test_commands.py            [M]  test_commands.py + test_commands_decomposition.py (§366)
+│   │   └── test_main.py
+│   │
+│   ├── config/
+│   │   ├── __init__.py
+│   │   ├── test_config_manager.py      [M]  test_config_manager.py
+│   │   │                                    + test_config_manager_sprint9.py (#163, #164)
+│   │   │                                    + test_config_consolidation.py  (#359)
+│   │   │                                    + Sprint 7c config regression   (from test_sprint7c_regressions.py)
+│   │   └── test_settings.py            [←]  from test_settings_sprint9.py (#162)
+│   │
+│   ├── data/
+│   │   ├── __init__.py
+│   │   └── test_fantasypros_loader.py  [M]  test_fantasypros_loader.py
+│   │                                        + test_fantasypros_loader_sprint9.py (#167, #166)
+│   │                                        + test_fantasypros_loader_security.py (#165)
+│   │                                        + test_fantasypros.py          (root)
+│   │                                        + test_data_api.py             (root, data-loader portion)
+│   │
+│   ├── lab/
+│   │   ├── __init__.py
+│   │   ├── test_auction_replay.py
+│   │   ├── test_experiment_config.py
+│   │   ├── test_gridiron_sage.py       [←]  from root test_gridiron_sage.py
+│   │   ├── test_lab_ci_pipeline.py
+│   │   ├── test_lab_results_db.py      [←]  from root test_lab_results_db.py
+│   │   ├── test_simulation_runner.py   [M]  test_simulation_runner.py
+│   │   │                                    + test_lab_simulation_runner.py (root, #257)
+│   │   └── test_sleeper_auction_scraper.py [M] test_sleeper_auction_scraper.py
+│   │                                        + test_lab_sleeper_scraper.py  (root, #235)
+│   │
+│   ├── services/
+│   │   ├── __init__.py
+│   │   ├── test_bid_recommendation_service.py [M] test_bid_recommendation_service.py
+│   │   │                                          + test_bid_recommendation_service_sprint9.py
+│   │   │                                          + Sprint 8 BRS regression (#246 cache mutation)
+│   │   ├── test_draft_loading_service.py      [M] test_draft_loading_service.py
+│   │   │                                          + Sprint 7b regression    (#131 no-timer-threads)
+│   │   │                                          + Sprint 8 regressions    (#FLEX triple-count, #data-path)
+│   │   ├── test_sleeper_draft_service.py      [M] test_sleeper_draft_service.py
+│   │   │                                          + test_sleeper_draft_service_sprint9.py
+│   │   └── test_tournament_service.py         [M] test_tournament_service.py
+│   │                                              + test_tournament_service_security.py (#133)
+│   │                                              + test_tournament_service_sprint9.py
+│   │                                              + Sprint 7 regression     (#132 KeyError)
+│   │                                              + Sprint 8 regression     (#elimination-tournament)
+│   │
+│   ├── strategies/
+│   │   ├── __init__.py
+│   │   ├── test_base_strategy.py       [M]  test_base_strategy.py
+│   │   │                                    + Sprint 7 regression  (#144 kwargs forwarding)
+│   │   │                                    + F811 base_strategy   (from test_f811_regressions.py)
+│   │   │                                    + Sprint 8 regressions (#aggressive-guard, #sigmoid-attrs)
+│   │   ├── test_position_targets_hardcoding.py
+│   │   ├── test_spending_strategy_analyzer.py
+│   │   ├── test_strategy_config.py
+│   │   ├── test_strategy_coverage.py   [M]  test_strategy_coverage.py
+│   │   │                                    + test_strategies.py   (root)
+│   │   │                                    + test_strategy_bids.py (root)
+│   │   │                                    + test_market_inflation.py  (root)
+│   │   │                                    + test_inflation_behavior.py (root)
+│   │   │                                    + Sprint 8 regressions (#vor-scaling-factor, #mandatory-pos)
+│   │   ├── test_strategy_registration.py
+│   │   └── test_vor_strategy.py
+│   │
+│   └── utils/
+│       ├── __init__.py
+│       ├── test_cheatsheet_parser.py   [←]  from test_cheatsheet_parser_sprint9.py (#168)
+│       ├── test_market_tracker.py      [←]  from test_market_tracker_sprint9.py (#169)
+│       ├── test_print_module.py
+│       ├── test_sleeper_cache.py       [←]  from test_sleeper_cache_sprint9.py (#170)
+│       └── test_utils_coverage.py
+│
+└── property/
+    ├── __init__.py
+    ├── conftest.py                     # existing — Hypothesis profiles + composite strategies
+    ├── test_api_deps_properties.py
+    ├── test_auction_class_properties.py
+    ├── test_auction_properties.py
+    ├── test_base_strategy_properties.py
+    ├── test_bid_recommendation_service_properties.py
+    ├── test_cheatsheet_parser_properties.py
+    ├── test_config_properties.py
+    ├── test_data_properties.py
+    ├── test_draft_loading_service_properties.py
+    ├── test_draft_properties.py
+    ├── test_draft_setup_properties.py
+    ├── test_owner_properties.py
+    ├── test_path_utils_properties.py
+    ├── test_placeholder.py
+    ├── test_recommend_schema_properties.py
+    ├── test_sigmoid_strategy_properties.py
+    ├── test_simulation_runner_properties.py
+    ├── test_sleeper_cache_properties.py
+    ├── test_spending_analyzer_properties.py
+    ├── test_strategy_properties.py
+    ├── test_strategy_registry_properties.py
+    ├── test_team_properties.py
+    ├── test_tournament_properties.py
+    ├── test_tournament_service_properties.py
+    └── test_vor_strategy_properties.py
+```
+
+### File count reconciliation
+
+| Area | Before | After (target) | Change |
+|---|---|---|---|
+| `tests/` root test files | 28 | 0 (all migrated) | −28 |
+| `tests/unit/` (all subdirs) | 56 | 43 | −13 (sprint merges) |
+| `tests/integration/` | 0 | 3 | +3 |
+| `tests/property/` | 25 | 25 | 0 |
+| Infrastructure (`__init__`, `conftest`) | 7 | 11 | +4 |
+| **Total test files** | **108** | **71** | **−37** |
+
+The 37-file reduction comes entirely from merging sprint-labeled variants into canonical files; no tests are deleted.
+
+---
+
+## 3. Fixture Hierarchy Design
+
+### Scope resolution order
+
+pytest resolves fixtures nearest-first: a local conftest shadows a parent conftest fixture of the same name. The design below assigns each fixture to the highest scope at which it is _universally_ needed, preventing leakage upward.
+
+```
+tests/conftest.py                    ← widest scope (root)
+  └── tests/unit/conftest.py         ← unit scope
+        └── tests/unit/classes/conftest.py  ← classes scope
+  └── tests/integration/conftest.py  ← integration scope
+  └── tests/property/conftest.py     ← property scope
+```
+
+### `tests/conftest.py` — Root scope
+
+Owns **domain data factories** needed by unit, integration, and property tests alike.
+
+| Fixture | Type | Scope | Notes |
+|---|---|---|---|
+| `sample_player` | `Player` | `function` | Single RB; position/budget defaults |
+| `sample_players` | `list[Player]` | `function` | 11-player set (QB×1, RB×4, WR×3, TE×1, K×1, DST×1) — **canonical**; `unit/classes/conftest.py` currently uses 14; resolve by adopting the 14-player set here and retiring the local override |
+| `sample_team` | `Team` | `function` | Budget=200 |
+| `sample_teams` | `list[Team]` | `function` | Two teams |
+| `sample_owner` | `Owner` | `function` | Single owner |
+| `sample_owners` | `list[Owner]` | `function` | Six owners (Alice–Frank); expand root from 2 to 6 to match the richer `classes/conftest.py` set |
+| `configured_draft` | `Draft` | `function` | Fully assembled: 2 teams, 2 owners, all 14 players |
+| `standard_roster_config` | `dict` | `session` | `{QB:1, RB:2, WR:3, TE:1, K:1, DST:1, FLEX:2}` — add FLEX |
+
+**`BaseTestCase` / `TestDataGenerator` pattern mapping:**
+
+`test_base.py::BaseTestCase.setUp` builds `self.test_config` and exposes `create_mock_player` / `create_mock_team` helpers. These map to named fixtures as follows:
+
+| `BaseTestCase` pattern | Target fixture | Location |
+|---|---|---|
+| `self.test_config` | `default_draft_config` | `tests/conftest.py` |
+| `create_mock_player(...)` | `sample_player` (parametrized via factory fixture) | `tests/conftest.py` |
+| `create_mock_team(...)` | `sample_team` | `tests/conftest.py` |
+| `TestDataGenerator` | Hypothesis strategies in `tests/property/conftest.py` | existing |
+
+`test_base.py` itself is **retired** after migration; no new `unittest.TestCase` subclass infrastructure is added.
+
+### `tests/unit/conftest.py` — Unit scope (new)
+
+Owns **mock/patch helpers** that are only meaningful in isolated unit tests — not in integration or property tests.
+
+| Fixture | Type | Scope | Purpose |
+|---|---|---|---|
+| `mock_config` | `MagicMock` | `function` | Pre-wired `ConfigManager` mock; eliminates the repeated `patch('config.config_manager.load_config')` boilerplate in `test_vor_strategy.py` and 9 other files |
+| `mock_settings` | `MagicMock` | `function` | Pre-wired `get_settings()` mock |
+| `mock_sleeper_client` | `MagicMock` | `function` | HTTP-level mock for SleeperAPI calls |
+| `patch_env_testing` | `None` | `session` | `autouse=True`; ensures `TESTING=true` is set for the entire unit run (currently done via `os.environ.setdefault` in root conftest — move the `autouse` session fixture here so integration tests can override it) |
+
+### `tests/unit/classes/conftest.py` — Classes scope (existing, trimmed)
+
+After the root conftest absorbs the canonical `sample_players` / `configured_draft` / `sample_owners`, this conftest retains only fixtures that are **specific to class-layer tests**:
+
+| Fixture | Retain? | Notes |
+|---|---|---|
+| `sample_players` | **Remove** — defer to root conftest | Conflict resolved by root winning |
+| `sample_teams` | **Remove** — defer to root conftest | |
+| `sample_owners` | **Remove** — defer to root conftest | |
+| `configured_draft` | **Remove** — defer to root conftest | |
+| `standard_roster_config` | **Remove** — defer to root conftest | |
+| `comprehensive_players` | **Keep** | 44-player list; only used in `test_team.py` realistic scenario |
+
+The resulting `unit/classes/conftest.py` will be ≤30 lines.
+
+### `tests/integration/conftest.py` — Integration scope (new)
+
+| Fixture | Type | Scope | Purpose |
+|---|---|---|---|
+| `test_client` | `httpx.AsyncClient` | `function` | Real FastAPI `TestClient` for route-level tests |
+| `temp_db` | `AsyncSession` | `function` | In-memory SQLite; `aiosqlite` backend |
+| `api_key_header` | `dict` | `session` | `{"X-API-Key": os.environ["PIGSKIN_API_KEY"]}` |
+
+### `tests/property/conftest.py` — Property scope (existing, unchanged)
+
+Already well-structured with Hypothesis profiles and composite strategies (`draft_player`, `draft_team`, `draft_state`). No changes required; see §7 Phase 0 for the one gap to close (adding `draft_state`).
+
+---
+
+## 4. Naming Convention Rules
+
+### 4.1 Test files
+
+| Rule | Pattern | Example |
+|---|---|---|
+| Mirror the production module name | `test_<module>.py` | `test_tournament_service.py` |
+| One file per production module | No suffixes | ~~`test_auction_sprint9.py`~~ |
+| Security tests co-located | Not a separate `_security.py` file; use a `TestSecurity*` class inside the canonical file | `test_tournament_service.py::TestSecurityCWDPath` |
+| Integration test files describe the interaction, not the module | `test_<scenario>.py` | `test_draft_end_to_end.py` |
+| Property test files use `_properties` suffix | `test_<module>_properties.py` | `test_auction_properties.py` |
+
+**Prohibited patterns:**
+- `test_<module>_sprint<N>.py` — sprint-labeled variants
+- `test_<module>_v2.py` — versioned variants
+- `test_<module>_security.py` — security as a separate top-level file
+
+### 4.2 Test classes
+
+| Rule | Pattern | Example |
+|---|---|---|
+| Group by behavior cluster | `Test<FeatureOrConcept>` | `TestBudgetEnforcement` |
+| Security tests use explicit prefix | `TestSecurity<Concept>` | `TestSecurityPathTraversal` |
+| Regression tests reference the issue | `TestIssue<N><ShortName>` | `TestIssue116IndependentStrategyInstances` |
+| No `Base` prefix unless it is genuinely abstract | `TestBase...` reserved for helpers with no test methods | — |
+
+**Do not use** `unittest.TestCase` for new tests. Existing `unittest.TestCase` subclasses migrated from sprint regression files may be left as-is for the duration of the migration sprint; conversion to plain pytest classes is a follow-up.
+
+### 4.3 Test functions
+
+| Rule | Pattern | Example |
+|---|---|---|
+| State what is asserted | `test_<thing>_<condition>_<expected>` | `test_bid_exceeds_budget_raises_value_error` |
+| Parametrized tests describe the variant | `test_<thing>[<id>]` via `pytest.mark.parametrize` ids | `test_strategy_bid[aggressive]` |
+| Do not use `test_it_works` or `test_happy_path` | — | ~~`test_it_works`~~ |
+
+### 4.4 Fixture names
+
+| Rule | Pattern | Example |
+|---|---|---|
+| Noun phrases, snake_case | `<noun_phrase>` | `sample_player`, `configured_draft` |
+| Factory fixtures (return a callable) | `make_<noun>` | `make_player`, `make_draft` |
+| Mock fixtures | `mock_<dependency>` | `mock_config`, `mock_sleeper_client` |
+| Patch fixtures (no return value) | `patch_<target>` | `patch_env_testing` |
+| Do not expose fixtures as class methods or `setUp` | — | ~~`self.create_mock_player()`~~ |
+
+### 4.5 Conftest placement
+
+| Fixture needed by | Conftest location |
+|---|---|
+| All test types (unit, integration, property) | `tests/conftest.py` |
+| Unit tests only | `tests/unit/conftest.py` |
+| A single unit subdirectory | `tests/unit/<subdir>/conftest.py` |
+| Integration tests only | `tests/integration/conftest.py` |
+| Property tests only | `tests/property/conftest.py` |
+
+**Rule:** A fixture must live in the _shallowest_ conftest where it is needed. Do not duplicate a root-scope fixture in a subdirectory conftest unless explicitly overriding it for that scope.
+
+---
+
+## 5. Marker Taxonomy
+
+### 5.1 Marker registry (target `pytest.ini`)
+
+```ini
+markers =
+    unit: isolated test; no I/O, no network, all external deps mocked
+    integration: real I/O; database, HTTP, filesystem, or multi-component
+    property: Hypothesis-driven generative test
+    slow: runtime >2 s on reference hardware; deselect in fast-feedback loops
+    performance: benchmarks and latency assertions; always deselect in unit run
+    simulation: runs a full tournament/draft simulation loop (stochastic, heavier than unit)
+    ml: requires torch/numpy/ML dependencies; skip if environment lacks them
+```
+
+### 5.2 Decision table
+
+| Test characteristics | Marker(s) to apply |
+|---|---|
+| Calls no I/O, all deps mocked/patched | `unit` |
+| Uses `hypothesis.given` | `property` |
+| Hits a real database or spawns real HTTP | `integration` |
+| Runs a full `Tournament.run()` or `Draft.run()` loop | `simulation` |
+| Typically runs in >2 s (including `simulation` tests) | `slow` _(in addition to primary marker)_ |
+| Asserts on wall-clock latency or memory usage | `performance` |
+| Imports `torch`, `numpy`, or lab ML modules | `ml` |
+
+**`slow` is always additive** — it is never the only marker on a test. A simulation test that takes 3 s should be marked `@pytest.mark.simulation` and `@pytest.mark.slow`.
+
+### 5.3 `xfail` discipline
+
+`pytestmark = pytest.mark.xfail(...)` at module level is currently used in `unit/strategies/` to gate acceptance criteria for open issues. The rules:
+
+| Condition | Action |
+|---|---|
+| Issue is open; feature is not yet implemented | `@pytest.mark.xfail(strict=False, reason="Closes #N — <title>")` |
+| Issue is closed; all tests pass | Remove `xfail` in the same PR that closes the issue |
+| Test unexpectedly passes (`XPASS`) | CI fails if `strict=True`; investigate before removing xfail |
+| Module-level `pytestmark` xfail | Allowed only when _every_ test in the file is blocked by the same issue |
+
+### 5.4 CI marker filter profiles
+
+| Profile | Command fragment | When used |
+|---|---|---|
+| Fast feedback (pre-commit) | `-m "unit and not slow"` | Local pre-commit hook |
+| Full unit gate | `-m "unit or property"` | PR CI |
+| Nightly | _(no -m filter)_ | Scheduled CI run |
+| Lab bench | `-m "simulation or performance"` | `make lab-bench` |
+
+---
+
+## 6. Coverage Toolchain Design
+
+### 6.1 `[tool.coverage.run]` — add to `pyproject.toml`
+
+```toml
+[tool.coverage.run]
+source = [
+    "api",
+    "classes",
+    "cli",
+    "config",
+    "data",
+    "services",
+    "strategies",
+    "utils",
+]
+omit = [
+    "*/venv/*",
+    "*/pigskin_auction_draft.egg-info/*",
+    "lab/*",
+    "tests/*",
+    "setup.py",
+    "run_tests.py",
+]
+branch = true
+```
+
+**Rationale for `branch = true`:** The strategy bid logic contains many short-circuit branches (`if remaining_budget < 1: return 1`). Line-only coverage would pass at 90% while missing entire conditional paths. Branch coverage exposes this.
+
+`lab/` is excluded because it lives in a separate `pyproject.toml` with its own coverage lifecycle.
+
+### 6.2 `[tool.coverage.report]` — add to `pyproject.toml`
+
+```toml
+[tool.coverage.report]
+show_missing = true
+skip_covered = false
+skip_empty = true
+precision = 1
+exclude_lines = [
+    "pragma: no cover",
+    "if TYPE_CHECKING:",
+    "raise NotImplementedError",
+    "@(abc\\.)?abstractmethod",
+    "if __name__ == ['\"]__main__['\"]:",
+]
+```
+
+`skip_covered = false` is intentional: hiding 100%-covered files masks regressions when a file is later edited but the test is not updated.
+
+### 6.3 `pytest.ini addopts`
+
+Replace the current (empty) `addopts` with:
+
+```ini
+[pytest]
+addopts =
+    -ra
+    --strict-markers
+    --tb=short
+    --timeout=60
+```
+
+| Flag | Purpose |
+|---|---|
+| `-ra` | Print a short summary for all non-passing outcomes (xfail, xpass, skip, error) |
+| `--strict-markers` | Fail on any undeclared marker; enforces the taxonomy in §5 |
+| `--tb=short` | Readable tracebacks without full frame noise |
+| `--timeout=60` | Kill runaway tests; `pytest-timeout` already installed |
+
+Coverage flags are **not** added to `addopts`. They belong in `make coverage` so that `make test` (the fast feedback loop) does not pay the coverage instrumentation overhead.
+
+### 6.4 `make test` and `make coverage` invocations
+
+**`make test`** — fast, no coverage instrumentation:
+
+```makefile
+test:
+	pytest -m "unit or property" -q
+```
+
+**`make test-all`** — full suite including integration and simulation:
+
+```makefile
+test-all:
+	pytest -q
+```
+
+**`make coverage`** — coverage-gated run:
+
+```makefile
+coverage:
+	pytest \
+	  --cov \
+	  --cov-report=term-missing \
+	  --cov-report=xml:coverage.xml \
+	  --cov-fail-under=$(COVERAGE_GATE) \
+	  -q
+```
+
+With a Makefile variable:
+
+```makefile
+COVERAGE_GATE ?= 85
+```
+
+The default is 85. CI overrides via environment variable: `make coverage COVERAGE_GATE=90`.
+
+### 6.5 `fail_under` ramp
+
+| Sprint | Gate | Rationale |
+|---|---|---|
+| Sprint 13 (migration) | **70** | Stabilize the structure; do not regress existing coverage |
+| Sprint 14 | **85** | Close known zero-coverage modules (config, cli); `make coverage` Makefile help text already advertises 85% |
+| Sprint 15 | **90** | Match the inline value currently in the Makefile `coverage` target; all strategy branches covered |
+
+The ramp is enforced by updating `COVERAGE_GATE` in the Makefile and committing the change in the sprint-start PR. CI reads the committed value.
+
+**Known coverage gaps to close on the path to 90%:**
+- `strategies/`: currently guarded by `xfail`; as issues resolve, test activation will raise coverage naturally
+- `config/`: `ConfigManager` deprecation sweep (issue #393) will add tests for every instantiation site
+- `cli/commands/`: decomposition (#366) acceptance tests are already written but `xfail`-guarded
+- `api/schemas/`: `test_schemas.py` exists but covers only the schema models, not route handlers
+
+---
+
+## 7. Migration Sequencing
+
+The migration must never leave CI red for longer than one PR cycle. The following phases are designed to be independently mergeable.
+
+### Phase 0 — Toolchain bootstrapping _(no test movement)_
+
+**Goal:** Install coverage config and `addopts` before touching any test file.
+
+1. Add `[tool.coverage.run]` and `[tool.coverage.report]` to `pyproject.toml` with `fail_under` at current measured baseline (record it first with `pytest --cov -q 2>&1 | tail -1`).
+2. Update `pytest.ini addopts` with `-ra --strict-markers --tb=short --timeout=60`.
+3. Add `property` to `REQUIRED_MARKS` in `tests/unit/test_pytest_marks.py`.
+4. Update Makefile `test` and `coverage` targets to the forms in §6.4.
+5. Set `COVERAGE_GATE = 70` in Makefile.
+
+**Risk:** `--strict-markers` will fail if any test file uses an undeclared marker. Run `pytest --collect-only -q 2>&1 | grep "PytestUnknownMarkWarning"` before merging to confirm zero warnings.
+
+**Dependencies:** None. Can be done in a single PR.
+
+---
+
+### Phase 1 — Root-level sprint regression consolidation _(highest duplication density)_
+
+**Goal:** Eliminate the 4 sprint regression files at `tests/test_sprint*.py`.
+
+**Order of merges within Phase 1:**
+
+1. `test_sprint7_regressions.py` → distribute test classes to:
+   - `unit/classes/test_tournament.py` (issues #116, #113)
+   - `unit/services/test_tournament_service.py` (issue #132)
+   - `unit/strategies/test_base_strategy.py` (issue #144)
+
+2. `test_sprint7b_regressions.py` → distribute to:
+   - `unit/classes/test_player.py` (#114)
+   - `unit/classes/test_auction.py` (#110)
+   - `unit/classes/test_team.py` (#112)
+   - `unit/services/test_draft_loading_service.py` (#131)
+
+3. `test_sprint7c_regressions.py` → distribute to:
+   - `unit/config/test_config_manager.py` (`TestUserBudgetFromConfig`)
+   - `unit/data/test_fantasypros_loader.py` (`TestConvertSleeperPlayerProjections`)
+
+4. `test_sprint8_regressions.py` → distribute to:
+   - `unit/api/test_sleeper_api.py` (JSONDecodeError, shared-dict mutation)
+   - `unit/classes/test_team.py` (QB bench constraint)
+   - `unit/services/test_bid_recommendation_service.py` (cache mutation)
+   - `unit/services/test_draft_loading_service.py` (FLEX triple-count, data-path bug)
+   - `unit/services/test_tournament_service.py` (elimination tournament)
+   - `unit/strategies/test_base_strategy.py` (aggressive-guard, sigmoid-attrs)
+   - `unit/strategies/test_vor_strategy.py` (scaling-factor shadowing)
+   - `unit/strategies/test_strategy_coverage.py` (mandatory position bid boost)
+   - `unit/cli/test_main.py` (handle-tournament non-numeric args)
+   - `unit/api/test_schemas.py` (display-ping-results missing tests key)
+
+**Constraint:** Do not delete source files until the destination file's test count has been verified by CI. Use `git mv` to preserve history; the merge itself is a code edit.
+
+**Dependencies:** Phase 0 must be complete (strict-markers must pass before new files land).
+
+---
+
+### Phase 2 — Unit sprint9 suffix merges _(lower risk; in-place)_
+
+**Goal:** Eliminate `_sprint9.py` files within `unit/`.
+
+Each merge is a straightforward append: copy test classes from the sprint9 file into the canonical file, then delete the sprint9 file. No fixture changes needed (both files already use the same conftest).
+
+**Safe merge order** (lowest coupling to highest):
+
+1. `unit/utils/*_sprint9.py` → three canonical files (no conftest changes)
+2. `unit/config/*_sprint9.py` → `test_config_manager.py`, `test_settings.py`
+3. `unit/data/test_fantasypros_loader_sprint9.py` → `test_fantasypros_loader.py`
+4. `unit/services/*_sprint9.py` → three canonical files
+5. `unit/classes/*_sprint9.py` → five canonical files
+
+**Dependencies:** Phase 1 must be complete so sprint7/8 merges do not conflict with sprint9 merges in the same file.
+
+---
+
+### Phase 3 — Root-level misc migration _(highest churn risk)_
+
+**Goal:** Move the 16 remaining root-level test files to their `unit/` destinations.
+
+**Sub-phases:**
+
+**3a — Lab files** (lowest blast radius; lab tests are already `xfail`-guarded or isolated):
+- `test_gridiron_sage.py` → `unit/lab/`
+- `test_lab_results_db.py` → `unit/lab/`
+- `test_lab_simulation_runner.py` → merge into `unit/lab/test_simulation_runner.py`
+- `test_lab_sleeper_scraper.py` → merge into `unit/lab/test_sleeper_auction_scraper.py`
+
+**3b — Data and API** (no strategy dependencies):
+- `test_fantasypros.py` → merge into `unit/data/test_fantasypros_loader.py`
+- `test_data_api.py` → split: data-loader assertions → `unit/data/`; route assertions → `integration/test_api_integration.py`
+- `test_ping_format.py` → `integration/test_ping.py`
+
+**3c — Strategy and budget** (many files, same target):
+- `test_auction_budget.py`, `test_auction_enforcement.py`, `test_budget_violation.py`, `test_multilevel_constraints.py`, `test_integer_budgets.py` → merge into `unit/classes/test_auction.py`
+- `test_strategies.py`, `test_strategy_bids.py`, `test_market_inflation.py`, `test_inflation_behavior.py` → merge into `unit/strategies/test_strategy_coverage.py`
+
+**3d — Omnibus files** (highest cognitive load; do last):
+- `test_classes.py` — scan and distribute by class touched
+- `test_services.py` — scan and distribute by service touched
+- `test_f811_regressions.py` → split: auction → `unit/classes/test_auction.py`; base_strategy → `unit/strategies/test_base_strategy.py`
+- `test_integration.py` → `integration/test_draft_end_to_end.py`
+- `test_project.py` → `integration/test_draft_end_to_end.py`
+- `test_runner.py` → **delete** (runner scaffolding; no test content)
+- `test_base.py` → **delete** after all `BaseTestCase` subclasses are migrated
+
+**Dependencies:** Phase 2 complete; root conftest fixture expansion (§3) must precede 3c/3d since those files use `BaseTestCase.setUp` patterns that will be replaced by root fixtures.
+
+---
+
+### Phase 4 — Conftest consolidation _(final polish)_
+
+**Goal:** Apply the fixture hierarchy design from §3.
+
+1. Expand `tests/conftest.py`: canonical 14-player set, 6-owner set, `FLEX`-inclusive roster config.
+2. Create `tests/unit/conftest.py` with `mock_config`, `mock_settings`, `mock_sleeper_client`, `patch_env_testing`.
+3. Trim `tests/unit/classes/conftest.py` to `comprehensive_players` only.
+4. Create `tests/integration/conftest.py` with `test_client`, `temp_db`, `api_key_header`.
+5. Set `COVERAGE_GATE = 85` in Makefile; verify CI passes.
+
+**Dependencies:** Phase 3 complete; all test files have been moved and use root fixtures.
+
+---
+
+### Phase 5 — Coverage ramp to 90 _(future sprint)_
+
+Not a structural change. Activities:
+
+- Resolve xfail-guarded strategies (issues #151, #153, #213–217)
+- Complete `ConfigManager` deprecation sweep (#393)
+- Fill `cli/commands/` gap after decomposition (#366)
+- Set `COVERAGE_GATE = 90`
+
+---
+
+### Dependency graph summary
+
+```
+Phase 0 (toolchain)
+    └── Phase 1 (sprint7/8 regression merges)
+            └── Phase 2 (sprint9 merges)
+                    └── Phase 3 (root misc → unit/)
+                            └── Phase 4 (conftest consolidation)
+                                    └── Phase 5 (coverage ramp, future sprint)
+```
+
+Each phase is independently CI-green. No phase requires a force-push or skipping of test gates.
+
+---
+
+## Appendix A — Files retired (no content to migrate)
+
+| File | Reason |
+|---|---|
+| `tests/test_runner.py` | Runner scaffolding only; no test assertions |
+| `tests/test_base.py` | `BaseTestCase` patterns replaced by named fixtures in §3 |
+| `tests/test_project.py` | Superseded by `integration/test_draft_end_to_end.py` |
+| `run_tests.py` (root) | Superseded by `pytest` invocation in Makefile |
+
+---
+
+## Appendix B — Open questions deferred to implementation
+
+1. **`unittest.TestCase` migration policy.** Sprint regression classes (`TestIndependentStrategyInstances`, etc.) use `self.assert*` methods. The decision of whether to convert them to plain `assert` statements during the merge (preferred) or leave them as-is (safe but inconsistent) is left to the implementing engineer. Converting them simplifies fixture injection but risks subtle behavioral differences in error reporting.
+
+2. **`test_classes.py` and `test_services.py` content.** These files were created early in the project and may contain broad smoke tests that overlap significantly with the canonical unit files. A content audit is required before the Phase 3d merge; they may be deleteable rather than mergeable.
+
+3. **`property` marker on Hypothesis tests.** Currently `tests/property/` files do not uniformly apply `@pytest.mark.property`. The Phase 0 toolchain work should include adding `pytestmark = pytest.mark.property` to each file in `tests/property/` as a block change — this is mechanical and low-risk.

--- a/docs/adr/QA-010-testing-refactor-validation-plan.md
+++ b/docs/adr/QA-010-testing-refactor-validation-plan.md
@@ -1,0 +1,472 @@
+# QA Validation Plan — Testing Refactor (ADR-010)
+
+**Date:** 2026-05-13  
+**ADR:** ADR-010  
+**Prepared by:** QA Agent  
+**Scope:** Validating the test-suite refactor itself, not production code changes
+
+---
+
+## Regression Definition
+
+> **An unacceptable regression is any of the following:**
+> - A test that passed before the refactor now fails (exit-code change or status `FAILED`)
+> - A test that was collected before the refactor is no longer collected (silent deletion)
+> - A test that was `XFAIL` (expected failure) unexpectedly becomes `ERROR` (import error or collection crash)
+> - The total collected test count drops below 2076 at any gate where no tests have been intentionally merged/removed
+> - A previously-silent `DeprecationWarning` becomes an `ERROR` due to unintended `-W error` escalation
+> - Coverage drops below the `fail_under` threshold set in Phase 4
+
+> **Acceptable non-regressions:**
+> - `XPASS` (unexpected pass) for any of the 5 QA-gate xfail files — these are the target outcome of the issues they guard
+> - Test count change caused by a documented merge of duplicate tests (must match merge manifest)
+> - A `DeprecationWarning` from `ConfigManager()` in `draft_loading_service.py` — tracked in issue #393, out of scope here
+
+---
+
+## Section 1: Pre-Refactor Baseline Capture (Gate 0)
+
+Run the following commands **on the unmodified branch** (before any PR changes). Commit or archive every output file. All subsequent gates compare against these snapshots.
+
+### 1.1 — Lock the test count
+
+```bash
+source venv/bin/activate
+pytest --collect-only -q 2>/dev/null | tail -1
+# Expected: "2076 tests collected" (or current count — record the exact number)
+```
+
+### 1.2 — Capture the full test name list
+
+```bash
+pytest --collect-only -q 2>/dev/null \
+    | grep "::" \
+    | sort \
+    > /tmp/baseline_test_names.txt
+
+wc -l /tmp/baseline_test_names.txt
+# Commit this file or store it as a CI artifact
+```
+
+### 1.3 — Capture current xfail/xpass breakdown
+
+```bash
+pytest -v --tb=no -q 2>/dev/null \
+    | grep -E "XFAIL|XPASS" \
+    > /tmp/baseline_xfail.txt
+
+cat /tmp/baseline_xfail.txt
+# Expected: entries for 5 files:
+#   tests/unit/strategies/test_position_targets_hardcoding.py
+#   tests/unit/classes/test_draft_setup_layering.py
+#   tests/unit/config/test_config_consolidation.py
+#   tests/unit/cli/test_commands_decomposition.py
+#   tests/unit/lab/test_lab_ci_pipeline.py
+```
+
+### 1.4 — Capture DeprecationWarning inventory
+
+```bash
+pytest -W error::DeprecationWarning --tb=short -q 2>&1 \
+    | grep -E "DeprecationWarning|FAILED|ERROR" \
+    > /tmp/baseline_deprecation_warnings.txt
+
+cat /tmp/baseline_deprecation_warnings.txt
+# Expected: failures from ConfigManager() in draft_loading_service.py (issue #393)
+# Record exact count of failures so Phase 4 can distinguish old from new
+```
+
+### 1.5 — Confirm no existing coverage config
+
+```bash
+grep -n "tool.coverage\|fail_under" pyproject.toml
+# Expected: no matches — confirms pyproject.toml has no coverage section yet
+```
+
+### 1.6 — Record which root-level files are currently collected
+
+```bash
+pytest --collect-only -q tests/ 2>/dev/null \
+    | grep "^tests/test_" \
+    | sed 's/::.*$//' \
+    | sort -u \
+    > /tmp/baseline_root_files.txt
+
+wc -l /tmp/baseline_root_files.txt
+# Expected: 28 lines — one per root-level test file
+```
+
+---
+
+## Section 2: Per-Phase Validation Gates
+
+Each gate must exit 0 (or meet the documented criterion) before proceeding to the next phase.
+
+---
+
+### Phase 0 — Add `--strict-markers` and fix unregistered markers
+
+**Goal:** Confirm that every marker in use across the test suite is declared in `pytest.ini`, then lock the suite against future undeclared markers.
+
+#### Step 0.1 — Dry-run with `--strict-markers` (before any fixes)
+
+```bash
+pytest --collect-only --strict-markers -q 2>&1 \
+    | grep -E "PytestUnknownMarkWarning|ERROR|error" \
+    | sort -u
+```
+
+**Pass criterion:** Output is empty (no unknown markers), or output lists only the markers that will be added to `pytest.ini` in this phase.  
+**Fail criterion:** Any `PytestUnknownMarkWarning` for a marker not in the fix plan.
+
+#### Step 0.2 — After adding `--strict-markers` to `pytest.ini` `addopts` and fixing all gaps
+
+```bash
+pytest --tb=short -q 2>&1 | tail -5
+```
+
+**Pass criteria (all must hold):**
+- Exit code 0
+- Collected test count equals baseline (2076, or current baseline from Gate 0)
+- Zero `FAILED`, zero `ERROR`
+- XFAIL count matches `/tmp/baseline_xfail.txt` (no change to xfail status)
+- No `PytestUnknownMarkWarning` anywhere in stdout/stderr
+
+**What counts as a regression:** Any previously-passing test now has `FAILED` or `ERROR` status.
+
+**Edge case:** `test_pytest_marks.py` asserts that all markers in `REQUIRED_MARKS` are registered. If `property` is absent from `REQUIRED_MARKS` (known gap per ADR-010 §1), this test will fail. Fix: add `property` to `REQUIRED_MARKS` in `tests/unit/test_pytest_marks.py` as part of this phase.
+
+---
+
+### Phase 1 — Add `@pytest.mark` annotations to all unmarked files
+
+**Goal:** Every file in `tests/unit/` and `tests/integration/` carries at least one `pytestmark` or per-test `@pytest.mark.*` annotation. This enables selective test runs by marker.
+
+#### Step 1.1 — Smoke: run only the `unit` marker before and after
+
+Before annotating (should collect 0 if `--strict-markers` is on but no files are annotated yet):
+
+```bash
+pytest -m unit --collect-only -q 2>/dev/null | tail -1
+# Record baseline unit-marked count
+```
+
+After annotating:
+
+```bash
+pytest -m unit --collect-only -q 2>/dev/null | tail -1
+# Must be > 0 and ≤ total count
+```
+
+#### Step 1.2 — Full suite regression check
+
+```bash
+pytest --tb=short -q 2>&1 | tail -5
+```
+
+**Pass criteria:**
+- Exit code 0
+- Collected count unchanged from Phase 0 gate
+- Zero `FAILED`, zero `ERROR`
+- XFAIL count unchanged from baseline
+
+#### Step 1.3 — Marker isolation check
+
+```bash
+pytest -m "unit or integration or property" --collect-only -q 2>/dev/null | tail -1
+# Must match total collected count — every test file must carry one of these markers
+```
+
+**Pass criterion:** Count from this command equals the total test count. Any test not reachable by `unit or integration or property` is an unmarked test that was missed.
+
+**What counts as a regression:** Any test that was collected before is now excluded by the marker filter.
+
+---
+
+### Phase 2 — Structural consolidation (root → `unit/`) and sprint-file renames
+
+**Goal:** All 28 root-level test files moved/merged into canonical `tests/unit/` subdirectory files; 4 sprint-labeled root files absorbed into their target canonical files. No tests are deleted.
+
+#### Step 2.1 — Pre-move: snapshot merged-in test names
+
+Before merging each sprint/root file, capture its test names:
+
+```bash
+# Example for test_sprint7_regressions.py before merge
+pytest --collect-only -q tests/test_sprint7_regressions.py 2>/dev/null \
+    | grep "::" | sort > /tmp/sprint7_before_merge.txt
+```
+
+Repeat for: `test_sprint7b_regressions.py`, `test_sprint7c_regressions.py`, `test_sprint8_regressions.py`, `test_f811_regressions.py`, and each of the 23 other root test files.
+
+#### Step 2.2 — After each individual file move/merge
+
+```bash
+pytest --collect-only -q 2>/dev/null | tail -1
+# Count must be ≥ baseline (never drop below 2076 mid-phase unless a file
+# was intentionally removed AND its tests appear in a canonical file)
+```
+
+Verify the moved tests are present in the destination file:
+
+```bash
+# Example: after merging sprint7 into unit/strategies/test_base_strategy.py
+pytest --collect-only -q tests/unit/strategies/test_base_strategy.py 2>/dev/null \
+    | grep "::" | sort > /tmp/sprint7_after_merge.txt
+
+diff /tmp/sprint7_before_merge.txt /tmp/sprint7_after_merge.txt
+# Expected: all sprint7 test names appear as added lines in the after-merge file
+```
+
+#### Step 2.3 — After all 28 root files are removed
+
+```bash
+# Root tests/ directory should have NO test_*.py files remaining
+ls tests/test_*.py 2>&1
+# Expected: "No such file or directory" or empty listing
+
+# Full suite must still pass
+pytest --tb=short -q 2>&1 | tail -5
+```
+
+**Pass criteria:**
+- Exit code 0
+- `ls tests/test_*.py` returns no files
+- Collected count equals baseline (all tests preserved, none deleted)
+- Zero `FAILED`, zero `ERROR`
+- XFAIL count unchanged from baseline
+
+#### Step 2.4 — Diff collected test names against baseline
+
+```bash
+pytest --collect-only -q 2>/dev/null \
+    | grep "::" \
+    | sort \
+    > /tmp/phase2_test_names.txt
+
+diff /tmp/baseline_test_names.txt /tmp/phase2_test_names.txt
+```
+
+**Pass criterion:** No lines prefixed with `<` (i.e., no tests present in baseline that are now missing). Lines prefixed with `>` are permitted only if they correspond to documented test additions (from merges that produced new parametrized IDs or renamed classes).
+
+**Gotchas specific to this codebase:**
+
+1. **`sys.path.insert` in root test files.** Three root files (`test_f811_regressions.py`, `test_sprint7_regressions.py`, `test_sprint8_regressions.py`) contain `sys.path.insert(0, ...)`. These lines must be **deleted** when moving those files into `unit/` — they are no longer needed because `pytest.ini` already sets `pythonpath = . tests`. Do not delete the `sys.path.insert` at `tests/unit/utils/test_utils_coverage.py` line 431 — that one is inside a test function body and is testing path manipulation behavior, not a module-level hack.
+
+2. **`tests/__init__.py` imports `BaseTestCase`.** The file `tests/__init__.py` contains `from .test_base import BaseTestCase, TestDataGenerator, run_test_suite`. This import will crash as soon as `test_base.py` is deleted. Update or clear `tests/__init__.py` as part of Phase 2 (or Phase 4 at the latest), before deleting `test_base.py`.
+
+3. **Five files inherit from `BaseTestCase`:** `test_classes.py`, `test_integration.py`, `test_data_api.py`, `test_services.py`, `test_strategies.py`. All five are root-level files that will be moved in Phase 2. Ensure each destination canonical file no longer imports from `test_base`; instead use conftest fixtures or inline the setUp logic.
+
+4. **Sprint-file `unittest.TestCase` subclasses.** Per ADR-010 §4.2, existing `unittest.TestCase` subclasses may remain as-is during migration; conversion to plain pytest classes is a follow-up. Verify the migrated classes still run by checking they appear in `pytest --collect-only` output (pytest collects `unittest.TestCase` subclasses natively).
+
+5. **`testpaths = tests` in `pytest.ini`.** After the move, `testpaths` still resolves to `tests/`, which includes `tests/unit/`. No change needed — but confirm that `tests/integration/` is also discovered (it falls within `tests/`).
+
+---
+
+### Phase 3 — Strategy xfail removal and strategy test restoration
+
+**Goal:** Remove `pytestmark = pytest.mark.xfail(...)` from all 5 QA-gate files after their tracked issues are resolved. The removed xfail tests must now either PASS or be explicitly skipped with justification.
+
+**Prerequisite:** Confirm the underlying issue for each xfail file is resolved before removing its mark. The 5 files and their issues:
+
+| File | Issue | Condition for xfail removal |
+|---|---|---|
+| `tests/unit/strategies/test_position_targets_hardcoding.py` | #213–217 | Hardcoded `total_slots=15` / `position_targets` removed from all strategy files |
+| `tests/unit/classes/test_draft_setup_layering.py` | #358 | `classes/draft_setup.py` decoupled from `api/` |
+| `tests/unit/config/test_config_consolidation.py` | #359 | `ConfigManager()` emits `DeprecationWarning`; all production callers migrated to `get_settings()` |
+| `tests/unit/cli/test_commands_decomposition.py` | #366 | `cli/commands.py` decomposed below 400 lines |
+| `tests/unit/lab/test_lab_ci_pipeline.py` | #190 | `PromotionGate` / `BenchmarkRunner` implemented |
+
+#### Step 3.1 — Before removing each xfail mark, verify the issue is done
+
+```bash
+# Confirm the file currently has XFAIL results (not ERROR)
+pytest -v tests/unit/strategies/test_position_targets_hardcoding.py --tb=short 2>&1 \
+    | grep -E "XFAIL|XPASS|ERROR|PASSED|FAILED"
+# Must show XFAIL or XPASS — never ERROR (ERROR means collection crash, not a known failure)
+```
+
+If `ERROR` appears, the file has an import problem that must be fixed before touching the xfail mark.
+
+#### Step 3.2 — After removing a single xfail mark
+
+```bash
+pytest -v tests/unit/strategies/test_position_targets_hardcoding.py --tb=short 2>&1 \
+    | grep -E "PASSED|FAILED|ERROR"
+```
+
+**Pass criterion:** All tests in the file show `PASSED`. Zero `FAILED`, zero `ERROR`.
+
+#### Step 3.3 — Full suite check after all xfail marks removed
+
+```bash
+pytest --tb=short -q 2>&1 | tail -5
+```
+
+**Pass criteria:**
+- Exit code 0
+- Zero `FAILED`, zero `ERROR`, zero `XFAIL` (none remaining)
+- Collected count equals or exceeds baseline (xfail tests that now PASS still count)
+
+#### Step 3.4 — Confirm no stale xfail marks anywhere in the test suite
+
+```bash
+grep -rn "pytestmark.*xfail\|pytest.mark.xfail" tests/ --include="*.py" \
+    | grep -v __pycache__
+# Expected: no output — all xfail marks removed
+```
+
+**What counts as a regression:** Any test in these 5 files that fails (`FAILED`) after xfail removal. `XPASS` before removal was the signal that the underlying issue was already fixed; a `FAILED` after removal means the production fix is incomplete.
+
+---
+
+### Phase 4 — Coverage configuration, `fail_under`, and BaseTestCase removal
+
+**Goal:** `pyproject.toml` gains `[tool.coverage.run]` and `[tool.coverage.report]` with `fail_under = 70`; `tests/test_base.py` is deleted; `tests/__init__.py` no longer imports from it; all 4 `ConfigManager()` call sites in `tests/test_data_api.py` (lines 203, 217, 233, 246) are replaced with `get_settings()`-compatible construction.
+
+#### Step 4.1 — Verify BaseTestCase consumers are migrated before deletion
+
+```bash
+grep -rn "from test_base import\|import BaseTestCase\|from tests.test_base import" \
+    tests/ --include="*.py" | grep -v __pycache__
+# Expected: no matches
+# Also check tests/__init__.py explicitly:
+grep "test_base" tests/__init__.py
+# Expected: no matches
+```
+
+Do not delete `test_base.py` until this step passes cleanly.
+
+#### Step 4.2 — Verify ConfigManager() call sites in test files are gone
+
+```bash
+grep -rn "ConfigManager()" tests/ --include="*.py" | grep -v __pycache__
+# Expected: no matches
+# (The 4 sites in tests/test_data_api.py must be replaced; unit/config/test_config_consolidation.py
+#  references ConfigManager() in string literals / test assertions — those are intentional and OK)
+```
+
+Disambiguate: string/comment references vs. live instantiations:
+
+```bash
+grep -rn "ConfigManager()" tests/ --include="*.py" | grep -v __pycache__ \
+    | grep -v "\"ConfigManager()" | grep -v "'ConfigManager()"
+# Expected: no matches
+```
+
+#### Step 4.3 — Confirm coverage config is present in pyproject.toml
+
+```bash
+grep -A 10 "\[tool.coverage" pyproject.toml
+# Expected: sections [tool.coverage.run] and [tool.coverage.report] with fail_under = 70
+```
+
+#### Step 4.4 — Run coverage with the new config and verify the gate
+
+```bash
+pytest --cov=. --cov-report=term-missing --cov-fail-under=70 -q 2>&1 | tail -20
+```
+
+**Pass criteria:**
+- Exit code 0 (which means both tests pass AND coverage ≥ 70%)
+- "Required test coverage of 70% reached" message in output
+- Zero `FAILED`, zero `ERROR`
+
+**Fail criterion:** Exit code 2 (coverage below threshold). If coverage is below 70%, this is a configuration problem (wrong `source` in `[tool.coverage.run]`, or `omit` excluding too much), not a test failure.
+
+#### Step 4.5 — Delete test_base.py and confirm no import errors
+
+```bash
+# Delete the file
+rm tests/test_base.py
+
+# Immediately re-collect to surface any broken imports
+pytest --collect-only -q 2>&1 | grep -E "ERROR|ImportError|ModuleNotFoundError"
+# Expected: no matches
+```
+
+**What counts as a regression:** Any `ImportError` or `ModuleNotFoundError` after deletion. Any test count drop (all BaseTestCase consumers must have been migrated in previous steps).
+
+---
+
+## Section 3: Final Acceptance Gate
+
+Run this sequence on the final refactor branch. **All commands must exit 0.**
+
+```bash
+#!/usr/bin/env bash
+set -euo pipefail
+
+# 1. Collect: must match or exceed baseline, no collection errors
+pytest --collect-only --strict-markers -q 2>/dev/null | tail -1
+
+# 2. Full suite: zero failures, zero errors, strict markers enforced
+pytest --strict-markers --tb=short -q
+
+# 3. Marker completeness: every test reachable by the three top-level markers
+TOTAL=$(pytest --collect-only -q 2>/dev/null | tail -1 | awk '{print $1}')
+MARKED=$(pytest -m "unit or integration or property" --collect-only -q 2>/dev/null | tail -1 | awk '{print $1}')
+[ "$TOTAL" = "$MARKED" ] || { echo "FAIL: $((TOTAL - MARKED)) unmarked tests"; exit 1; }
+
+# 4. No stale xfail marks
+XFAIL_COUNT=$(grep -rn "pytestmark.*xfail\|pytest.mark.xfail" tests/ --include="*.py" \
+    | grep -v __pycache__ | wc -l)
+[ "$XFAIL_COUNT" -eq 0 ] || { echo "FAIL: $XFAIL_COUNT xfail marks remain"; exit 1; }
+
+# 5. No root-level test files
+ROOT_FILES=$(ls tests/test_*.py 2>/dev/null | wc -l)
+[ "$ROOT_FILES" -eq 0 ] || { echo "FAIL: $ROOT_FILES root test files remain"; exit 1; }
+
+# 6. No sys.path.insert hacks (module-level)
+# Exclude the one inside test_utils_coverage.py which is inside a function body
+SYSPATH=$(grep -rn "^sys.path.insert" tests/ --include="*.py" | grep -v __pycache__ | wc -l)
+[ "$SYSPATH" -eq 0 ] || { echo "FAIL: $SYSPATH module-level sys.path.insert lines remain"; exit 1; }
+
+# 7. No live ConfigManager() instantiation in test files
+CM=$(grep -rn "ConfigManager()" tests/ --include="*.py" | grep -v __pycache__ \
+    | grep -v "\"ConfigManager()" | grep -v "'ConfigManager()" | wc -l)
+[ "$CM" -eq 0 ] || { echo "FAIL: $CM live ConfigManager() call sites in tests"; exit 1; }
+
+# 8. test_base.py deleted
+[ ! -f tests/test_base.py ] || { echo "FAIL: tests/test_base.py still exists"; exit 1; }
+
+# 9. Coverage gate
+pytest --cov=. --cov-report=term-missing --cov-fail-under=70 -q
+
+echo ""
+echo "✓ All acceptance gates passed — refactor PR is mergeable"
+```
+
+If every step in this script exits 0, the PR is mergeable.
+
+---
+
+## Appendix: Edge Cases and Codebase-Specific Gotchas
+
+### A. `tests/__init__.py` is a live import, not dead code
+
+`tests/__init__.py` re-exports `BaseTestCase`, `TestDataGenerator`, and `run_test_suite` from `test_base.py`. Deleting `test_base.py` without updating `__init__.py` will cause an `ImportError` on the entire `tests` package. This will manifest as **all tests failing to collect** — not a single test failure but a total collection crash. Update `tests/__init__.py` to an empty file (or remove the imports) as part of Phase 2 before `test_base.py` is deleted.
+
+### B. `strict=False` on all xfail files means XPASS is silent today
+
+The 5 xfail files use `strict=False`, so if an underlying issue gets fixed before Phase 3, the tests will silently show `XPASS` without failing the suite. The Phase 3 gate in Step 3.3 explicitly checks for zero remaining `XFAIL` — but also run `grep -rn "XPASS" /tmp/pytest_output.txt` to detect stealth passes that indicate early issue resolution.
+
+### C. `test_utils_coverage.py` has a legitimate `sys.path.insert` inside a test
+
+`tests/unit/utils/test_utils_coverage.py` line 431 contains `sys.path.insert(0, root)` **inside a test function body** — it is testing path manipulation behavior, not a module-level import hack. The final acceptance gate uses `^sys.path.insert` (anchored to start of line) to exclude this. Do not remove it.
+
+### D. `pytest.ini` `pythonpath = . tests` makes `sys.path.insert` redundant
+
+The three root files that have module-level `sys.path.insert` (`test_f811_regressions.py`, `test_sprint7_regressions.py`, `test_sprint8_regressions.py`) were written before `pythonpath` was added to `pytest.ini`. They will work without the hack. After merging these files into `unit/`, simply delete those lines.
+
+### E. `DeprecationWarning` from `ConfigManager()` in production code
+
+`draft_loading_service.py` emits a `DeprecationWarning` when tests exercise it. This is tracked in issue #393 and is **out of scope for this refactor**. The Phase 0 baseline captures the exact failure count under `-W error::DeprecationWarning`. Do not use `-W error::DeprecationWarning` in any phase gate — it would erroneously block the refactor on an unrelated issue.
+
+### F. Conftest fixture shadowing during Phase 2
+
+While root files and `unit/classes/conftest.py` coexist, there are two `sample_players` fixtures (11-player root version vs 14-player classes version). This is fine during migration. Once root files are removed, the `unit/classes/conftest.py` version shadows the root — verify that `configured_draft` in tests that previously used the 11-player set still works after the root fixture takes over. Per ADR-010 §3, the root fixture will be expanded to 14 players; confirm that no test performs `assert len(sample_players) == 11`.
+
+### G. Coverage source must be scoped correctly
+
+`[tool.coverage.run]` `source` should point to the production packages (`api`, `classes`, `cli`, `config`, `data`, `services`, `strategies`, `utils`), not to `tests/`, `lab/`, or `venv/`. An incorrect `source` configuration will produce inflated or deflated coverage numbers. If the Phase 4 coverage gate fails unexpectedly, inspect the `[tool.coverage.run]` `omit` list for accidental exclusions of production modules.


### PR DESCRIPTION
## Summary

Splits Phase 1 pre-development test definition out of QA Agent into a dedicated **Test Definition Agent**, and introduces ADR-010 for the test suite refactor.

## Changes

**New files:**
- `.agents/quality/test-definition.agent.md` — Phase 1 agent: translates issue ACs into failing pytest tests before dev starts, enforces ADR-010 structure/markers.
- `docs/adr/ADR-010-testing-refactor.md` — Decision to consolidate the test suite (stable directory hierarchy, fixture ownership, `pyproject.toml` coverage config, `--strict-markers`).
- `docs/adr/QA-010-testing-refactor-validation-plan.md` — QA validation plan for Phases 0–4.

**Modified files:**
- `.agents/AGENT_MANAGER.md` — Test Definition Agent added to Quality table.
- `.agents/orchestration/orchestrator.agent.md` — Agent directory updated; Phase 1/Phase 2 ownership clarified.
- `.agents/quality/qa.agent.md` — Scoped to Phase 2 verification only.

## Motivation

Separating these roles clarifies ownership, reduces agent scope, and ensures `qa:tests-defined` is enforced by an agent with full ADR-010 knowledge.

## Related Issues

Relates to #399 (epic: testing infrastructure refactor). Provides infrastructure for #398, #400–#403.

## Test Results

No production code changed. Pre-push CI: 1816 passed, 97.94% coverage.