### PR TITLE
fix(ci/tests): coverage omit, fix RuntimeWarning sys.modules (#395, #396, #397)

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -4,6 +4,7 @@ omit =
     venv/*
     tests/*
     setup.py
+    run_tests.py
     lab/*
     cli/commands/_tournament.py
     cli/commands/_tournament_stats.py

--- a/tests/unit/strategies/test_spending_strategy_analyzer.py
+++ b/tests/unit/strategies/test_spending_strategy_analyzer.py
@@ -375,10 +375,11 @@ class TestSpendingAnalyzerMainBlock(unittest.TestCase):
 
     def test_main_block(self):
         """Cover lines 154-155 — if __name__ == '__main__' block."""
-        with patch("strategies.spending_analyzer.analyze_spending_patterns"), \
-             patch("strategies.spending_analyzer.suggest_specific_improvements"):
-            import runpy
-            runpy.run_module('strategies.spending_analyzer', run_name='__main__')
+        import sys
+        import runpy
+        # Pop from sys.modules first to prevent RuntimeWarning from runpy (#397)
+        sys.modules.pop('strategies.spending_analyzer', None)
+        runpy.run_module('strategies.spending_analyzer', run_name='__main__')
         # If we got here without error, the block ran
 
 
@@ -387,7 +388,10 @@ class TestStrategyAnalyzerMainBlock(unittest.TestCase):
 
     def test_main_block(self):
         """Cover lines 112-113 — if __name__ == '__main__' block."""
+        import sys
         import runpy
+        # Pop from sys.modules first to prevent RuntimeWarning from runpy (#397)
+        sys.modules.pop('strategies.strategy_analyzer', None)
         try:
             runpy.run_module('strategies.strategy_analyzer', run_name='__main__')
         except Exception:


### PR DESCRIPTION
## Summary

Three CI/test hygiene fixes.

### #395 — omit run_tests.py from coverage
- \.coveragerc\`: added `run_tests.py` to `[run] omit` list
- Verified: `run_tests.py` no longer appears in coverage report

### #396 — stale xfail markers audit
- Ran full suite; confirmed **0 XPASS tests** in current codebase
- All xfail-marked tests are either still failing (XFAIL, correct) or the markers were already removed in earlier sprints
- No changes required

### #397 — fix RuntimeWarning in sys.modules during test run
- Root cause: `TestSpendingAnalyzerMainBlock` and `TestStrategyAnalyzerMainBlock` called `runpy.run_module()` after the same module had already been imported by earlier tests in the session — Python's runpy emits a RuntimeWarning when it finds the module pre-loaded in sys.modules
- Fix: call `sys.modules.pop('strategies.{spending,strategy}_analyzer', None)` immediately before each `runpy.run_module()` call so runpy loads a clean slate
- Also removed now-unnecessary `patch()` wrappers from `TestSpendingAnalyzerMainBlock.test_main_block` (the functions are lightweight, hardcoded-data printers)
- Verified: 0 RuntimeWarning lines matching `sys.modules` after fix

## Tests
- Before: 1594 unit tests passed, RuntimeWarning emitted 2× per run
- After: 1594 unit tests passed, 0 sys.modules RuntimeWarnings

Closes #395
Closes #396
Closes #397
