### PR TITLE
feat(cli): Phase 0 foundation layer — context, output, exceptions, options, lazy (#411)

### DIFF
--- a/cli/_lazy.py
+++ b/cli/_lazy.py
@@ -8,7 +8,7 @@ in the lab package.
 from __future__ import annotations
 
 import importlib
-from typing import Optional
+from typing import Any, Optional
 
 import click
 
@@ -29,7 +29,7 @@ class LazyGroup(click.Group):
         super().__init__(*args, **kwargs)
         self._import_name = import_name
 
-    def get_command(self, ctx: click.Context, cmd_name: str) -> Optional[click.BaseCommand]:
+    def get_command(self, ctx: click.Context, cmd_name: str) -> Optional[Any]:
         # Try the parent registry first (commands added via .add_command)
         rv = super().get_command(ctx, cmd_name)
         if rv is not None:

--- a/cli/_lazy.py
+++ b/cli/_lazy.py
@@ -1,0 +1,46 @@
+"""LazyGroup — a Click Group subclass that loads subcommands on demand.
+
+Using importlib.import_module keeps heavy optional packages (e.g. ``lab``)
+out of the interpreter until the user actually invokes a command from that
+group.  This means ``import cli._lazy`` at the top of main.py never pulls
+in the lab package.
+"""
+from __future__ import annotations
+
+import importlib
+from typing import Optional
+
+import click
+
+
+class LazyGroup(click.Group):
+    """A :class:`click.Group` that imports subcommand modules lazily.
+
+    Parameters
+    ----------
+    import_name:
+        Dotted module path prefix used to resolve subcommands, e.g.
+        ``"cli.commands.lab"``.  When a user runs ``pigskin lab <cmd>``,
+        :meth:`get_command` calls
+        ``importlib.import_module(f"{import_name}.{cmd_name}")``.
+    """
+
+    def __init__(self, *args, import_name: str = "", **kwargs) -> None:
+        super().__init__(*args, **kwargs)
+        self._import_name = import_name
+
+    def get_command(self, ctx: click.Context, cmd_name: str) -> Optional[click.BaseCommand]:
+        # Try the parent registry first (commands added via .add_command)
+        rv = super().get_command(ctx, cmd_name)
+        if rv is not None:
+            return rv
+
+        # Lazy-load via importlib — never a bare ``import lab``
+        if self._import_name:
+            try:
+                mod = importlib.import_module(f"{self._import_name}.{cmd_name}")
+                return getattr(mod, cmd_name, None)
+            except ImportError:
+                return None
+
+        return None

--- a/cli/context.py
+++ b/cli/context.py
@@ -1,0 +1,16 @@
+"""CLI application context — carried via ctx.obj in every Click command."""
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+
+# IMPORTANT: Zero Click imports in this file.
+from cli.output import OutputFormat
+
+
+@dataclass
+class AppContext:
+    """Shared state threaded through all Click command invocations via ctx.obj."""
+
+    output_format: OutputFormat = field(default=OutputFormat.TABLE)
+    quiet: bool = False
+    verbose: bool = False

--- a/cli/exceptions.py
+++ b/cli/exceptions.py
@@ -1,0 +1,31 @@
+"""CLI exception hierarchy with exit_code attributes."""
+from __future__ import annotations
+
+
+class PigskinCLIError(Exception):
+    """Base exception for all Pigskin CLI errors."""
+
+    exit_code: int = 1
+
+    def __init__(self, message: str = "", exit_code: int | None = None) -> None:
+        super().__init__(message)
+        if exit_code is not None:
+            self.exit_code = exit_code
+
+
+class NetworkError(PigskinCLIError):
+    """Raised when a network request fails."""
+
+    exit_code: int = 3
+
+
+class AuthError(PigskinCLIError):
+    """Raised when authentication fails."""
+
+    exit_code: int = 4
+
+
+class LabNotInstalledError(PigskinCLIError):
+    """Raised when the optional lab package is not installed."""
+
+    exit_code: int = 126

--- a/cli/options.py
+++ b/cli/options.py
@@ -1,0 +1,47 @@
+"""Shared Click option decorators for the Pigskin CLI."""
+from __future__ import annotations
+
+from typing import Callable
+
+import click
+
+
+def global_options() -> Callable:
+    """Return a decorator that adds shared CLI flags to a Click command.
+
+    Flags added:
+    - ``--output / -o``  (choice: table, json, csv; default: table)
+    - ``--quiet  / -q``  (flag, default False)
+    - ``--verbose / -v`` (flag, default False)
+
+    Usage::
+
+        @cli.command()
+        @global_options()
+        def my_command(output, quiet, verbose, **kwargs):
+            ...
+    """
+
+    def decorator(func: Callable) -> Callable:
+        func = click.option(
+            "--output", "-o",
+            type=click.Choice(["table", "json", "csv"], case_sensitive=False),
+            default="table",
+            show_default=True,
+            help="Output format.",
+        )(func)
+        func = click.option(
+            "--quiet", "-q",
+            is_flag=True,
+            default=False,
+            help="Suppress non-essential output.",
+        )(func)
+        func = click.option(
+            "--verbose", "-v",
+            is_flag=True,
+            default=False,
+            help="Enable verbose output.",
+        )(func)
+        return func
+
+    return decorator

--- a/cli/output.py
+++ b/cli/output.py
@@ -1,0 +1,68 @@
+"""Output format enum, render_output(), and echo_error() for the CLI."""
+from __future__ import annotations
+
+import csv
+import io
+import json
+import sys
+from enum import Enum
+from typing import Any
+
+
+class OutputFormat(Enum):
+    """Output format for CLI rendering."""
+
+    TABLE = "table"
+    JSON = "json"
+    CSV = "csv"
+
+
+def render_output(
+    data: Any,
+    fmt: OutputFormat,
+    quiet: bool,
+    verbose: bool,
+) -> None:
+    """Render *data* according to *fmt*.
+
+    Rules (ADR-012 Q3):
+    - TABLE + quiet  → silent (no output)
+    - JSON           → always emit JSON (even if quiet=True)
+    - CSV            → always emit CSV  (even if quiet=True)
+    - verbose        → affects TABLE verbosity only
+    """
+    if fmt == OutputFormat.TABLE:
+        if quiet:
+            return
+        # Basic table rendering — pretty-print dict/list for now
+        if isinstance(data, (dict, list)):
+            print(json.dumps(data, indent=2))
+        else:
+            print(data)
+
+    elif fmt == OutputFormat.JSON:
+        print(json.dumps(data, indent=2))
+
+    elif fmt == OutputFormat.CSV:
+        output = io.StringIO()
+        if isinstance(data, dict):
+            writer = csv.DictWriter(output, fieldnames=list(data.keys()))
+            writer.writeheader()
+            writer.writerow(data)
+        elif isinstance(data, list) and data and isinstance(data[0], dict):
+            writer = csv.DictWriter(output, fieldnames=list(data[0].keys()))
+            writer.writeheader()
+            writer.writerows(data)
+        else:
+            writer = csv.writer(output)
+            if isinstance(data, list):
+                for row in data:
+                    writer.writerow(row if isinstance(row, (list, tuple)) else [row])
+            else:
+                writer.writerow([data])
+        print(output.getvalue(), end="")
+
+
+def echo_error(msg: str) -> None:
+    """Print *msg* to stderr."""
+    print(msg, file=sys.stderr)

--- a/cli/output.py
+++ b/cli/output.py
@@ -46,20 +46,20 @@ def render_output(
     elif fmt == OutputFormat.CSV:
         output = io.StringIO()
         if isinstance(data, dict):
-            writer = csv.DictWriter(output, fieldnames=list(data.keys()))
-            writer.writeheader()
-            writer.writerow(data)
+            dict_writer = csv.DictWriter(output, fieldnames=list(data.keys()))
+            dict_writer.writeheader()
+            dict_writer.writerow(data)
         elif isinstance(data, list) and data and isinstance(data[0], dict):
-            writer = csv.DictWriter(output, fieldnames=list(data[0].keys()))
-            writer.writeheader()
-            writer.writerows(data)
+            dict_writer = csv.DictWriter(output, fieldnames=list(data[0].keys()))
+            dict_writer.writeheader()
+            dict_writer.writerows(data)
         else:
-            writer = csv.writer(output)
+            plain_writer = csv.writer(output)
             if isinstance(data, list):
                 for row in data:
-                    writer.writerow(row if isinstance(row, (list, tuple)) else [row])
+                    plain_writer.writerow(row if isinstance(row, (list, tuple)) else [row])
             else:
-                writer.writerow([data])
+                plain_writer.writerow([data])
         print(output.getvalue(), end="")
 
 

--- a/tests/unit/cli/test_cli_foundation.py
+++ b/tests/unit/cli/test_cli_foundation.py
@@ -1,0 +1,251 @@
+"""Gate tests for #411: CLI foundation layer.
+
+These tests define acceptance criteria for the 5 new files that the Backend
+Agent will create as part of ARCH-004 Phase 0.  All tests are marked xfail
+because the source files do not exist yet; they will transition to XPASS once
+the implementation lands.
+
+Files under test (none exist yet):
+  cli/context.py
+  cli/output.py
+  cli/exceptions.py
+  cli/options.py
+  cli/_lazy.py
+"""
+
+from __future__ import annotations
+
+import importlib
+import io
+import sys
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).parents[3]
+CLI_DIR = REPO_ROOT / "cli"
+
+# ---------------------------------------------------------------------------
+# AC 1 — all 5 foundation files exist
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+@pytest.mark.xfail(strict=False, reason="pending #411: cli/context.py not yet created")
+def test_context_module_exists():
+    """cli/context.py must exist and export AppContext."""
+    import cli.context  # noqa: F401
+    from cli.context import AppContext  # noqa: F401
+
+
+@pytest.mark.unit
+@pytest.mark.xfail(strict=False, reason="pending #411: cli/output.py not yet created")
+def test_output_module_exists():
+    """cli/output.py must exist and export OutputFormat and render_output."""
+    import cli.output  # noqa: F401
+    from cli.output import OutputFormat, render_output  # noqa: F401
+
+
+@pytest.mark.unit
+@pytest.mark.xfail(strict=False, reason="pending #411: cli/exceptions.py not yet created")
+def test_exceptions_module_exists():
+    """cli/exceptions.py must exist and export PigskinCLIError."""
+    import cli.exceptions  # noqa: F401
+    from cli.exceptions import PigskinCLIError  # noqa: F401
+
+
+@pytest.mark.unit
+@pytest.mark.xfail(strict=False, reason="pending #411: cli/options.py not yet created")
+def test_options_module_exists():
+    """cli/options.py must exist and export global_options."""
+    import cli.options  # noqa: F401
+    from cli.options import global_options  # noqa: F401
+
+
+@pytest.mark.unit
+@pytest.mark.xfail(strict=False, reason="pending #411: cli/_lazy.py not yet created")
+def test_lazy_module_exists():
+    """cli/_lazy.py must exist and export LazyGroup."""
+    import cli._lazy  # noqa: F401
+    from cli._lazy import LazyGroup  # noqa: F401
+
+
+# ---------------------------------------------------------------------------
+# AC 2 — context.py has zero Click imports
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+@pytest.mark.xfail(strict=False, reason="pending #411: cli/context.py not yet created")
+def test_context_has_no_click_imports():
+    """AppContext must be a plain dataclass with no Click dependency."""
+    context_path = CLI_DIR / "context.py"
+    assert context_path.exists(), "cli/context.py does not exist"
+    source = context_path.read_text()
+    assert "import click" not in source, "cli/context.py must not 'import click'"
+    assert "from click" not in source, "cli/context.py must not 'from click import ...'"
+
+
+# ---------------------------------------------------------------------------
+# AC 3 — render_output with JSON format + quiet=True still emits JSON
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+@pytest.mark.xfail(strict=False, reason="pending #411: cli/output.py not yet created")
+def test_render_output_json_quiet_still_emits():
+    """JSON output must be emitted even when quiet=True (JSON is machine-readable)."""
+    from cli.output import OutputFormat, render_output
+
+    captured = io.StringIO()
+    old_stdout = sys.stdout
+    sys.stdout = captured
+    try:
+        render_output({"key": "val"}, fmt=OutputFormat.JSON, quiet=True, verbose=False)
+    finally:
+        sys.stdout = old_stdout
+
+    output = captured.getvalue().strip()
+    assert output, "render_output with JSON+quiet=True must still emit JSON data"
+    # Ensure it is valid JSON
+    import json
+
+    parsed = json.loads(output)
+    assert parsed == {"key": "val"}
+
+
+# ---------------------------------------------------------------------------
+# AC 4 — render_output with TABLE format + quiet=True returns nothing
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+@pytest.mark.xfail(strict=False, reason="pending #411: cli/output.py not yet created")
+def test_render_output_table_quiet_is_silent():
+    """TABLE output must be suppressed when quiet=True."""
+    from cli.output import OutputFormat, render_output
+
+    captured = io.StringIO()
+    old_stdout = sys.stdout
+    sys.stdout = captured
+    try:
+        result = render_output(
+            {"key": "val"}, fmt=OutputFormat.TABLE, quiet=True, verbose=False
+        )
+    finally:
+        sys.stdout = old_stdout
+
+    output = captured.getvalue().strip()
+    # Either nothing is printed, or None is returned — both signal silence
+    assert not output or result is None, (
+        "render_output with TABLE+quiet=True must produce no output"
+    )
+
+
+# ---------------------------------------------------------------------------
+# AC 5 — PigskinCLIError subclass hierarchy with correct exit codes
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+@pytest.mark.xfail(strict=False, reason="pending #411: cli/exceptions.py not yet created")
+def test_network_error_exit_code():
+    """NetworkError must be a PigskinCLIError subclass with exit_code=3."""
+    from cli.exceptions import NetworkError, PigskinCLIError
+
+    assert issubclass(NetworkError, PigskinCLIError)
+    err = NetworkError("test")
+    assert err.exit_code == 3, f"Expected exit_code=3, got {err.exit_code}"
+
+
+@pytest.mark.unit
+@pytest.mark.xfail(strict=False, reason="pending #411: cli/exceptions.py not yet created")
+def test_auth_error_exit_code():
+    """AuthError must be a PigskinCLIError subclass with exit_code=4."""
+    from cli.exceptions import AuthError, PigskinCLIError
+
+    assert issubclass(AuthError, PigskinCLIError)
+    err = AuthError("test")
+    assert err.exit_code == 4, f"Expected exit_code=4, got {err.exit_code}"
+
+
+@pytest.mark.unit
+@pytest.mark.xfail(strict=False, reason="pending #411: cli/exceptions.py not yet created")
+def test_lab_not_installed_error_exit_code():
+    """LabNotInstalledError must be a PigskinCLIError subclass with exit_code=126."""
+    from cli.exceptions import LabNotInstalledError, PigskinCLIError
+
+    assert issubclass(LabNotInstalledError, PigskinCLIError)
+    err = LabNotInstalledError("test")
+    assert err.exit_code == 126, f"Expected exit_code=126, got {err.exit_code}"
+
+
+@pytest.mark.unit
+@pytest.mark.xfail(strict=False, reason="pending #411: cli/exceptions.py not yet created")
+def test_pigskin_cli_error_is_exception():
+    """PigskinCLIError must be a proper Exception subclass."""
+    from cli.exceptions import PigskinCLIError
+
+    assert issubclass(PigskinCLIError, Exception)
+
+
+# ---------------------------------------------------------------------------
+# AC 6 — LazyGroup: importing cli._lazy does NOT drag in the lab package
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+@pytest.mark.xfail(strict=False, reason="pending #411: cli/_lazy.py not yet created")
+def test_lazy_group_import_does_not_load_lab():
+    """Importing cli._lazy must NOT cause the 'lab' package to appear in sys.modules."""
+    # Ensure lab is not already loaded (clean slate for this check)
+    lab_keys_before = {k for k in sys.modules if k == "lab" or k.startswith("lab.")}
+
+    # Force a fresh import of cli._lazy (unload if already cached)
+    sys.modules.pop("cli._lazy", None)
+    importlib.import_module("cli._lazy")
+
+    lab_keys_after = {k for k in sys.modules if k == "lab" or k.startswith("lab.")}
+    newly_loaded = lab_keys_after - lab_keys_before
+    assert not newly_loaded, (
+        f"Importing cli._lazy must not load lab modules; found: {newly_loaded}"
+    )
+
+
+@pytest.mark.unit
+@pytest.mark.xfail(strict=False, reason="pending #411: cli/_lazy.py not yet created")
+def test_lazy_group_is_click_group_subclass():
+    """LazyGroup must subclass click.Group so Click treats it as a command group."""
+    import click
+    from cli._lazy import LazyGroup
+
+    assert issubclass(LazyGroup, click.Group), (
+        "LazyGroup must subclass click.Group"
+    )
+
+
+@pytest.mark.unit
+@pytest.mark.xfail(strict=False, reason="pending #411: cli/options.py not yet created")
+def test_global_options_is_callable_decorator():
+    """global_options() must return a callable (decorator) for use with @global_options."""
+    from cli.options import global_options
+
+    assert callable(global_options), "global_options must be callable"
+    # When called with no args it should return a decorator (another callable)
+    decorator = global_options()
+    assert callable(decorator), "global_options() must return a decorator"
+
+
+@pytest.mark.unit
+@pytest.mark.xfail(strict=False, reason="pending #411: cli/context.py not yet created")
+def test_app_context_is_dataclass():
+    """AppContext must be a dataclass (or similar) with at least output_format and quiet fields."""
+    import dataclasses
+
+    from cli.context import AppContext
+
+    fields = {f.name for f in dataclasses.fields(AppContext)}
+    assert "output_format" in fields or "fmt" in fields, (
+        "AppContext must have an output_format (or fmt) field"
+    )
+    assert "quiet" in fields, "AppContext must have a quiet field"

--- a/tests/unit/cli/test_cli_foundation.py
+++ b/tests/unit/cli/test_cli_foundation.py
@@ -31,7 +31,6 @@ CLI_DIR = REPO_ROOT / "cli"
 
 
 @pytest.mark.unit
-@pytest.mark.xfail(strict=False, reason="pending #411: cli/context.py not yet created")
 def test_context_module_exists():
     """cli/context.py must exist and export AppContext."""
     import cli.context  # noqa: F401
@@ -39,7 +38,6 @@ def test_context_module_exists():
 
 
 @pytest.mark.unit
-@pytest.mark.xfail(strict=False, reason="pending #411: cli/output.py not yet created")
 def test_output_module_exists():
     """cli/output.py must exist and export OutputFormat and render_output."""
     import cli.output  # noqa: F401
@@ -47,7 +45,6 @@ def test_output_module_exists():
 
 
 @pytest.mark.unit
-@pytest.mark.xfail(strict=False, reason="pending #411: cli/exceptions.py not yet created")
 def test_exceptions_module_exists():
     """cli/exceptions.py must exist and export PigskinCLIError."""
     import cli.exceptions  # noqa: F401
@@ -55,7 +52,6 @@ def test_exceptions_module_exists():
 
 
 @pytest.mark.unit
-@pytest.mark.xfail(strict=False, reason="pending #411: cli/options.py not yet created")
 def test_options_module_exists():
     """cli/options.py must exist and export global_options."""
     import cli.options  # noqa: F401
@@ -63,7 +59,6 @@ def test_options_module_exists():
 
 
 @pytest.mark.unit
-@pytest.mark.xfail(strict=False, reason="pending #411: cli/_lazy.py not yet created")
 def test_lazy_module_exists():
     """cli/_lazy.py must exist and export LazyGroup."""
     import cli._lazy  # noqa: F401
@@ -76,7 +71,6 @@ def test_lazy_module_exists():
 
 
 @pytest.mark.unit
-@pytest.mark.xfail(strict=False, reason="pending #411: cli/context.py not yet created")
 def test_context_has_no_click_imports():
     """AppContext must be a plain dataclass with no Click dependency."""
     context_path = CLI_DIR / "context.py"
@@ -92,7 +86,6 @@ def test_context_has_no_click_imports():
 
 
 @pytest.mark.unit
-@pytest.mark.xfail(strict=False, reason="pending #411: cli/output.py not yet created")
 def test_render_output_json_quiet_still_emits():
     """JSON output must be emitted even when quiet=True (JSON is machine-readable)."""
     from cli.output import OutputFormat, render_output
@@ -120,7 +113,6 @@ def test_render_output_json_quiet_still_emits():
 
 
 @pytest.mark.unit
-@pytest.mark.xfail(strict=False, reason="pending #411: cli/output.py not yet created")
 def test_render_output_table_quiet_is_silent():
     """TABLE output must be suppressed when quiet=True."""
     from cli.output import OutputFormat, render_output
@@ -148,7 +140,6 @@ def test_render_output_table_quiet_is_silent():
 
 
 @pytest.mark.unit
-@pytest.mark.xfail(strict=False, reason="pending #411: cli/exceptions.py not yet created")
 def test_network_error_exit_code():
     """NetworkError must be a PigskinCLIError subclass with exit_code=3."""
     from cli.exceptions import NetworkError, PigskinCLIError
@@ -159,7 +150,6 @@ def test_network_error_exit_code():
 
 
 @pytest.mark.unit
-@pytest.mark.xfail(strict=False, reason="pending #411: cli/exceptions.py not yet created")
 def test_auth_error_exit_code():
     """AuthError must be a PigskinCLIError subclass with exit_code=4."""
     from cli.exceptions import AuthError, PigskinCLIError
@@ -170,7 +160,6 @@ def test_auth_error_exit_code():
 
 
 @pytest.mark.unit
-@pytest.mark.xfail(strict=False, reason="pending #411: cli/exceptions.py not yet created")
 def test_lab_not_installed_error_exit_code():
     """LabNotInstalledError must be a PigskinCLIError subclass with exit_code=126."""
     from cli.exceptions import LabNotInstalledError, PigskinCLIError
@@ -181,7 +170,6 @@ def test_lab_not_installed_error_exit_code():
 
 
 @pytest.mark.unit
-@pytest.mark.xfail(strict=False, reason="pending #411: cli/exceptions.py not yet created")
 def test_pigskin_cli_error_is_exception():
     """PigskinCLIError must be a proper Exception subclass."""
     from cli.exceptions import PigskinCLIError
@@ -195,7 +183,6 @@ def test_pigskin_cli_error_is_exception():
 
 
 @pytest.mark.unit
-@pytest.mark.xfail(strict=False, reason="pending #411: cli/_lazy.py not yet created")
 def test_lazy_group_import_does_not_load_lab():
     """Importing cli._lazy must NOT cause the 'lab' package to appear in sys.modules."""
     # Ensure lab is not already loaded (clean slate for this check)
@@ -213,7 +200,6 @@ def test_lazy_group_import_does_not_load_lab():
 
 
 @pytest.mark.unit
-@pytest.mark.xfail(strict=False, reason="pending #411: cli/_lazy.py not yet created")
 def test_lazy_group_is_click_group_subclass():
     """LazyGroup must subclass click.Group so Click treats it as a command group."""
     import click
@@ -225,7 +211,6 @@ def test_lazy_group_is_click_group_subclass():
 
 
 @pytest.mark.unit
-@pytest.mark.xfail(strict=False, reason="pending #411: cli/options.py not yet created")
 def test_global_options_is_callable_decorator():
     """global_options() must return a callable (decorator) for use with @global_options."""
     from cli.options import global_options
@@ -237,7 +222,6 @@ def test_global_options_is_callable_decorator():
 
 
 @pytest.mark.unit
-@pytest.mark.xfail(strict=False, reason="pending #411: cli/context.py not yet created")
 def test_app_context_is_dataclass():
     """AppContext must be a dataclass (or similar) with at least output_format and quiet fields."""
     import dataclasses


### PR DESCRIPTION
## Summary

Implements [ARCH-004][Phase 0]: the five infrastructure modules that all CLI command handlers will depend on.

### Files Created
-  —  dataclass (zero Click imports)
-  —  enum +  + 
-  —  → //
-  —  Click decorator
-  —  with deferred  loading

### Tests
- All 16 QA gate tests pass (16 xpassed — xfail marks cleared by implementation)
- Full unit suite: 1594 passed, 16 xpassed, 0 failures

Part of #365 (ARCH-004).

Closes #411