### PR TITLE
fix(arch): ARCH-001 — remove api/ dependency from classes/draft_setup.py (#358)

### DIFF
--- a/classes/draft_setup.py
+++ b/classes/draft_setup.py
@@ -127,16 +127,21 @@ class DraftSetup:
         Args:
             position_filter: List of positions to include (e.g., ['QB', 'RB', 'WR'])
             min_projected_points: Minimum projected points to include player
-            sleeper_api: Optional pre-constructed SleeperAPI client. If None,
-                one is created internally (allows testing via injection).
+            sleeper_api: SleeperAPI client to use for fetching player data.
+                Must be provided by the caller (domain layer does not create
+                integration-layer clients). Returns [] if not provided.
 
         Returns:
             List of Player objects
         """
         if sleeper_api is None:
-            from api.sleeper_api import SleeperAPI  # lazy import — keeps domain layer independent
-            sleeper_api = SleeperAPI()
-        
+            logger.warning(
+                "import_players_from_sleeper() called without a sleeper_api client. "
+                "The domain layer cannot create API clients. Inject a SleeperAPI "
+                "instance via the sleeper_api parameter to fetch live data."
+            )
+            return []
+
         try:
             # Get player data from Sleeper
             converted_players = sleeper_api.bulk_convert_players(position_filter)

--- a/tests/unit/classes/test_draft_setup.py
+++ b/tests/unit/classes/test_draft_setup.py
@@ -74,49 +74,58 @@ class TestSetupDraftWithParticipants:
 class TestImportPlayersFromSleeper:
     def test_returns_players_on_success(self):
         from classes.draft_setup import DraftSetup
+        from unittest.mock import MagicMock
         player_data = [
             {'player_id': 'p1', 'name': 'Josh Allen', 'position': 'QB', 'team': 'BUF',
              'projected_points': 350.0, 'auction_value': 50.0, 'bye_week': 7}
         ]
-        with patch('api.sleeper_api.SleeperAPI') as MockAPI:
-            instance = MockAPI.return_value
-            instance.bulk_convert_players.return_value = player_data
-            players = DraftSetup.import_players_from_sleeper()
+        mock_client = MagicMock()
+        mock_client.bulk_convert_players.return_value = player_data
+        players = DraftSetup.import_players_from_sleeper(sleeper_api=mock_client)
         assert len(players) == 1
         assert players[0].name == 'Josh Allen'
 
     def test_filters_by_min_projected_points(self):
         from classes.draft_setup import DraftSetup
+        from unittest.mock import MagicMock
         player_data = [
             {'player_id': 'p1', 'name': 'Josh Allen', 'position': 'QB', 'team': 'BUF',
              'projected_points': 350.0, 'auction_value': 50.0, 'bye_week': 7},
             {'player_id': 'p2', 'name': 'Backup K', 'position': 'K', 'team': 'CLE',
              'projected_points': 5.0, 'auction_value': 1.0, 'bye_week': 9},
         ]
-        with patch('api.sleeper_api.SleeperAPI') as MockAPI:
-            instance = MockAPI.return_value
-            instance.bulk_convert_players.return_value = player_data
-            players = DraftSetup.import_players_from_sleeper(min_projected_points=100.0)
+        mock_client = MagicMock()
+        mock_client.bulk_convert_players.return_value = player_data
+        players = DraftSetup.import_players_from_sleeper(
+            min_projected_points=100.0, sleeper_api=mock_client
+        )
         assert len(players) == 1
 
     def test_returns_empty_on_exception(self):
         from classes.draft_setup import DraftSetup
-        with patch('api.sleeper_api.SleeperAPI') as MockAPI:
-            instance = MockAPI.return_value
-            instance.bulk_convert_players.side_effect = ConnectionError("API down")
-            players = DraftSetup.import_players_from_sleeper()
+        from unittest.mock import MagicMock
+        mock_client = MagicMock()
+        mock_client.bulk_convert_players.side_effect = ConnectionError("API down")
+        players = DraftSetup.import_players_from_sleeper(sleeper_api=mock_client)
+        assert players == []
+
+    def test_returns_empty_when_no_client_injected(self):
+        from classes.draft_setup import DraftSetup
+        players = DraftSetup.import_players_from_sleeper()
         assert players == []
 
     def test_filters_by_position(self):
         from classes.draft_setup import DraftSetup
+        from unittest.mock import MagicMock
         player_data = [
             {'player_id': 'p1', 'name': 'Josh Allen', 'position': 'QB', 'team': 'BUF',
              'projected_points': 350.0, 'auction_value': 50.0, 'bye_week': 7},
         ]
-        with patch('api.sleeper_api.SleeperAPI') as MockAPI:
-            instance = MockAPI.return_value
-            instance.bulk_convert_players.return_value = player_data
-            players = DraftSetup.import_players_from_sleeper(position_filter=['QB'])
+        mock_client = MagicMock()
+        mock_client.bulk_convert_players.return_value = player_data
+        players = DraftSetup.import_players_from_sleeper(
+            position_filter=['QB'], sleeper_api=mock_client
+        )
         assert len(players) == 1
 
 

--- a/tests/unit/classes/test_draft_setup_layering.py
+++ b/tests/unit/classes/test_draft_setup_layering.py
@@ -18,12 +18,8 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 
-# All tests in this file are QA Phase 1 gates — expected to FAIL until the
-# fix for issue #358 is implemented. Remove this mark after implementation.
-pytestmark = pytest.mark.xfail(
-    strict=False,
-    reason="QA Phase 1 gate for #358 — fails until classes/draft_setup.py is decoupled from api/",
-)
+# All tests in this file are QA Phase 1 gates — implementation complete for #358.
+pytestmark = pytest.mark.unit
 
 
 
@@ -48,24 +44,22 @@ class TestDraftSetupNoApiImport:
 
         The domain layer (classes/) must never depend on the integration layer
         (api/).  This is the ARCH-001 layering violation.
-        Lazy imports inside function bodies are allowed (they keep the domain
-        layer importable without triggering the api/ dependency).
         """
         tree = _source_ast()
-        # Only check direct children of the module (top-level statements)
-        for node in ast.iter_child_nodes(tree):
-            if isinstance(node, ast.ImportFrom) and node.module:
-                assert not node.module.startswith("api."), (
-                    f"Layering violation: 'classes/draft_setup.py' imports "
-                    f"from '{node.module}' (api layer) at line {node.lineno}. "
-                    "Move API access to a service or inject via parameter."
-                )
-            elif isinstance(node, ast.Import):
-                for alias in node.names:
-                    assert not alias.name.startswith("api."), (
-                        f"Layering violation: top-level import of '{alias.name}' "
-                        f"at line {node.lineno}."
+        for node in ast.walk(tree):
+            if isinstance(node, (ast.Import, ast.ImportFrom)):
+                if isinstance(node, ast.ImportFrom) and node.module:
+                    assert not node.module.startswith("api."), (
+                        f"Layering violation: 'classes/draft_setup.py' imports "
+                        f"from '{node.module}' (api layer) at line {node.lineno}. "
+                        "Move API access to a service or inject via parameter."
                     )
+                elif isinstance(node, ast.Import):
+                    for alias in node.names:
+                        assert not alias.name.startswith("api."), (
+                            f"Layering violation: top-level import of '{alias.name}' "
+                            f"at line {node.lineno}."
+                        )
 
     def test_sleeper_api_not_imported_at_top_level(self):
         """SleeperAPI must not be imported at the top of draft_setup.py."""
@@ -131,7 +125,6 @@ class TestDraftSetupInjection:
         assert len(result) == 1
         assert result[0].name == "Test Player"
 
-    @pytest.mark.xfail(strict=False, reason="Smoke import test — allowed to pass even before fix")
     def test_import_players_without_injection_does_not_crash_on_import(self):
         """Importing classes.draft_setup must not trigger a network call or crash."""
         # Simply re-importing (or freshly importing) must not raise an error.


### PR DESCRIPTION
## Summary

Fixes the P0 ARCH-001 layering violation: `classes/draft_setup.py` imported from `api.sleeper_api` via a lazy import inside `import_players_from_sleeper()`.

The domain layer (`classes/`) must never depend on the integration layer (`api/`).

## Changes

- **`classes/draft_setup.py`**: Remove the `from api.sleeper_api import SleeperAPI` lazy import and the `SleeperAPI()` auto-construction. If `sleeper_api` is not injected, the function logs a warning and returns `[]` (graceful degradation).
- **`tests/unit/classes/test_draft_setup.py`**: Update 4 test methods in `TestImportPlayersFromSleeper` to inject a `MagicMock` client directly instead of patching `api.sleeper_api.SleeperAPI`. Add `test_returns_empty_when_no_client_injected`.
- **`tests/unit/classes/test_draft_setup_layering.py`**: Remove `xfail` marks — all 5 QA Phase 1 gates now pass.

## Test Results

- 5/5 `test_draft_setup_layering.py` tests: PASS ✓
- 35/35 `test_draft_setup.py` tests: PASS ✓  
- 1528 unit tests + 53 xpassed: all green ✓
- 193 property tests: all green ✓

Closes #358