### PR TITLE
test(qa): cli/commands/ decomposition gates verified — remove xfail (#366)

### DIFF
--- a/tests/unit/cli/test_commands_decomposition.py
+++ b/tests/unit/cli/test_commands_decomposition.py
@@ -18,12 +18,8 @@ from unittest.mock import patch
 
 import pytest
 
-# All tests in this file are QA Phase 1 gates — expected to FAIL until the
-# fix for issue #366 is implemented. Remove this mark after implementation.
-pytestmark = pytest.mark.xfail(
-    strict=False,
-    reason="QA Phase 1 gate for #366 — fails until cli/commands.py is decomposed",
-)
+# QA Phase 1 gates for #366 — cli/commands/ package decomposition verified complete.
+pytestmark = pytest.mark.unit
 
 _REPO_ROOT = Path(__file__).parent.parent.parent.parent
 _COMMANDS_PATH = _REPO_ROOT / "cli" / "commands.py"
@@ -68,7 +64,6 @@ class TestCommandsModuleSize:
 # ---------------------------------------------------------------------------
 
 class TestCommandHandlerImports:
-    @pytest.mark.xfail(strict=False, reason="Import works today; only decomposition structure changes")
     def test_bid_handler_importable(self):
         """A bid recommendation handler must be importable after the split."""
         try:
@@ -76,7 +71,6 @@ class TestCommandHandlerImports:
         except ImportError as e:
             pytest.fail(f"Cannot import CommandProcessor from cli.commands: {e}")
 
-    @pytest.mark.xfail(strict=False, reason="Methods exist today; regression guard survives decomposition")
     def test_all_public_methods_present(self):
         """All CommandProcessor public methods must still exist after the split."""
         from cli.commands import CommandProcessor


### PR DESCRIPTION
## Summary

The `cli/commands/` package was already fully decomposed in a prior sprint. All 5 QA Phase 1 gates pass. This PR removes the `xfail` markers, making the tests proper enforcing regression guards.

## Package Structure

| Module | Lines |
|--------|-------|
| `__init__.py` | 58 |
| `_bid.py` | 65 |
| `_sleeper.py` | 147 |
| `_mock.py` | 183 |
| `_tournament_helpers.py` | 221 |
| `_tournament_stats.py` | 300 |
| `_simulation.py` | 356 |
| `_tournament.py` | 358 |

All submodules are ≤ 400 lines. The original `cli/commands.py` (1761 lines, MI=0) is gone.

Closes #366