### PR TITLE
fix(ci): align coverage gates + enforce --strict-markers (#392, #398)

### DIFF
--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -2,7 +2,7 @@
 # pre-push — sprint-branch guard + full CI suite before any push
 #
 # Mirrors the App CI workflow (app-ci.yml):
-#   flake8 (lint) → mypy (type check) → bandit (security) → pytest (unit + 85% coverage)
+#   flake8 (lint) → mypy (type check) → bandit (security) → pytest (unit + 90% coverage)
 #
 # Also enforces the 3-tier sprint branch workflow:
 #   feature/<slug>  →  sprint/N  →  develop  →  main
@@ -106,9 +106,9 @@ echo "      ✓ security scan passed"
 echo ""
 
 # ── 4. Unit tests + coverage gate ─────────────────────────────────────────────
-echo "[4/4] Unit tests + coverage gate (≥ 85%)..."
+echo "[4/4] Unit tests + coverage gate (≥ 90%)..."
 "$PYTEST" tests/ -x -q --timeout=60 \
-  --cov=. --cov-fail-under=85 \
+  --cov=. --cov-fail-under=90 \
   --cov-report=term-missing \
   --ignore=tests/test_integration.py \
   --ignore=tests/property

--- a/.github/workflows/app-ci.yml
+++ b/.github/workflows/app-ci.yml
@@ -1,7 +1,7 @@
 # app-ci.yml — PR-triggered pipeline for the production app
 #
 # Runs: flake8 (lint) → mypy (type check) → bandit (security scan)
-#       → pytest unit tests + 85% coverage gate → integration tests
+#       → pytest unit tests + 90% coverage gate → integration tests
 #
 # Idempotent: all steps are stateless and safe to re-run.
 # Python: 3.11+ (per setup.py python_requires=">=3.11")

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,6 +1,7 @@
 [pytest]
 pythonpath = . tests
 testpaths = tests
+addopts = --strict-markers
 python_files = test_*.py
 python_classes = Test*
 python_functions = test_*

--- a/tests/unit/ci/test_coverage_gate_alignment.py
+++ b/tests/unit/ci/test_coverage_gate_alignment.py
@@ -1,0 +1,72 @@
+"""QA Phase 1 gate tests for issue #392.
+
+Asserts that .githooks/pre-push and .github/workflows/app-ci.yml both use
+a 90% coverage threshold, eliminating the pre-push/CI drift introduced when
+CI was raised from 85 → 90 without updating the hook.
+
+All tests are xfail(strict=True) until the fix lands.
+"""
+
+import pathlib
+import re
+
+import pytest
+
+pytestmark = pytest.mark.unit
+
+_REPO_ROOT = pathlib.Path(__file__).resolve().parents[3]
+_PRE_PUSH = _REPO_ROOT / ".githooks" / "pre-push"
+_APP_CI = _REPO_ROOT / ".github" / "workflows" / "app-ci.yml"
+
+EXPECTED_THRESHOLD = 90
+
+
+def test_pre_push_threshold_is_90():
+    """pre-push hook must specify --cov-fail-under=90."""
+    content = _PRE_PUSH.read_text()
+    match = re.search(r"--cov-fail-under=(\d+)", content)
+    assert match is not None, "--cov-fail-under not found in pre-push"
+    actual = int(match.group(1))
+    assert actual == EXPECTED_THRESHOLD, (
+        f"pre-push uses --cov-fail-under={actual}, expected {EXPECTED_THRESHOLD}"
+    )
+
+
+def test_app_ci_stale_comment_references_90():
+    """app-ci.yml header comment must reference 90%, not 85%."""
+    content = _APP_CI.read_text()
+    # The stale comment pattern: "→ ... 85% coverage gate"
+    stale_pattern = re.compile(r"#.*→.*85%.*coverage gate", re.IGNORECASE)
+    assert not stale_pattern.search(content), (
+        "app-ci.yml still contains a stale comment referencing 85% coverage gate"
+    )
+
+
+def test_app_ci_pytest_threshold_is_90():
+    """app-ci.yml pytest step already uses --cov-fail-under=90 (should pass now)."""
+    content = _APP_CI.read_text()
+    match = re.search(r"--cov-fail-under=(\d+)", content)
+    assert match is not None, "--cov-fail-under not found in app-ci.yml"
+    actual = int(match.group(1))
+    assert actual == EXPECTED_THRESHOLD, (
+        f"app-ci.yml uses --cov-fail-under={actual}, expected {EXPECTED_THRESHOLD}"
+    )
+
+
+def test_pre_push_and_app_ci_thresholds_match():
+    """Both files must use the same --cov-fail-under value."""
+    pre_push_content = _PRE_PUSH.read_text()
+    ci_content = _APP_CI.read_text()
+
+    pre_push_match = re.search(r"--cov-fail-under=(\d+)", pre_push_content)
+    ci_match = re.search(r"--cov-fail-under=(\d+)", ci_content)
+
+    assert pre_push_match is not None, "--cov-fail-under not found in pre-push"
+    assert ci_match is not None, "--cov-fail-under not found in app-ci.yml"
+
+    pre_push_val = int(pre_push_match.group(1))
+    ci_val = int(ci_match.group(1))
+
+    assert pre_push_val == ci_val, (
+        f"Coverage threshold mismatch: pre-push={pre_push_val}, app-ci.yml={ci_val}"
+    )

--- a/tests/unit/ci/test_strict_markers_config.py
+++ b/tests/unit/ci/test_strict_markers_config.py
@@ -1,0 +1,55 @@
+"""QA Phase 1 gate tests for issue #398.
+
+Asserts that pytest.ini is configured with --strict-markers and that all
+markers defined in REQUIRED_MARKS (tests/unit/test_pytest_marks.py) are
+registered in pytest.ini.
+
+The --strict-markers test is xfail(strict=True) until the fix lands.
+Marker registration tests pass immediately (unit, and all REQUIRED_MARKS,
+are already registered in pytest.ini).
+"""
+
+import configparser
+import pathlib
+
+import pytest
+
+pytestmark = pytest.mark.unit
+
+_REPO_ROOT = pathlib.Path(__file__).resolve().parents[3]
+_PYTEST_INI = _REPO_ROOT / "pytest.ini"
+
+# Mirrors REQUIRED_MARKS from tests/unit/test_pytest_marks.py
+REQUIRED_MARKS = ["integration", "performance", "ml", "unit", "simulation", "slow"]
+
+
+def _read_pytest_ini() -> configparser.ConfigParser:
+    cfg = configparser.ConfigParser()
+    cfg.read(_PYTEST_INI)
+    return cfg
+
+
+def test_strict_markers_in_addopts():
+    """pytest.ini [pytest] addopts must include --strict-markers."""
+    cfg = _read_pytest_ini()
+    addopts = cfg.get("pytest", "addopts", fallback="")
+    assert "--strict-markers" in addopts, (
+        f"--strict-markers not found in pytest.ini addopts: {addopts!r}"
+    )
+
+
+def test_unit_marker_registered_in_pytest_ini():
+    """pytest.ini must register the 'unit' marker (already present)."""
+    content = _PYTEST_INI.read_text()
+    assert "unit" in content, (
+        "'unit' marker not found in pytest.ini markers section"
+    )
+
+
+@pytest.mark.parametrize("mark", REQUIRED_MARKS)
+def test_required_mark_registered(mark: str):
+    """Every marker in REQUIRED_MARKS must be registered in pytest.ini."""
+    content = _PYTEST_INI.read_text()
+    assert mark in content, (
+        f"Required marker '{mark}' is not registered in pytest.ini"
+    )


### PR DESCRIPTION
## Summary

Fixes two CI configuration issues surfaced in Sprint 12:

### #392 — Align pre-push coverage gate with CI
- `.githooks/pre-push`: 85 → 90 (matches app-ci.yml)  
- `.github/workflows/app-ci.yml`: stale comment updated 85% → 90%

### #398 — Enforce `--strict-markers` in pytest
- `pytest.ini`: added `--strict-markers` to addopts
- Ensures marker typos fail loudly instead of passing silently

## Tests
- All QA Phase 1 gate tests pass (xfail marks removed)
- Full unit suite: green

Closes #392
Closes #398